### PR TITLE
Delete cached A-GPS aiding data to force GPS cold start

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -39,6 +39,7 @@ class Scanner implements LocationListener {
 
     void startScanning() {
         Log.d(LOGTAG, "Scanning started...");
+        deleteAidingData();
         LocationManager lm = getLocationManager();
         lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, MIN_UPDATE_TIME, MIN_UPDATE_DISTANCE, getLocationListener());
     }
@@ -201,6 +202,17 @@ class Scanner implements LocationListener {
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
         // TODO Auto-generated method stub
+    }
+
+    private void deleteAidingData() {
+        LocationManager lm = getLocationManager();
+
+        // Delete cached A-GPS aiding data to force GPS cold start.
+        lm.sendExtraCommand(LocationManager.GPS_PROVIDER, "delete_aiding_data", null);
+        lm.sendExtraCommand(LocationManager.GPS_PROVIDER, "force_xtra_injection", null);
+
+        // Force NTP resync.
+        lm.sendExtraCommand(LocationManager.GPS_PROVIDER, "force_time_injection", null);
     }
 
     private LocationManager getLocationManager() {


### PR DESCRIPTION
Issue #9

According to "Professional Android Sensor Programming" and cargo cult programming advice on Stack Overflow, the device's cached A-GPS data can be up to 5 minutes out of date. The `delete_aiding_data` and `force_extra_injection` GPS commands will force the device to download the latest GPS ephemeris and almanac data. The `force_time_injection` command will resynchronize the system clock with NTP.
