### PR TITLE
Increase minimum update distance from 0.5 to 10 meters

### DIFF
--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 class Scanner implements LocationListener {
     private static final String LOGTAG = "Scanner";
     private static final long MIN_UPDATE_TIME = 1000; // milliseconds
-    private static final float MIN_UPDATE_DISTANCE = 0.5f; // meters
+    private static final float MIN_UPDATE_DISTANCE = 10; // meters
 
     private final Context mContext;
     private int mSignalStrength;


### PR DESCRIPTION
A quick fix to reduce some duplicate measurements (and save battery): increase minimum update distance from 0.5 to 10 meters, as suggested by @hannosch in issue #3.
