### PR TITLE
Generate random user token for database submission stats

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -18,139 +18,137 @@ import android.widget.Button;
 
 public class MainActivity extends Activity {
 
-	private static final String LOGTAG = MainActivity.class.getName();
+    private static final String LOGTAG = MainActivity.class.getName();
 
-	private ScannerServiceInterface mConnectionRemote;
-	private ServiceConnection mConnection;
-	
-	protected void onNewIntent(Intent intent) {
-		super.onNewIntent(intent);
-		Log.d(LOGTAG, "New intent with flags " + intent.getFlags());
-	}
+    private ScannerServiceInterface mConnectionRemote;
+    private ServiceConnection mConnection;
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		enableStrictMode();
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Log.d(LOGTAG, "New intent with flags " + intent.getFlags());
+    }
 
-		setContentView(R.layout.activity_main);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        enableStrictMode();
 
-		Log.e(LOGTAG, "onCreate");
-	}
+        setContentView(R.layout.activity_main);
 
-	@Override
-	protected void onStart() {
-		super.onStart();
-		
-		mConnection = new ServiceConnection() {
+        Log.d(LOGTAG, "onCreate");
+    }
 
-			public void onServiceConnected(ComponentName className, IBinder binder) {
-				mConnectionRemote = ScannerServiceInterface.Stub
-						.asInterface(binder);
-				Log.d(LOGTAG, "Service connected");
+    @Override
+    protected void onStart() {
+        super.onStart();
 
-				updateUI();
-			}
+        mConnection = new ServiceConnection() {
+            public void onServiceConnected(ComponentName className, IBinder binder) {
+                mConnectionRemote = ScannerServiceInterface.Stub.asInterface(binder);
+                Log.d(LOGTAG, "Service connected");
+                updateUI();
+            }
 
-			public void onServiceDisconnected(ComponentName className) {
-				mConnectionRemote = null;
-				Log.d(LOGTAG, "Service disconnected", new Exception());
-			}
-		};
-		
-		Intent intent = new Intent(this, ScannerService.class);
-		startService(intent);
-		bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
-	}
-	
-	@Override
-	protected void onStop() {
-		super.onStop();
+            public void onServiceDisconnected(ComponentName className) {
+                mConnectionRemote = null;
+                Log.d(LOGTAG, "Service disconnected", new Exception());
+            }
+        };
 
-		try {
-			if (mConnectionRemote.isScanning()) {
-				mConnectionRemote.showNotification();
-			}
-		} catch (RemoteException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+        Intent intent = new Intent(this, ScannerService.class);
+        startService(intent);
+        bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
 
-		unbindService(mConnection);
-		mConnection = null;
-		mConnectionRemote = null;
+        Log.d(LOGTAG, "onStart");
+    }
 
-		Log.d(LOGTAG, "onStop");
-	}
-	
-	@Override
-	protected void onDestroy() {
-		super.onDestroy();
-		Log.d(LOGTAG, "onDestory");
-	}
-	
-	protected void updateUI() {
-		Log.d(LOGTAG, "Updating UI");
+    @Override
+    protected void onStop() {
+        super.onStop();
 
-		boolean scanning = false;
-		try {
-			scanning = mConnectionRemote.isScanning();
-		} catch (RemoteException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+        try {
+            if (mConnectionRemote.isScanning()) {
+                mConnectionRemote.showNotification();
+            }
+        } catch (RemoteException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
 
-		int buttonText;
-		if (scanning) {
-			buttonText = R.string.stop_scanning;
-		} else {
-			buttonText = R.string.start_scanning;
-		}
+        unbindService(mConnection);
+        mConnection = null;
+        mConnectionRemote = null;
 
-		Button scanningBtn = (Button) findViewById(R.id.toggle_scanning);
-		scanningBtn.setText(buttonText);
-	}
+        Log.d(LOGTAG, "onStop");
+    }
 
-	public void onBtnClicked(View v) throws RemoteException {
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Log.d(LOGTAG, "onDestroy");
+    }
 
-		if (v.getId() == R.id.toggle_scanning) {
+    protected void updateUI() {
+        Log.d(LOGTAG, "Updating UI");
 
-			boolean scanning = mConnectionRemote.isScanning();
-			Log.d(LOGTAG, "Connection remote return: isScanning() = "
-					+ scanning);
+        boolean scanning = false;
+        try {
+            scanning = mConnectionRemote.isScanning();
+        } catch (RemoteException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
 
-			int buttonText;
+        int buttonText;
+        if (scanning) {
+            buttonText = R.string.stop_scanning;
+        } else {
+            buttonText = R.string.start_scanning;
+        }
 
-			if (scanning) {
-				mConnectionRemote.stopScanning();
-				buttonText = R.string.start_scanning;
-			} else {
-				mConnectionRemote.startScanning();
-				buttonText = R.string.stop_scanning;
-			}
+        Button scanningBtn = (Button) findViewById(R.id.toggle_scanning);
+        scanningBtn.setText(buttonText);
+    }
 
-			Button b = (Button) v;
-			b.setText(buttonText);
-		}
-	}
+    public void onBtnClicked(View v) throws RemoteException {
 
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		// Inflate the menu; this adds items to the action bar if it is present.
-		getMenuInflater().inflate(R.menu.main, menu);
-		return true;
-	}
+        if (v.getId() == R.id.toggle_scanning) {
 
-	@TargetApi(9)
-	private void enableStrictMode() {
-		if (Build.VERSION.SDK_INT < 9) {
-			return;
-		}
+            boolean scanning = mConnectionRemote.isScanning();
+            Log.d(LOGTAG, "Connection remote return: isScanning() = " + scanning);
 
-		StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
-				.detectAll().penaltyLog().build());
+            int buttonText;
 
-		StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll()
-				.penaltyLog().build());
-	}
+            if (scanning) {
+                mConnectionRemote.stopScanning();
+                buttonText = R.string.start_scanning;
+            } else {
+                mConnectionRemote.startScanning();
+                buttonText = R.string.stop_scanning;
+            }
+
+            Button b = (Button) v;
+            b.setText(buttonText);
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.main, menu);
+        return true;
+    }
+
+    @TargetApi(9)
+    private void enableStrictMode() {
+        if (Build.VERSION.SDK_INT < 9) {
+            return;
+        }
+
+        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                  .detectAll().penaltyLog().build());
+
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll()
+                  .penaltyLog().build());
+    }
 }

--- a/src/org/mozilla/mozstumbler/Prefs.java
+++ b/src/org/mozilla/mozstumbler/Prefs.java
@@ -1,0 +1,60 @@
+package org.mozilla.mozstumbler;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.util.UUID;
+
+final class Prefs {
+    private static final String LOGTAG = Prefs.class.getName();
+    private static final String PREFS_FILE = Prefs.class.getName();
+    private static final String TOKEN_PREF = "token";
+
+    private final SharedPreferences mPrefs;
+
+    Prefs(Context context) {
+        mPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+    }
+
+    UUID getToken() {
+        UUID token = null;
+
+        String pref = getStringPref(TOKEN_PREF);
+        if (pref != null) {
+            try {
+                token = UUID.fromString(pref);
+            } catch (IllegalArgumentException e) {
+                Log.e(LOGTAG, "bad token pref: " + pref, e);
+            }
+        }
+
+        if (token == null) {
+            token = UUID.randomUUID();
+            setStringPref(TOKEN_PREF, token.toString());
+        }
+
+        Log.d(LOGTAG, "token: " + token);
+        return token;
+    }
+
+    void deleteToken() {
+        deleteStringPref(TOKEN_PREF);
+    }
+
+    private String getStringPref(String key) {
+        return mPrefs.getString(key, null);
+    }
+
+    private void setStringPref(String key, String value) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putString(key, value);
+        editor.commit();
+    }
+
+    private void deleteStringPref(String key) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.remove(key);
+        editor.commit();
+    }
+}

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -26,9 +26,12 @@ class Reporter {
     private static final String LOGTAG = Reporter.class.getName();
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
 
+    private final Prefs mPrefs;
     private final MessageDigest mSHA1;
 
-    Reporter() {
+    Reporter(Prefs prefs) {
+        mPrefs = prefs;
+
         try {
             mSHA1 = MessageDigest.getInstance("SHA-1");
         } catch (NoSuchAlgorithmException e) {
@@ -46,6 +49,7 @@ class Reporter {
             locInfo.put("lat", location.getLatitude());
             locInfo.put("accuracy", (int) location.getAccuracy());
             locInfo.put("altitude", (int) location.getAltitude());
+            locInfo.put("token", mPrefs.getToken());
 
             locInfo.put("cell", cellInfo);
             if (radioType == TelephonyManager.PHONE_TYPE_GSM)

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -30,12 +30,12 @@ class Scanner implements LocationListener {
     private final Context mContext;
     private int mSignalStrength;
     private PhoneStateListener mPhoneStateListener;
-    private Reporter mReporter;
+    private final Reporter mReporter;
     private boolean mIsScanning;
 
-    Scanner(Context context) {
+    Scanner(Context context, Reporter reporter) {
         mContext = context;
-        mReporter = new Reporter();
+        mReporter = reporter;
     }
 
     void startScanning() {

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -31,18 +31,17 @@ class Scanner implements LocationListener {
     private int mSignalStrength;
     private PhoneStateListener mPhoneStateListener;
     private Reporter mReporter;
-
     private boolean mIsScanning;
-    
+
     Scanner(Context context) {
         mContext = context;
         mReporter = new Reporter();
     }
 
     void startScanning() {
-    	if (mIsScanning) {
+        if (mIsScanning) {
           return;
-    	}
+        }
         Log.d(LOGTAG, "Scanning started...");
         deleteAidingData();
         LocationManager lm = getLocationManager();
@@ -51,9 +50,9 @@ class Scanner implements LocationListener {
     }
 
     void stopScanning() {
-    	if (mIsScanning == false) {
+        if (!mIsScanning) {
             return;
-      	}
+        }
         Log.d(LOGTAG, "Scanning stopped");
         LocationManager lm = getLocationManager();
         lm.removeUpdates(getLocationListener());
@@ -64,9 +63,9 @@ class Scanner implements LocationListener {
         }
         mIsScanning = false;
     }
-    
+
     boolean isScanning() {
-    	return mIsScanning;
+        return mIsScanning;
     }
 
     private LocationListener getLocationListener() {

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -41,7 +41,9 @@ public class ScannerService extends Service {
         super.onCreate();
         Log.d(LOGTAG, "onCreate");
 
-        mScanner = new Scanner(this);
+        Prefs prefs = new Prefs(this);
+        Reporter reporter = new Reporter(prefs);
+        mScanner = new Scanner(this, reporter);
         mLooper = new LooperThread();
         mLooper.start();
     }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -2,6 +2,7 @@ package org.mozilla.mozstumbler;
 
 import java.util.Calendar;
 
+import android.annotation.TargetApi;
 import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -61,8 +62,8 @@ public class ScannerService extends Service {
         // Toast.LENGTH_SHORT).show();
     }
 
+    @TargetApi(11)
     public void postNotification() {
-
         if (mLooper.mHandler == null)
             return;
 
@@ -162,7 +163,7 @@ public class ScannerService extends Service {
             @Override
             public void showNotification() throws RemoteException {
                 postNotification();
-            };
+            }
         };
     }
 }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -18,152 +18,151 @@ import android.util.Log;
 
 public class ScannerService extends Service {
 
-	private static final String LOGTAG = ScannerService.class.getName();
-	private static final int NOTIFICATION_ID = 0;
-	private static final int WAKE_TIMEOUT = 5 * 1000;
-	private Scanner mScanner = null;
-	private LooperThread mLooper = null;
-	private PendingIntent mWakeIntent = null;
+    private static final String LOGTAG = ScannerService.class.getName();
+    private static final int NOTIFICATION_ID = 0;
+    private static final int WAKE_TIMEOUT = 5 * 1000;
+    private Scanner mScanner = null;
+    private LooperThread mLooper = null;
+    private PendingIntent mWakeIntent = null;
 
-	public class LooperThread extends Thread {
-		public Handler mHandler;
+    public class LooperThread extends Thread {
+        public Handler mHandler;
 
-		public void run() {
-			Looper.prepare();
-			mHandler = new Handler();
-			Looper.loop();
-		}
-	}
+        public void run() {
+            Looper.prepare();
+            mHandler = new Handler();
+            Looper.loop();
+        }
+    }
 
-	@Override
-	public void onCreate() {
-		super.onCreate();
-		Log.d(LOGTAG, "onCreate");
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Log.d(LOGTAG, "onCreate");
 
-		mScanner = new Scanner(this);
-		mLooper = new LooperThread();
-		mLooper.start();
-	}
+        mScanner = new Scanner(this);
+        mLooper = new LooperThread();
+        mLooper.start();
+    }
 
-	@Override
-	public void onDestroy() {
-		super.onDestroy();
-		Log.d(LOGTAG, "onDestroy");
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.d(LOGTAG, "onDestroy");
 
-		mLooper.interrupt();
-		mLooper = null;
-		mScanner = null;
+        mLooper.interrupt();
+        mLooper = null;
+        mScanner = null;
 
-		NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-		nm.cancel(NOTIFICATION_ID);
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        nm.cancel(NOTIFICATION_ID);
 
-		// TODO Toast.makeText(this, R.string.local_service_stopped,
-		// Toast.LENGTH_SHORT).show();
-	}
+        // TODO Toast.makeText(this, R.string.local_service_stopped,
+        // Toast.LENGTH_SHORT).show();
+    }
 
-	public void postNotification() {
+    public void postNotification() {
 
-		if (mLooper.mHandler == null)
-			return;
+        if (mLooper.mHandler == null)
+            return;
 
-		mLooper.mHandler.post(new Runnable() {
-			@Override
-			public void run() {
+        mLooper.mHandler.post(new Runnable() {
+            @Override
+            public void run() {
 
-				NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-				Context ctx = getApplicationContext();
-				Intent notificationIntent = new Intent(ctx, MainActivity.class);
-				PendingIntent contentIntent = PendingIntent.getActivity(ctx,
-						NOTIFICATION_ID, notificationIntent,
-						PendingIntent.FLAG_CANCEL_CURRENT);
+                NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+                Context ctx = getApplicationContext();
+                Intent notificationIntent = new Intent(ctx, MainActivity.class);
+                PendingIntent contentIntent = PendingIntent.getActivity(ctx,
+                        NOTIFICATION_ID, notificationIntent,
+                        PendingIntent.FLAG_CANCEL_CURRENT);
 
-				Resources res = ctx.getResources();
-				// TODO - Do something compat w/ older os's
-				// See https://github.com/dougt/MozStumbler/pull/26#commitcomment-3689527
-				Notification.Builder builder = new Notification.Builder(ctx);
+                Resources res = ctx.getResources();
+                // TODO - Do something compat w/ older os's
+                // See https://github.com/dougt/MozStumbler/pull/26#commitcomment-3689527
+                Notification.Builder builder = new Notification.Builder(ctx);
 
-				builder.setContentIntent(contentIntent)
-						.setSmallIcon(R.drawable.ic_launcher)
-						.setOngoing(true)
-						.setAutoCancel(false)
-						.setContentTitle(res.getString(R.string.service_name))
-						.setContentText(
-								res.getString(R.string.service_scanning));
-				Notification n = builder.build();
+                builder.setContentIntent(contentIntent)
+                        .setSmallIcon(R.drawable.ic_launcher)
+                        .setOngoing(true)
+                        .setAutoCancel(false)
+                        .setContentTitle(res.getString(R.string.service_name))
+                        .setContentText(
+                                res.getString(R.string.service_scanning));
+                Notification n = builder.build();
 
-				nm.notify(NOTIFICATION_ID, n);
-			}
-		});
-	}
+                nm.notify(NOTIFICATION_ID, n);
+            }
+        });
+    }
 
-	@Override
-	public int onStartCommand(Intent intent, int flags, int startId) {
-		// keep running!
-		return Service.START_STICKY;
-	}
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // keep running!
+        return Service.START_STICKY;
+    }
 
-	@Override
-	public IBinder onBind(Intent intent) {
-		Log.d(LOGTAG, "onBind");
+    @Override
+    public IBinder onBind(Intent intent) {
+        Log.d(LOGTAG, "onBind");
 
-		return new ScannerServiceInterface.Stub() {
+        return new ScannerServiceInterface.Stub() {
 
-			@Override
-			public boolean isScanning() throws RemoteException {
-				return mScanner.isScanning();
-			};
+            @Override
+            public boolean isScanning() throws RemoteException {
+                return mScanner.isScanning();
+            };
 
-			@Override
-			public void startScanning() throws RemoteException {
-				if (mScanner.isScanning()) {
-					return;
-				}
+            @Override
+            public void startScanning() throws RemoteException {
+                if (mScanner.isScanning()) {
+                    return;
+                }
 
-				mLooper.mHandler.post(new Runnable() {
-					@Override
-					public void run() {
-						mScanner.startScanning();
+                mLooper.mHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mScanner.startScanning();
 
-						// keep us awake.
-						Context cxt = getApplicationContext();
-						Calendar cal = Calendar.getInstance();
-						Intent intent = new Intent(cxt, ScannerService.class);
-						mWakeIntent = PendingIntent.getService(cxt, 0, intent,
-								0);
-						AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-						alarm.setRepeating(AlarmManager.RTC_WAKEUP,
-								cal.getTimeInMillis(), WAKE_TIMEOUT,
-								mWakeIntent);
+                        // keep us awake.
+                        Context cxt = getApplicationContext();
+                        Calendar cal = Calendar.getInstance();
+                        Intent intent = new Intent(cxt, ScannerService.class);
+                        mWakeIntent = PendingIntent.getService(cxt, 0, intent,
+                                0);
+                        AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+                        alarm.setRepeating(AlarmManager.RTC_WAKEUP,
+                                cal.getTimeInMillis(), WAKE_TIMEOUT,
+                                mWakeIntent);
 
-					}
-				});
-			};
+                    }
+                });
+            };
 
-			@Override
-			public void stopScanning() throws RemoteException {
+            @Override
+            public void stopScanning() throws RemoteException {
+                if (!mScanner.isScanning()) {
+                    return;
+                }
 
-				if (! mScanner.isScanning()) {
-					return;
-				}
+                mLooper.mHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+                        alarm.cancel(mWakeIntent);
 
-				mLooper.mHandler.post(new Runnable() {
-					@Override
-					public void run() {
-						AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-						alarm.cancel(mWakeIntent);
+                        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+                        nm.cancel(NOTIFICATION_ID);
 
-						NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-						nm.cancel(NOTIFICATION_ID);
+                        mScanner.stopScanning();
+                    }
+                });
+            }
 
-						mScanner.stopScanning();
-					}
-				});
-			}
-
-			@Override
-			public void showNotification() throws RemoteException {
-				postNotification();
-			};
-		};
-	}
+            @Override
+            public void showNotification() throws RemoteException {
+                postNotification();
+            };
+        };
+    }
 }


### PR DESCRIPTION
This PR fixes #16.

If a user token (UUID) does not exist, a random one is generated. The `Prefs` class includes a `deleteToken()` method so we can add UI to allow users to delete their token to opt-out.

I moved the report's JSON encoding to the background thread to avoid StrictMode warnings because `getToken()` caused SharedPreferences file I/O on the main thread.
