### PR TITLE
Encapsulate BSSID, SSID, and location sanity checks in blocklists

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-feature android:name="android.hardware.location"/>
     <uses-feature android:name="android.hardware.location.gps"/>
-    
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"

--- a/src/com/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/com/mozilla/mozstumbler/BSSIDBlockList.java
@@ -1,0 +1,40 @@
+package com.mozilla.mozstumbler;
+
+import android.net.wifi.ScanResult;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+final class BSSIDBlockList {
+    private static final String NULL_BSSID = "00:00:00:00:00:00";
+    private static final String WILDCARD_BSSID = "ff:ff:ff:ff:ff:ff";
+
+    // copied from
+    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
+    // which is Apache licensed.
+    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
+            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
+
+    private BSSIDBlockList() {
+    }
+
+    static boolean contains(ScanResult scanResult) {
+        String BSSID = scanResult.BSSID;
+        return BSSID == null ||
+               isAdHocBSSID(BSSID) ||
+               NULL_BSSID.equals(BSSID) ||
+               WILDCARD_BSSID.equals(BSSID);
+    }
+
+    private static boolean isAdHocBSSID(String BSSID) {
+        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
+        // having a 2,6,a or e in the second nybble.
+        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
+        // have the last two bits of the second nybble set to 10.
+        // Only apply this test if we have exactly 17 character long BSSID which
+        // should be the case.
+        char secondNybble = BSSID.charAt(1);
+        return AD_HOC_HEX_VALUES.contains(secondNybble);
+    }
+}

--- a/src/com/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/com/mozilla/mozstumbler/BSSIDBlockList.java
@@ -2,22 +2,14 @@ package com.mozilla.mozstumbler;
 
 import android.net.wifi.ScanResult;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 final class BSSIDBlockList {
     private static final String NULL_BSSID = "00:00:00:00:00:00";
     private static final String WILDCARD_BSSID = "ff:ff:ff:ff:ff:ff";
     private static final Pattern BSSID_PATTERN = Pattern.compile("([0-9a-f]{2}:){5}[0-9a-f]{2}");
-
-    // copied from
-    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
-    // which is Apache licensed.
-    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
-            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
+    private static final String AD_HOC_HEX_VALUES = "26aeAE";
 
     private BSSIDBlockList() {
     }
@@ -26,6 +18,7 @@ final class BSSIDBlockList {
         String BSSID = scanResult.BSSID;
         return BSSID == null ||
                isAdHocBSSID(BSSID) ||
+               !isCanonicalBSSID(BSSID) ||
                NULL_BSSID.equals(BSSID) ||
                WILDCARD_BSSID.equals(BSSID);
     }
@@ -49,9 +42,7 @@ final class BSSIDBlockList {
         // having a 2,6,a or e in the second nybble.
         // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
         // have the last two bits of the second nybble set to 10.
-        // Only apply this test if we have exactly 17 character long BSSID which
-        // should be the case.
         char secondNybble = BSSID.charAt(1);
-        return AD_HOC_HEX_VALUES.contains(secondNybble);
+        return AD_HOC_HEX_VALUES.indexOf(secondNybble) != -1;
     }
 }

--- a/src/com/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/com/mozilla/mozstumbler/BSSIDBlockList.java
@@ -4,11 +4,14 @@ import android.net.wifi.ScanResult;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 final class BSSIDBlockList {
     private static final String NULL_BSSID = "00:00:00:00:00:00";
     private static final String WILDCARD_BSSID = "ff:ff:ff:ff:ff:ff";
+    private static final Pattern BSSID_PATTERN = Pattern.compile("([0-9a-f]{2}:){5}[0-9a-f]{2}");
 
     // copied from
     // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
@@ -25,6 +28,20 @@ final class BSSIDBlockList {
                isAdHocBSSID(BSSID) ||
                NULL_BSSID.equals(BSSID) ||
                WILDCARD_BSSID.equals(BSSID);
+    }
+
+    static String canonicalizeBSSID(String BSSID) {
+        if (BSSID == null || isCanonicalBSSID(BSSID)) {
+            return BSSID;
+        }
+
+        // Some devices may return BSSIDs with '-' or '.' delimiters.
+        BSSID = BSSID.toLowerCase(Locale.US).replace('-', ':').replace('.', ':');
+        return isCanonicalBSSID(BSSID) ? BSSID : null;
+    }
+
+    private static boolean isCanonicalBSSID(String BSSID) {
+        return BSSID_PATTERN.matcher(BSSID).matches();
     }
 
     private static boolean isAdHocBSSID(String BSSID) {

--- a/src/com/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/com/mozilla/mozstumbler/LocationBlockList.java
@@ -1,0 +1,42 @@
+package com.mozilla.mozstumbler;
+
+import android.location.Location;
+
+final class LocationBlockList {
+    private static final long MILLISECONDS_PER_DAY = 86400000; // milliseconds/day
+    private static final double MAX_ALTITUDE = 8848; // Mount Everest's altitude in meters
+    private static final double MIN_ALTITUDE = -418; // Dead Sea's altitude in meters
+    private static final float MAX_SPEED = 340.29f; // Mach 1 in meters/second
+    private static final float MAX_INACCURACY = 500; // meter radius
+    private static final long MIN_TIMESTAMP = 946684801; // 2000-01-01 00:00:01
+
+    private LocationBlockList() {
+    }
+
+    static boolean contains(Location location) {
+        final float inaccuracy = location.getAccuracy();
+        final double altitude = location.getAltitude();
+        final float bearing = location.getBearing();
+        final double latitude = location.getLatitude();
+        final double longitude = location.getLongitude();
+        final float speed = location.getSpeed();
+        final long timestamp = location.getTime();
+        final long tomorrow = System.currentTimeMillis() + MILLISECONDS_PER_DAY;
+
+        return inaccuracy < 0 ||
+               inaccuracy > MAX_INACCURACY ||
+               altitude < MIN_ALTITUDE ||
+               altitude > MAX_ALTITUDE ||
+               bearing < 0 ||
+               bearing > 360 ||
+               latitude < -180 ||
+               latitude > 180 ||
+               longitude < -180 ||
+               longitude > 180 ||
+               (latitude == 0 && longitude == 0) ||
+               speed < 0 ||
+               speed > MAX_SPEED ||
+               timestamp < MIN_TIMESTAMP ||
+               timestamp > tomorrow;
+    }
+}

--- a/src/com/mozilla/mozstumbler/MainActivity.java
+++ b/src/com/mozilla/mozstumbler/MainActivity.java
@@ -1,57 +1,16 @@
 package com.mozilla.mozstumbler;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Looper;
 import android.os.StrictMode;
-import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.telephony.CellLocation;
-import android.telephony.NeighboringCellInfo;
-import android.telephony.PhoneStateListener;
-import android.telephony.SignalStrength;
-import android.telephony.TelephonyManager;
-import android.telephony.gsm.GsmCellLocation;
-import android.util.Log;
 import android.view.Menu;
 import android.view.View;
 import android.widget.Button;
-import android.widget.TextView;
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import android.content.Context;
-import android.location.Criteria;
-import android.location.Location;
-import android.location.LocationListener;
-import android.location.LocationManager;
-import android.net.wifi.ScanResult;
-import android.net.wifi.WifiManager;
 
-public class MainActivity extends Activity implements LocationListener {
-    private static final String LOGTAG = "Mozilla Stumbler";
-    protected static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
-
-    private boolean mIsScanning = false;
-
-    private int mSignalStrenth;
-    private PhoneStateListener mPhoneStateListener = null;
+public class MainActivity extends Activity {
+    private Scanner mScanner;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -67,30 +26,21 @@ public class MainActivity extends Activity implements LocationListener {
     public void onBtnClicked(View v) {
         if (v.getId() == R.id.toggle_scanning) {
 
-            mIsScanning = !mIsScanning;
             // handle the click here
             Button b = (Button) v;
+            int buttonText;
 
-            LocationManager lm = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
-
-            if (mIsScanning) {
-
-                Criteria criteria = new Criteria();
-                criteria.setSpeedRequired(false);
-                criteria.setBearingRequired(false);
-                criteria.setAltitudeRequired(false);
-                criteria.setAccuracy(Criteria.ACCURACY_FINE);
-                criteria.setPowerRequirement(Criteria.POWER_HIGH); // hmm.
-
-                String provider = lm.getBestProvider(criteria, true);
-                lm.requestLocationUpdates(provider, 1000, (float) .5,
-                        getLocationListener(), Looper.getMainLooper());
-
-                b.setText(R.string.stop_scanning);
+            if (mScanner == null) {
+                mScanner = new Scanner(this);
+                mScanner.startScanning();
+                buttonText = R.string.stop_scanning;
             } else {
-                b.setText(R.string.start_scanning);
-                lm.removeUpdates(getLocationListener());
+                mScanner.stopScanning();
+                mScanner = null;
+                buttonText = R.string.start_scanning;
             }
+
+            b.setText(buttonText);
         }
     }
 
@@ -99,235 +49,6 @@ public class MainActivity extends Activity implements LocationListener {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.main, menu);
         return true;
-    }
-
-    public LocationListener getLocationListener() {
-        if (mPhoneStateListener == null) {
-            mPhoneStateListener = new PhoneStateListener() {
-                public void onSignalStrengthsChanged(
-                        SignalStrength signalStrength) {
-                    setCurrentSignalStrenth(signalStrength);
-                }
-            };
-            TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
-            tm.listen(mPhoneStateListener,
-                    PhoneStateListener.LISTEN_SIGNAL_STRENGTHS);
-        }
-        return this;
-    }
-
-    // copied from
-    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
-    // which is apache licensed
-    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
-            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
-
-    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
-
-    private static boolean shouldLog(final ScanResult sr) {
-        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
-        // having a
-        // 2,6,a or e in the second nybble.
-        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
-        // have the last two bits of the second nybble set to 10.
-        // Only apply this test if we have exactly 17 character long BSSID which
-        // should
-        // be the case.
-        final char secondNybble = sr.BSSID.length() == 17 ? sr.BSSID.charAt(1)
-                : ' ';
-
-        if (AD_HOC_HEX_VALUES.contains(secondNybble)) {
-            return false;
-
-        } else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    @Override
-    public void onLocationChanged(Location location) {
-        collectAndReportLocInfo(location);
-    }
-
-    public void setCurrentSignalStrenth(SignalStrength ss) {
-        if (ss.isGsm())
-            mSignalStrenth = ss.getGsmSignalStrength();
-    }
-
-    private int getCellInfo(JSONArray cellInfo) {
-        TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
-        if (tm == null)
-            return TelephonyManager.PHONE_TYPE_NONE;
-        List<NeighboringCellInfo> cells = tm.getNeighboringCellInfo();
-        CellLocation cl = tm.getCellLocation();
-        if (cl == null)
-            return TelephonyManager.PHONE_TYPE_NONE;
-        String mcc = "", mnc = "";
-        if (cl instanceof GsmCellLocation) {
-            JSONObject obj = new JSONObject();
-            GsmCellLocation gcl = (GsmCellLocation) cl;
-            try {
-                obj.put("lac", gcl.getLac());
-                obj.put("cid", gcl.getCid());
-                obj.put("psc", gcl.getPsc());
-                switch (tm.getNetworkType()) {
-                case TelephonyManager.NETWORK_TYPE_GPRS:
-                case TelephonyManager.NETWORK_TYPE_EDGE:
-                    obj.put("radio", "gsm");
-                    break;
-                case TelephonyManager.NETWORK_TYPE_UMTS:
-                case TelephonyManager.NETWORK_TYPE_HSDPA:
-                case TelephonyManager.NETWORK_TYPE_HSUPA:
-                case TelephonyManager.NETWORK_TYPE_HSPA:
-                case TelephonyManager.NETWORK_TYPE_HSPAP:
-                    obj.put("radio", "umts");
-                    break;
-                }
-                String mcc_mnc = tm.getNetworkOperator();
-                if (mcc_mnc.length() > 3) {
-                    mcc = mcc_mnc.substring(0, 3);
-                    mnc = mcc_mnc.substring(3);
-                    obj.put("mcc", mcc);
-                    obj.put("mnc", mnc);
-                }
-                obj.put("asu", mSignalStrenth);
-            } catch (JSONException jsonex) {
-            }
-            cellInfo.put(obj);
-        }
-        if (cells != null) {
-            for (NeighboringCellInfo nci : cells) {
-                try {
-                    JSONObject obj = new JSONObject();
-                    obj.put("lac", nci.getLac());
-                    obj.put("cid", nci.getCid());
-                    obj.put("psc", nci.getPsc());
-                    obj.put("mcc", mcc);
-                    obj.put("mnc", mnc);
-
-                    switch (nci.getNetworkType()) {
-                    case TelephonyManager.NETWORK_TYPE_GPRS:
-                    case TelephonyManager.NETWORK_TYPE_EDGE:
-                        obj.put("radio", "gsm");
-                        break;
-                    case TelephonyManager.NETWORK_TYPE_UMTS:
-                    case TelephonyManager.NETWORK_TYPE_HSDPA:
-                    case TelephonyManager.NETWORK_TYPE_HSUPA:
-                    case TelephonyManager.NETWORK_TYPE_HSPA:
-                    case TelephonyManager.NETWORK_TYPE_HSPAP:
-                        obj.put("radio", "umts");
-                        break;
-                    }
-
-                    obj.put("asu", nci.getRssi());
-                    cellInfo.put(obj);
-                } catch (JSONException jsonex) {
-                }
-            }
-        }
-        return tm.getPhoneType();
-    }
-
-    @SuppressLint("SimpleDateFormat")
-    private void collectAndReportLocInfo(Location location) {
-        final JSONObject locInfo = new JSONObject();
-        WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
-        wm.startScan();
-        try {
-            JSONArray cellInfo = new JSONArray();
-            int radioType = getCellInfo(cellInfo);
-            if (radioType == TelephonyManager.PHONE_TYPE_GSM)
-                locInfo.put("radio", "gsm");
-
-            locInfo.put("lon", location.getLongitude());
-            locInfo.put("lat", location.getLatitude());
-            locInfo.put("accuracy", (int) location.getAccuracy());
-            locInfo.put("altitude", (int) location.getAltitude());
-
-            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
-            locInfo.put("time", df.format(new Date(location.getTime())));
-            locInfo.put("cell", cellInfo);
-
-            MessageDigest digest = MessageDigest.getInstance("SHA-1");
-
-            JSONArray wifiInfo = new JSONArray();
-            List<ScanResult> aps = wm.getScanResults();
-            if (aps != null) {
-                for (ScanResult ap : aps) {
-                    if (!shouldLog(ap))
-                        continue;
-                    StringBuilder sb = new StringBuilder();
-                    try {
-                        byte[] result = digest.digest((ap.BSSID + ap.SSID)
-                                .getBytes("UTF-8"));
-                        for (byte b : result)
-                            sb.append(String.format("%02X", b));
-
-                        JSONObject obj = new JSONObject();
-
-                        obj.put("key", sb.toString());
-                        obj.put("frequency", ap.frequency);
-                        obj.put("signal", ap.level);
-                        wifiInfo.put(obj);
-                    } catch (UnsupportedEncodingException uee) {
-                        Log.w(LOGTAG, "can't encode the key", uee);
-                    }
-                }
-            }
-            locInfo.put("wifi", wifiInfo);
-        } catch (JSONException jsonex) {
-            Log.w(LOGTAG, "json exception", jsonex);
-        } catch (NoSuchAlgorithmException nsae) {
-            Log.w(LOGTAG, "can't creat a SHA1", nsae);
-        }
-
-        new Thread(new Runnable() {
-            public void run() {
-                try {
-                    URL url = new URL(LOCATION_URL);
-                    HttpURLConnection urlConnection = (HttpURLConnection) url
-                            .openConnection();
-                    try {
-                        urlConnection.setDoOutput(true);
-                        JSONArray batch = new JSONArray();
-                        batch.put(locInfo);
-                        JSONObject wrapper = new JSONObject();
-                        wrapper.put("items", batch);
-                        byte[] bytes = wrapper.toString().getBytes();
-                        urlConnection.setFixedLengthStreamingMode(bytes.length);
-                        OutputStream out = new BufferedOutputStream(
-                                urlConnection.getOutputStream());
-                        out.write(bytes);
-                        out.flush();
-                    } catch (JSONException jsonex) {
-                        Log.e(LOGTAG, "error wrapping data as a batch", jsonex);
-                    } catch (Exception ex) {
-                        Log.e(LOGTAG, "error submitting data", ex);
-                    } finally {
-                        urlConnection.disconnect();
-                    }
-                } catch (Exception ex) {
-                    Log.e(LOGTAG, "error submitting data", ex);
-                }
-            }
-        }).start();
-    }
-
-    @Override
-    public void onProviderDisabled(String provider) {
-        // TODO Auto-generated method stub
-    }
-
-    @Override
-    public void onProviderEnabled(String provider) {
-        // TODO Auto-generated method stub
-    }
-
-    @Override
-    public void onStatusChanged(String provider, int status, Bundle extras) {
-        // TODO Auto-generated method stub
     }
 
     @TargetApi(9)

--- a/src/com/mozilla/mozstumbler/MainActivity.java
+++ b/src/com/mozilla/mozstumbler/MainActivity.java
@@ -42,291 +42,286 @@ import android.net.wifi.ScanResult;
 import android.net.wifi.WifiManager;
 
 public class MainActivity extends Activity implements LocationListener {
+    private static final String LOGTAG = "Mozilla Stumbler";
+    protected static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
 
-	private static final String LOGTAG = "Mozilla Stumbler";
-	protected static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
+    private boolean mIsScanning = false;
 
-	private boolean mIsScanning = false;
+    private int mSignalStrenth;
+    private PhoneStateListener mPhoneStateListener = null;
 
-	private int mSignalStrenth;
-	private PhoneStateListener mPhoneStateListener = null;
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_main);
+        Button scanningBtn = (Button) findViewById(R.id.toggle_scanning);
+        scanningBtn.setText(R.string.start_scanning);
+    }
 
-		Button scanningBtn = (Button) findViewById(R.id.toggle_scanning);
-		scanningBtn.setText(R.string.start_scanning);
-	}
+    public void onBtnClicked(View v) {
+        if (v.getId() == R.id.toggle_scanning) {
 
-	public void onBtnClicked(View v) {
-		if (v.getId() == R.id.toggle_scanning) {
+            mIsScanning = !mIsScanning;
+            // handle the click here
+            Button b = (Button) v;
 
-			mIsScanning = !mIsScanning;
-			// handle the click here
-			Button b = (Button) v;
+            LocationManager lm = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
 
-			LocationManager lm = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+            if (mIsScanning) {
 
-			if (mIsScanning) {
+                Criteria criteria = new Criteria();
+                criteria.setSpeedRequired(false);
+                criteria.setBearingRequired(false);
+                criteria.setAltitudeRequired(false);
+                criteria.setAccuracy(Criteria.ACCURACY_FINE);
+                criteria.setPowerRequirement(Criteria.POWER_HIGH); // hmm.
 
-				Criteria criteria = new Criteria();
-				criteria.setSpeedRequired(false);
-				criteria.setBearingRequired(false);
-				criteria.setAltitudeRequired(false);
-				criteria.setAccuracy(Criteria.ACCURACY_FINE);
-				criteria.setPowerRequirement(Criteria.POWER_HIGH); // hmm.
+                String provider = lm.getBestProvider(criteria, true);
+                lm.requestLocationUpdates(provider, 1000, (float) .5,
+                        getLocationListener(), Looper.getMainLooper());
 
-				String provider = lm.getBestProvider(criteria, true);
-				lm.requestLocationUpdates(provider, 1000, (float) .5,
-						getLocationListener(), Looper.getMainLooper());
+                b.setText(R.string.stop_scanning);
+            } else {
+                b.setText(R.string.start_scanning);
+                lm.removeUpdates(getLocationListener());
+            }
+        }
+    }
 
-				b.setText(R.string.stop_scanning);
-			} else {
-				b.setText(R.string.start_scanning);
-				lm.removeUpdates(getLocationListener());
-			}
-		}
-	}
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.main, menu);
+        return true;
+    }
 
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		// Inflate the menu; this adds items to the action bar if it is present.
-		getMenuInflater().inflate(R.menu.main, menu);
-		return true;
-	}
+    public LocationListener getLocationListener() {
+        if (mPhoneStateListener == null) {
+            mPhoneStateListener = new PhoneStateListener() {
+                public void onSignalStrengthsChanged(
+                        SignalStrength signalStrength) {
+                    setCurrentSignalStrenth(signalStrength);
+                }
+            };
+            TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
+            tm.listen(mPhoneStateListener,
+                    PhoneStateListener.LISTEN_SIGNAL_STRENGTHS);
+        }
+        return this;
+    }
 
-	public LocationListener getLocationListener() {
-		if (mPhoneStateListener == null) {
-			mPhoneStateListener = new PhoneStateListener() {
-				public void onSignalStrengthsChanged(
-						SignalStrength signalStrength) {
-					setCurrentSignalStrenth(signalStrength);
-				}
-			};
-			TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
-			tm.listen(mPhoneStateListener,
-					PhoneStateListener.LISTEN_SIGNAL_STRENGTHS);
-		}
-		return this;
-	}
+    // copied from
+    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
+    // which is apache licensed
+    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
+            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
 
-	// copied from
-	// http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
-	// which is apache licensed
-	private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
-			Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
+    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
 
-	private static final String OPTOUT_SSID_SUFFIX = "_nomap";
+    private static boolean shouldLog(final ScanResult sr) {
+        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
+        // having a
+        // 2,6,a or e in the second nybble.
+        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
+        // have the last two bits of the second nybble set to 10.
+        // Only apply this test if we have exactly 17 character long BSSID which
+        // should
+        // be the case.
+        final char secondNybble = sr.BSSID.length() == 17 ? sr.BSSID.charAt(1)
+                : ' ';
 
-	private static boolean shouldLog(final ScanResult sr) {
-		// We filter out any ad-hoc devices. Ad-hoc devices are identified by
-		// having a
-		// 2,6,a or e in the second nybble.
-		// See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
-		// have the last two bits of the second nybble set to 10.
-		// Only apply this test if we have exactly 17 character long BSSID which
-		// should
-		// be the case.
-		final char secondNybble = sr.BSSID.length() == 17 ? sr.BSSID.charAt(1)
-				: ' ';
+        if (AD_HOC_HEX_VALUES.contains(secondNybble)) {
+            return false;
 
-		if (AD_HOC_HEX_VALUES.contains(secondNybble)) {
-			return false;
+        } else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 
-		} else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
-			return false;
-		} else {
-			return true;
-		}
-	}
+    @Override
+    public void onLocationChanged(Location location) {
+        collectAndReportLocInfo(location);
+    }
 
-	@Override
-	public void onLocationChanged(Location location) {
-		collectAndReportLocInfo(location);
-	}
+    public void setCurrentSignalStrenth(SignalStrength ss) {
+        if (ss.isGsm())
+            mSignalStrenth = ss.getGsmSignalStrength();
+    }
 
-	public void setCurrentSignalStrenth(SignalStrength ss) {
-		if (ss.isGsm())
-			mSignalStrenth = ss.getGsmSignalStrength();
-	}
+    private int getCellInfo(JSONArray cellInfo) {
+        TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
+        if (tm == null)
+            return TelephonyManager.PHONE_TYPE_NONE;
+        List<NeighboringCellInfo> cells = tm.getNeighboringCellInfo();
+        CellLocation cl = tm.getCellLocation();
+        if (cl == null)
+            return TelephonyManager.PHONE_TYPE_NONE;
+        String mcc = "", mnc = "";
+        if (cl instanceof GsmCellLocation) {
+            JSONObject obj = new JSONObject();
+            GsmCellLocation gcl = (GsmCellLocation) cl;
+            try {
+                obj.put("lac", gcl.getLac());
+                obj.put("cid", gcl.getCid());
+                obj.put("psc", gcl.getPsc());
+                switch (tm.getNetworkType()) {
+                case TelephonyManager.NETWORK_TYPE_GPRS:
+                case TelephonyManager.NETWORK_TYPE_EDGE:
+                    obj.put("radio", "gsm");
+                    break;
+                case TelephonyManager.NETWORK_TYPE_UMTS:
+                case TelephonyManager.NETWORK_TYPE_HSDPA:
+                case TelephonyManager.NETWORK_TYPE_HSUPA:
+                case TelephonyManager.NETWORK_TYPE_HSPA:
+                case TelephonyManager.NETWORK_TYPE_HSPAP:
+                    obj.put("radio", "umts");
+                    break;
+                }
+                String mcc_mnc = tm.getNetworkOperator();
+                if (mcc_mnc.length() > 3) {
+                    mcc = mcc_mnc.substring(0, 3);
+                    mnc = mcc_mnc.substring(3);
+                    obj.put("mcc", mcc);
+                    obj.put("mnc", mnc);
+                }
+                obj.put("asu", mSignalStrenth);
+            } catch (JSONException jsonex) {
+            }
+            cellInfo.put(obj);
+        }
+        if (cells != null) {
+            for (NeighboringCellInfo nci : cells) {
+                try {
+                    JSONObject obj = new JSONObject();
+                    obj.put("lac", nci.getLac());
+                    obj.put("cid", nci.getCid());
+                    obj.put("psc", nci.getPsc());
+                    obj.put("mcc", mcc);
+                    obj.put("mnc", mnc);
 
-	private int getCellInfo(JSONArray cellInfo) {
-		TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
-		if (tm == null)
-			return TelephonyManager.PHONE_TYPE_NONE;
-		List<NeighboringCellInfo> cells = tm.getNeighboringCellInfo();
-		CellLocation cl = tm.getCellLocation();
-		if (cl == null)
-			return TelephonyManager.PHONE_TYPE_NONE;
-		String mcc = "", mnc = "";
-		if (cl instanceof GsmCellLocation) {
-			JSONObject obj = new JSONObject();
-			GsmCellLocation gcl = (GsmCellLocation) cl;
-			try {
-				obj.put("lac", gcl.getLac());
-				obj.put("cid", gcl.getCid());
-				obj.put("psc", gcl.getPsc());
-				switch (tm.getNetworkType()) {
-				case TelephonyManager.NETWORK_TYPE_GPRS:
-				case TelephonyManager.NETWORK_TYPE_EDGE:
-					obj.put("radio", "gsm");
-					break;
-				case TelephonyManager.NETWORK_TYPE_UMTS:
-				case TelephonyManager.NETWORK_TYPE_HSDPA:
-				case TelephonyManager.NETWORK_TYPE_HSUPA:
-				case TelephonyManager.NETWORK_TYPE_HSPA:
-				case TelephonyManager.NETWORK_TYPE_HSPAP:
-					obj.put("radio", "umts");
-					break;
-				}
-				String mcc_mnc = tm.getNetworkOperator();
-				if (mcc_mnc.length() > 3) {
-					mcc = mcc_mnc.substring(0, 3);
-					mnc = mcc_mnc.substring(3);
-					obj.put("mcc", mcc);
-					obj.put("mnc", mnc);
-				}
-				obj.put("asu", mSignalStrenth);
-			} catch (JSONException jsonex) {
-			}
-			cellInfo.put(obj);
-		}
-		if (cells != null) {
-			for (NeighboringCellInfo nci : cells) {
-				try {
-					JSONObject obj = new JSONObject();
-					obj.put("lac", nci.getLac());
-					obj.put("cid", nci.getCid());
-					obj.put("psc", nci.getPsc());
-					obj.put("mcc", mcc);
-					obj.put("mnc", mnc);
+                    switch (nci.getNetworkType()) {
+                    case TelephonyManager.NETWORK_TYPE_GPRS:
+                    case TelephonyManager.NETWORK_TYPE_EDGE:
+                        obj.put("radio", "gsm");
+                        break;
+                    case TelephonyManager.NETWORK_TYPE_UMTS:
+                    case TelephonyManager.NETWORK_TYPE_HSDPA:
+                    case TelephonyManager.NETWORK_TYPE_HSUPA:
+                    case TelephonyManager.NETWORK_TYPE_HSPA:
+                    case TelephonyManager.NETWORK_TYPE_HSPAP:
+                        obj.put("radio", "umts");
+                        break;
+                    }
 
-					switch (nci.getNetworkType()) {
-					case TelephonyManager.NETWORK_TYPE_GPRS:
-					case TelephonyManager.NETWORK_TYPE_EDGE:
-						obj.put("radio", "gsm");
-						break;
-					case TelephonyManager.NETWORK_TYPE_UMTS:
-					case TelephonyManager.NETWORK_TYPE_HSDPA:
-					case TelephonyManager.NETWORK_TYPE_HSUPA:
-					case TelephonyManager.NETWORK_TYPE_HSPA:
-					case TelephonyManager.NETWORK_TYPE_HSPAP:
-						obj.put("radio", "umts");
-						break;
-					}
+                    obj.put("asu", nci.getRssi());
+                    cellInfo.put(obj);
+                } catch (JSONException jsonex) {
+                }
+            }
+        }
+        return tm.getPhoneType();
+    }
 
-					obj.put("asu", nci.getRssi());
-					cellInfo.put(obj);
-				} catch (JSONException jsonex) {
-				}
-			}
-		}
-		return tm.getPhoneType();
-	}
+    @SuppressLint("SimpleDateFormat")
+    private void collectAndReportLocInfo(Location location) {
+        final JSONObject locInfo = new JSONObject();
+        WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+        wm.startScan();
+        try {
+            JSONArray cellInfo = new JSONArray();
+            int radioType = getCellInfo(cellInfo);
+            if (radioType == TelephonyManager.PHONE_TYPE_GSM)
+                locInfo.put("radio", "gsm");
 
-	@SuppressLint("SimpleDateFormat")
-	private void collectAndReportLocInfo(Location location) {
-		final JSONObject locInfo = new JSONObject();
-		WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
-		wm.startScan();
-		try {
-			JSONArray cellInfo = new JSONArray();
-			int radioType = getCellInfo(cellInfo);
-			if (radioType == TelephonyManager.PHONE_TYPE_GSM)
-				locInfo.put("radio", "gsm");
+            locInfo.put("lon", location.getLongitude());
+            locInfo.put("lat", location.getLatitude());
+            locInfo.put("accuracy", (int) location.getAccuracy());
+            locInfo.put("altitude", (int) location.getAltitude());
 
-			locInfo.put("lon", location.getLongitude());
-			locInfo.put("lat", location.getLatitude());
-			locInfo.put("accuracy", (int) location.getAccuracy());
-			locInfo.put("altitude", (int) location.getAltitude());
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+            locInfo.put("time", df.format(new Date(location.getTime())));
+            locInfo.put("cell", cellInfo);
 
-			DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
-			locInfo.put("time", df.format(new Date(location.getTime())));
-			locInfo.put("cell", cellInfo);
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
 
-			MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            JSONArray wifiInfo = new JSONArray();
+            List<ScanResult> aps = wm.getScanResults();
+            if (aps != null) {
+                for (ScanResult ap : aps) {
+                    if (!shouldLog(ap))
+                        continue;
+                    StringBuilder sb = new StringBuilder();
+                    try {
+                        byte[] result = digest.digest((ap.BSSID + ap.SSID)
+                                .getBytes("UTF-8"));
+                        for (byte b : result)
+                            sb.append(String.format("%02X", b));
 
-			JSONArray wifiInfo = new JSONArray();
-			List<ScanResult> aps = wm.getScanResults();
-			if (aps != null) {
-				for (ScanResult ap : aps) {
-					if (!shouldLog(ap))
-						continue;
-					StringBuilder sb = new StringBuilder();
-					try {
-						byte[] result = digest.digest((ap.BSSID + ap.SSID)
-								.getBytes("UTF-8"));
-						for (byte b : result)
-							sb.append(String.format("%02X", b));
+                        JSONObject obj = new JSONObject();
 
-						JSONObject obj = new JSONObject();
+                        obj.put("key", sb.toString());
+                        obj.put("frequency", ap.frequency);
+                        obj.put("signal", ap.level);
+                        wifiInfo.put(obj);
+                    } catch (UnsupportedEncodingException uee) {
+                        Log.w(LOGTAG, "can't encode the key", uee);
+                    }
+                }
+            }
+            locInfo.put("wifi", wifiInfo);
+        } catch (JSONException jsonex) {
+            Log.w(LOGTAG, "json exception", jsonex);
+        } catch (NoSuchAlgorithmException nsae) {
+            Log.w(LOGTAG, "can't creat a SHA1", nsae);
+        }
 
-						obj.put("key", sb.toString());
-						obj.put("frequency", ap.frequency);
-						obj.put("signal", ap.level);
-						wifiInfo.put(obj);
-					} catch (UnsupportedEncodingException uee) {
-						Log.w(LOGTAG, "can't encode the key", uee);
-					}
-				}
-			}
-			locInfo.put("wifi", wifiInfo);
-		} catch (JSONException jsonex) {
-			Log.w(LOGTAG, "json exception", jsonex);
-		} catch (NoSuchAlgorithmException nsae) {
-			Log.w(LOGTAG, "can't creat a SHA1", nsae);
-		}
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    URL url = new URL(LOCATION_URL);
+                    HttpURLConnection urlConnection = (HttpURLConnection) url
+                            .openConnection();
+                    try {
+                        urlConnection.setDoOutput(true);
+                        JSONArray batch = new JSONArray();
+                        batch.put(locInfo);
+                        JSONObject wrapper = new JSONObject();
+                        wrapper.put("items", batch);
+                        byte[] bytes = wrapper.toString().getBytes();
+                        urlConnection.setFixedLengthStreamingMode(bytes.length);
+                        OutputStream out = new BufferedOutputStream(
+                                urlConnection.getOutputStream());
+                        out.write(bytes);
+                        out.flush();
+                    } catch (JSONException jsonex) {
+                        Log.e(LOGTAG, "error wrapping data as a batch", jsonex);
+                    } catch (Exception ex) {
+                        Log.e(LOGTAG, "error submitting data", ex);
+                    } finally {
+                        urlConnection.disconnect();
+                    }
+                } catch (Exception ex) {
+                    Log.e(LOGTAG, "error submitting data", ex);
+                }
+            }
+        }).start();
+    }
 
-		new Thread(new Runnable() {
-			public void run() {
-				try {
-					URL url = new URL(LOCATION_URL);
-					HttpURLConnection urlConnection = (HttpURLConnection) url
-							.openConnection();
-					try {
-						urlConnection.setDoOutput(true);
-						JSONArray batch = new JSONArray();
-						batch.put(locInfo);
-						JSONObject wrapper = new JSONObject();
-						wrapper.put("items", batch);
-						byte[] bytes = wrapper.toString().getBytes();
-						urlConnection.setFixedLengthStreamingMode(bytes.length);
-						OutputStream out = new BufferedOutputStream(
-								urlConnection.getOutputStream());
-						out.write(bytes);
-						out.flush();
-					} catch (JSONException jsonex) {
-						Log.e(LOGTAG, "error wrapping data as a batch", jsonex);
-					} catch (Exception ex) {
-						Log.e(LOGTAG, "error submitting data", ex);
-					} finally {
-						urlConnection.disconnect();
-					}
-				} catch (Exception ex) {
-					Log.e(LOGTAG, "error submitting data", ex);
-				}
-			}
-		}).start();
-	}
+    @Override
+    public void onProviderDisabled(String provider) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void onProviderDisabled(String provider) {
-		// TODO Auto-generated method stub
+    @Override
+    public void onProviderEnabled(String provider) {
+        // TODO Auto-generated method stub
+    }
 
-	}
-
-	@Override
-	public void onProviderEnabled(String provider) {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void onStatusChanged(String provider, int status, Bundle extras) {
-		// TODO Auto-generated method stub
-
-	}
-
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+        // TODO Auto-generated method stub
+    }
 }

--- a/src/com/mozilla/mozstumbler/MainActivity.java
+++ b/src/com/mozilla/mozstumbler/MainActivity.java
@@ -1,7 +1,10 @@
 package com.mozilla.mozstumbler;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
+import android.os.StrictMode;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.telephony.CellLocation;
@@ -53,6 +56,8 @@ public class MainActivity extends Activity implements LocationListener {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        enableStrictMode();
+
         setContentView(R.layout.activity_main);
 
         Button scanningBtn = (Button) findViewById(R.id.toggle_scanning);
@@ -323,5 +328,22 @@ public class MainActivity extends Activity implements LocationListener {
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
         // TODO Auto-generated method stub
+    }
+
+    @TargetApi(9)
+    private void enableStrictMode() {
+        if (Build.VERSION.SDK_INT < 9) {
+            return;
+        }
+
+        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                                                              .detectAll()
+                                                              .penaltyLog()
+                                                              .build());
+
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                                                      .detectAll()
+                                                      .penaltyLog()
+                                                      .build());
     }
 }

--- a/src/com/mozilla/mozstumbler/Reporter.java
+++ b/src/com/mozilla/mozstumbler/Reporter.java
@@ -68,6 +68,10 @@ class Reporter {
                         obj.put("frequency", ap.frequency);
                         obj.put("signal", ap.level);
                         wifiInfo.put(obj);
+
+                        Log.v(LOGTAG, "Reporting: BSSID=" + ap.BSSID
+                                      + ", SSID=\"" + ap.SSID
+                                      + "\", Signal=" + ap.level);
                     } catch (UnsupportedEncodingException uee) {
                         Log.w(LOGTAG, "can't encode the key", uee);
                     }
@@ -111,7 +115,14 @@ class Reporter {
     }
 
     private static boolean shouldLog(ScanResult scanResult) {
-        return !BSSIDBlockList.contains(scanResult) &&
-               !SSIDBlockList.contains(scanResult);
+        if (BSSIDBlockList.contains(scanResult)) {
+            Log.w(LOGTAG, "Blocked BSSID: " + scanResult);
+            return false;
+        }
+        if (SSIDBlockList.contains(scanResult)) {
+            Log.w(LOGTAG, "Blocked SSID: " + scanResult);
+            return false;
+        }
+        return true;
     }
 }

--- a/src/com/mozilla/mozstumbler/Reporter.java
+++ b/src/com/mozilla/mozstumbler/Reporter.java
@@ -25,7 +25,6 @@ import java.util.Date;
 class Reporter {
     private static final String LOGTAG = "Reporter";
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
-    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
 
     private final MessageDigest mSHA1;
 
@@ -111,13 +110,8 @@ class Reporter {
         }).start();
     }
 
-    private static boolean shouldLog(final ScanResult sr) {
-        if (BSSIDBlockList.contains(sr)) {
-            return false;
-        } else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
-            return false;
-        } else {
-            return true;
-        }
+    private static boolean shouldLog(ScanResult scanResult) {
+        return !BSSIDBlockList.contains(scanResult) &&
+               !SSIDBlockList.contains(scanResult);
     }
 }

--- a/src/com/mozilla/mozstumbler/Reporter.java
+++ b/src/com/mozilla/mozstumbler/Reporter.java
@@ -19,22 +19,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 class Reporter {
     private static final String LOGTAG = "Reporter";
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
-
-    // copied from
-    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
-    // which is apache licensed
-    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
-            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
-
     private static final String OPTOUT_SSID_SUFFIX = "_nomap";
 
     private final MessageDigest mSHA1;
@@ -122,20 +112,8 @@ class Reporter {
     }
 
     private static boolean shouldLog(final ScanResult sr) {
-        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
-        // having a
-        // 2,6,a or e in the second nybble.
-        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
-        // have the last two bits of the second nybble set to 10.
-        // Only apply this test if we have exactly 17 character long BSSID which
-        // should
-        // be the case.
-        final char secondNybble = sr.BSSID.length() == 17 ? sr.BSSID.charAt(1)
-                : ' ';
-
-        if (AD_HOC_HEX_VALUES.contains(secondNybble)) {
+        if (BSSIDBlockList.contains(sr)) {
             return false;
-
         } else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
             return false;
         } else {

--- a/src/com/mozilla/mozstumbler/Reporter.java
+++ b/src/com/mozilla/mozstumbler/Reporter.java
@@ -1,0 +1,145 @@
+package com.mozilla.mozstumbler;
+
+import android.annotation.SuppressLint;
+import android.location.Location;
+import android.net.wifi.ScanResult;
+import android.telephony.TelephonyManager;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+class Reporter {
+    private static final String LOGTAG = "Reporter";
+    private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
+
+    // copied from
+    // http://code.google.com/p/sensor-data-collection-library/source/browse/src/main/java/TextFileSensorLog.java#223,
+    // which is apache licensed
+    private static final Set<Character> AD_HOC_HEX_VALUES = new HashSet<Character>(
+            Arrays.asList('2', '6', 'a', 'e', 'A', 'E'));
+
+    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
+
+    private final MessageDigest mSHA1;
+
+    Reporter() {
+        try {
+            mSHA1 = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    void reportLocation(Location location, Collection<ScanResult> scanResults, int radioType, JSONArray cellInfo) {
+        final JSONObject locInfo = new JSONObject();
+        try {
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+            locInfo.put("time", df.format(new Date(location.getTime())));
+            locInfo.put("lon", location.getLongitude());
+            locInfo.put("lat", location.getLatitude());
+            locInfo.put("accuracy", (int) location.getAccuracy());
+            locInfo.put("altitude", (int) location.getAltitude());
+
+            locInfo.put("cell", cellInfo);
+            if (radioType == TelephonyManager.PHONE_TYPE_GSM)
+                locInfo.put("radio", "gsm");
+
+            JSONArray wifiInfo = new JSONArray();
+            if (scanResults != null) {
+                for (ScanResult ap : scanResults) {
+                    if (!shouldLog(ap))
+                        continue;
+                    StringBuilder sb = new StringBuilder();
+                    try {
+                        byte[] result = mSHA1.digest((ap.BSSID + ap.SSID)
+                                .getBytes("UTF-8"));
+                        for (byte b : result)
+                            sb.append(String.format("%02X", b));
+
+                        JSONObject obj = new JSONObject();
+                        obj.put("key", sb.toString());
+                        obj.put("frequency", ap.frequency);
+                        obj.put("signal", ap.level);
+                        wifiInfo.put(obj);
+                    } catch (UnsupportedEncodingException uee) {
+                        Log.w(LOGTAG, "can't encode the key", uee);
+                    }
+                }
+            }
+            locInfo.put("wifi", wifiInfo);
+        } catch (JSONException jsonex) {
+            Log.w(LOGTAG, "json exception", jsonex);
+        }
+
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    URL url = new URL(LOCATION_URL);
+                    HttpURLConnection urlConnection = (HttpURLConnection) url
+                            .openConnection();
+                    try {
+                        urlConnection.setDoOutput(true);
+                        JSONArray batch = new JSONArray();
+                        batch.put(locInfo);
+                        JSONObject wrapper = new JSONObject();
+                        wrapper.put("items", batch);
+                        byte[] bytes = wrapper.toString().getBytes();
+                        urlConnection.setFixedLengthStreamingMode(bytes.length);
+                        OutputStream out = new BufferedOutputStream(
+                                urlConnection.getOutputStream());
+                        out.write(bytes);
+                        out.flush();
+                    } catch (JSONException jsonex) {
+                        Log.e(LOGTAG, "error wrapping data as a batch", jsonex);
+                    } catch (Exception ex) {
+                        Log.e(LOGTAG, "error submitting data", ex);
+                    } finally {
+                        urlConnection.disconnect();
+                    }
+                } catch (Exception ex) {
+                    Log.e(LOGTAG, "error submitting data", ex);
+                }
+            }
+        }).start();
+    }
+
+    private static boolean shouldLog(final ScanResult sr) {
+        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
+        // having a
+        // 2,6,a or e in the second nybble.
+        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
+        // have the last two bits of the second nybble set to 10.
+        // Only apply this test if we have exactly 17 character long BSSID which
+        // should
+        // be the case.
+        final char secondNybble = sr.BSSID.length() == 17 ? sr.BSSID.charAt(1)
+                : ' ';
+
+        if (AD_HOC_HEX_VALUES.contains(secondNybble)) {
+            return false;
+
+        } else if (sr.SSID != null && sr.SSID.endsWith(OPTOUT_SSID_SUFFIX)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/src/com/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/com/mozilla/mozstumbler/SSIDBlockList.java
@@ -3,15 +3,122 @@ package com.mozilla.mozstumbler;
 import android.net.wifi.ScanResult;
 
 final class SSIDBlockList {
-    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
+    private static final String[] PREFIX_LIST = {
+        // Mobile devices
+        "ASUS",
+        "AndroidAP",
+        "AndroidTether",
+        "CLEAR Spot",
+        "CLEARSpot",
+        "Clear Spot",
+        "ClearSPOT",
+        "ClearSpot",
+        "Ericsson",
+        "Galaxy Note",
+        "Galaxy S",
+        "Galaxy Tab",
+        "HTC ",
+        "HelloMoto",
+        "LG VS910 4G",
+        "Laptop",
+        "MIFI",
+        "MiFi",
+        "PhoneAP",
+        "SAMSUNG",
+        "SCH-I",
+        "SPRINT",
+        "Samsung",
+        "Sprint",
+        "Verizon",
+        "VirginMobile MiFi2200",
+        "WaveLAN Network",
+        "barnacle",                 // Android Barnacle Wifi Tether
+        "docomo",
+        "hellomoto",
+        "iDockUSA",
+        "iHub_",
+        "iPad",
+        "iPhone",
+        "ipad",
+        "laptop",
+        "mifi",
+        "myLGNet",
+        "myTouch 4G Hotspot",
+        "samsung",
+        "sprint",
+        "webOS Network",
+
+        // Transportation Wi-Fi
+        "GBUS",
+        "GBusWifi",
+        "SF Shuttle Wireless",
+        "SST-PR-1",                 // Sears Home Service van hotspot?!
+        "Shuttle",
+        "Trimble ",
+        "VTA Free Wi-Fi",           // VTA light rail
+        "ac_transit_wifi_bus",
+        "airbusA380",
+        "amtrak_",
+        "shuttle",
+
+        // "Viral" SSIDs that infect some Windows laptops
+        "Adhoc",
+        "Free Internet Access",
+        "Free Internet!",
+        "Jet Blue hot spot",
+        "US Airways Free WiFi",
+        "adhoc",
+        "hpsetup",
+        "tsunami",
+    };
+
+    private static final String[] SUFFIX_LIST = {
+        // Mobile devices
+        " ASUS",
+        "-ASUS",
+        "Laptop",
+        "MacBook",
+        "MacBook Pro",
+        "MIFI",
+        "MiFi",
+        "Mifi",
+        "MyWi",
+        "Tether",
+        "_ASUS",
+        "iPad",
+        "iPhone",
+        "ipad",
+        "iphone",
+        "laptop",
+        "macbook",
+        "mifi",
+        "tether",
+
+        // Google's SSID opt-out
+        "_nomap",
+    };
 
     private SSIDBlockList() {
     }
 
     static boolean contains(ScanResult scanResult) {
         String SSID = scanResult.SSID;
-        return SSID == null ||
-               SSID.length() == 0 ||
-               SSID.endsWith(OPTOUT_SSID_SUFFIX);
+        if (SSID == null || SSID.length() == 0) {
+            return true; // blocked!
+        }
+
+        for (String prefix : PREFIX_LIST) {
+            if (SSID.startsWith(prefix)) {
+                return true; // blocked!
+            }
+        }
+
+        for (String suffix : SUFFIX_LIST) {
+            if (SSID.endsWith(suffix)) {
+                return true; // blocked!
+            }
+        }
+
+        return false; // OK
     }
 }

--- a/src/com/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/com/mozilla/mozstumbler/SSIDBlockList.java
@@ -1,0 +1,17 @@
+package com.mozilla.mozstumbler;
+
+import android.net.wifi.ScanResult;
+
+final class SSIDBlockList {
+    private static final String OPTOUT_SSID_SUFFIX = "_nomap";
+
+    private SSIDBlockList() {
+    }
+
+    static boolean contains(ScanResult scanResult) {
+        String SSID = scanResult.SSID;
+        return SSID == null ||
+               SSID.length() == 0 ||
+               SSID.endsWith(OPTOUT_SSID_SUFFIX);
+    }
+}

--- a/src/com/mozilla/mozstumbler/Scanner.java
+++ b/src/com/mozilla/mozstumbler/Scanner.java
@@ -1,0 +1,191 @@
+package com.mozilla.mozstumbler;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.location.Criteria;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.net.wifi.ScanResult;
+import android.net.wifi.WifiManager;
+import android.os.Bundle;
+import android.os.Looper;
+import android.telephony.CellLocation;
+import android.telephony.NeighboringCellInfo;
+import android.telephony.PhoneStateListener;
+import android.telephony.SignalStrength;
+import android.telephony.TelephonyManager;
+import android.telephony.gsm.GsmCellLocation;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Collection;
+
+class Scanner implements LocationListener {
+    private static final long MIN_UPDATE_TIME = 1000; // milliseconds
+    private static final float MIN_UPDATE_DISTANCE = .5f; // meters
+
+    private final Context mContext;
+    private int mSignalStrength;
+    private PhoneStateListener mPhoneStateListener;
+    private Reporter mReporter;
+
+    Scanner(Context context) {
+        mContext = context;
+        mReporter = new Reporter();
+    }
+
+    void startScanning() {
+        LocationManager lm = getLocationManager();
+        Criteria criteria = new Criteria();
+        criteria.setSpeedRequired(false);
+        criteria.setBearingRequired(false);
+        criteria.setAltitudeRequired(false);
+        criteria.setAccuracy(Criteria.ACCURACY_FINE);
+        criteria.setPowerRequirement(Criteria.POWER_HIGH); // hmm.
+
+        String provider = lm.getBestProvider(criteria, true);
+        lm.requestLocationUpdates(provider, MIN_UPDATE_TIME, MIN_UPDATE_DISTANCE,
+                getLocationListener(), Looper.getMainLooper());
+    }
+
+    void stopScanning() {
+        LocationManager lm = getLocationManager();
+        lm.removeUpdates(getLocationListener());
+    }
+
+    private LocationListener getLocationListener() {
+        if (mPhoneStateListener == null) {
+            mPhoneStateListener = new PhoneStateListener() {
+                public void onSignalStrengthsChanged(SignalStrength ss) {
+                    if (ss.isGsm()) {
+                        mSignalStrength = ss.getGsmSignalStrength();
+                    }
+                }
+            };
+            TelephonyManager tm = getTelephonyManager();
+            tm.listen(mPhoneStateListener,
+                    PhoneStateListener.LISTEN_SIGNAL_STRENGTHS);
+        }
+        return this;
+    }
+
+    @Override
+    public void onLocationChanged(Location location) {
+        collectAndReportLocInfo(location);
+    }
+
+    private int getCellInfo(JSONArray cellInfo) {
+        TelephonyManager tm = getTelephonyManager();
+        if (tm == null)
+            return TelephonyManager.PHONE_TYPE_NONE;
+        Collection<NeighboringCellInfo> cells = tm.getNeighboringCellInfo();
+        CellLocation cl = tm.getCellLocation();
+        if (cl == null)
+            return TelephonyManager.PHONE_TYPE_NONE;
+        String mcc = "", mnc = "";
+        if (cl instanceof GsmCellLocation) {
+            JSONObject obj = new JSONObject();
+            GsmCellLocation gcl = (GsmCellLocation) cl;
+            try {
+                obj.put("lac", gcl.getLac());
+                obj.put("cid", gcl.getCid());
+                obj.put("psc", gcl.getPsc());
+                switch (tm.getNetworkType()) {
+                case TelephonyManager.NETWORK_TYPE_GPRS:
+                case TelephonyManager.NETWORK_TYPE_EDGE:
+                    obj.put("radio", "gsm");
+                    break;
+                case TelephonyManager.NETWORK_TYPE_UMTS:
+                case TelephonyManager.NETWORK_TYPE_HSDPA:
+                case TelephonyManager.NETWORK_TYPE_HSUPA:
+                case TelephonyManager.NETWORK_TYPE_HSPA:
+                case TelephonyManager.NETWORK_TYPE_HSPAP:
+                    obj.put("radio", "umts");
+                    break;
+                }
+                String mcc_mnc = tm.getNetworkOperator();
+                if (mcc_mnc.length() > 3) {
+                    mcc = mcc_mnc.substring(0, 3);
+                    mnc = mcc_mnc.substring(3);
+                    obj.put("mcc", mcc);
+                    obj.put("mnc", mnc);
+                }
+                obj.put("asu", mSignalStrength);
+            } catch (JSONException jsonex) {
+            }
+            cellInfo.put(obj);
+        }
+        if (cells != null) {
+            for (NeighboringCellInfo nci : cells) {
+                try {
+                    JSONObject obj = new JSONObject();
+                    obj.put("lac", nci.getLac());
+                    obj.put("cid", nci.getCid());
+                    obj.put("psc", nci.getPsc());
+                    obj.put("mcc", mcc);
+                    obj.put("mnc", mnc);
+
+                    switch (nci.getNetworkType()) {
+                    case TelephonyManager.NETWORK_TYPE_GPRS:
+                    case TelephonyManager.NETWORK_TYPE_EDGE:
+                        obj.put("radio", "gsm");
+                        break;
+                    case TelephonyManager.NETWORK_TYPE_UMTS:
+                    case TelephonyManager.NETWORK_TYPE_HSDPA:
+                    case TelephonyManager.NETWORK_TYPE_HSUPA:
+                    case TelephonyManager.NETWORK_TYPE_HSPA:
+                    case TelephonyManager.NETWORK_TYPE_HSPAP:
+                        obj.put("radio", "umts");
+                        break;
+                    }
+
+                    obj.put("asu", nci.getRssi());
+                    cellInfo.put(obj);
+                } catch (JSONException jsonex) {
+                }
+            }
+        }
+        return tm.getPhoneType();
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    private void collectAndReportLocInfo(Location location) {
+        JSONArray cellInfo = new JSONArray();
+        int radioType = getCellInfo(cellInfo);
+
+        WifiManager wm = getWifiManager();
+        wm.startScan();
+        Collection<ScanResult> scanResults = wm.getScanResults();
+        mReporter.reportLocation(location, scanResults, radioType, cellInfo);
+    }
+
+    @Override
+    public void onProviderDisabled(String provider) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void onProviderEnabled(String provider) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+        // TODO Auto-generated method stub
+    }
+
+    private LocationManager getLocationManager() {
+        return (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+    }
+
+    private TelephonyManager getTelephonyManager() {
+        return (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+    }
+
+    private WifiManager getWifiManager() {
+        return (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+    }
+}

--- a/src/com/mozilla/mozstumbler/Scanner.java
+++ b/src/com/mozilla/mozstumbler/Scanner.java
@@ -74,7 +74,9 @@ class Scanner implements LocationListener {
 
     @Override
     public void onLocationChanged(Location location) {
-        collectAndReportLocInfo(location);
+        if (!LocationBlockList.contains(location)) {
+            collectAndReportLocInfo(location);
+        }
     }
 
     private int getCellInfo(JSONArray cellInfo) {

--- a/src/com/mozilla/mozstumbler/Scanner.java
+++ b/src/com/mozilla/mozstumbler/Scanner.java
@@ -58,6 +58,11 @@ class Scanner implements LocationListener {
         Log.d(LOGTAG, "Scanning stopped");
         LocationManager lm = getLocationManager();
         lm.removeUpdates(getLocationListener());
+        if (mPhoneStateListener != null) {
+            TelephonyManager tm = getTelephonyManager();
+            tm.listen(mPhoneStateListener, PhoneStateListener.LISTEN_NONE);
+            mPhoneStateListener = null;
+        }
     }
 
     private LocationListener getLocationListener() {

--- a/src/com/mozilla/mozstumbler/Scanner.java
+++ b/src/com/mozilla/mozstumbler/Scanner.java
@@ -159,6 +159,12 @@ class Scanner implements LocationListener {
         WifiManager wm = getWifiManager();
         wm.startScan();
         Collection<ScanResult> scanResults = wm.getScanResults();
+        if (scanResults != null) {
+            for (ScanResult scanResult : scanResults) {
+                scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
+            }
+        }
+
         mReporter.reportLocation(location, scanResults, radioType, cellInfo);
     }
 


### PR DESCRIPTION
These classes do not implement lists, but conceptually they act like block lists.

If we want to get fancy, we could block BSSIDs that don't have valid manufacturer OUIs. Wireshark maintains a list of known OUIs: http://anonsvn.wireshark.org/wireshark/trunk/manuf . However, I don't think we should care as long as the BSSIDs are still unique (unlike `00:00:00:00:00:00`, which I have seen multiple times in my own stumbling).

The SSID blocklist checks for `_nomap` and a list of some common SSIDs for mobile devices (`AndroidTether` and `iPhone`), hotspots (`MiFi` and `MacBook`), and shuttles (`GBusWifi` and `ac_transit_wifi_bus`) we could block. If our server algorithms uses trilateration, then we probably want to block mobile APs. If our server algorithms uses the grid method instead of trilateration, we probably _want to unblock_ mobile APs and ad-hoc BSSIDs because duplicate measurements of the same device in multiple locations doesn't hurt. Unfortunately, our server can't make these distinctions if it only knows about SHA1 fingerprints instead of actual SSIDs. I think our early stumbling filters should be conservative because it's easier to remove these restrictions later than to clean up a polluted database later.

The values I chose for the location sanity checks are pretty arbitrary. I figured we could tighten the limits later. I have seen some Android devices, like the Galaxy Nexus, that report valid latitude and longitude with bogus negative altitudes. So we might want to be relax altitude sanity checks. The iPhone GPS seems to clamp negative altitudes at 0.
