### PR TITLE
Make service

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -25,12 +25,20 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="org.mozilla.mozstumbler.MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+	  		android:name=".ScannerService"
+	  		android:process=":.ScannerService" 
+	  		android:icon="@drawable/ic_launcher"
+	 		android:label="@string/service_name">
+	</service> 
+	
     </application>
 
 </manifest>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="mozilla_title">Mozilla</string>
     <string name="start_scanning">Start Scanning</string>
     <string name="stop_scanning">Stop Scanning</string>
-
+    <string name="service_name">Mozilla Stumbler</string>
+    <string name="service_scanning">Scanning for WiFi and Cellular networks</string>
+    
     
 </resources>

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -18,7 +18,7 @@ import android.widget.Button;
 
 public class MainActivity extends Activity {
 
-	private static final String LOGTAG = "MainActivity";
+	private static final String LOGTAG = MainActivity.class.getName();
 
 	private ScannerServiceInterface mConnectionRemote;
 	private ServiceConnection mConnection = new ServiceConnection() {

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Date;
 
 class Reporter {
-    private static final String LOGTAG = "Reporter";
+    private static final String LOGTAG = Reporter.class.getName();
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
 
     private final MessageDigest mSHA1;

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 import java.util.Collection;
 
 class Scanner implements LocationListener {
-    private static final String LOGTAG = "Scanner";
+    private static final String LOGTAG = Scanner.class.getName();
     private static final long MIN_UPDATE_TIME = 1000; // milliseconds
     private static final float MIN_UPDATE_DISTANCE = 10; // meters
 

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -32,19 +32,28 @@ class Scanner implements LocationListener {
     private PhoneStateListener mPhoneStateListener;
     private Reporter mReporter;
 
+    public boolean mIsScanning = false;
+    
     Scanner(Context context) {
         mContext = context;
         mReporter = new Reporter();
     }
 
     void startScanning() {
+    	if (mIsScanning) {
+          return;
+    	}
         Log.d(LOGTAG, "Scanning started...");
         deleteAidingData();
         LocationManager lm = getLocationManager();
         lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, MIN_UPDATE_TIME, MIN_UPDATE_DISTANCE, getLocationListener());
+        mIsScanning = true;
     }
 
     void stopScanning() {
+    	if (mIsScanning == false) {
+            return;
+      	}
         Log.d(LOGTAG, "Scanning stopped");
         LocationManager lm = getLocationManager();
         lm.removeUpdates(getLocationListener());
@@ -53,6 +62,11 @@ class Scanner implements LocationListener {
             tm.listen(mPhoneStateListener, PhoneStateListener.LISTEN_NONE);
             mPhoneStateListener = null;
         }
+        mIsScanning = false;
+    }
+    
+    boolean isScanning() {
+    	return mIsScanning;
     }
 
     private LocationListener getLocationListener() {

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -19,7 +19,7 @@ import android.util.Log;
 
 public class ScannerService extends Service {
 
-	private static final String LOGTAG = "BackgroundService";
+	private static final String LOGTAG = ScannerService.class.getName();
 	private static final int NOTIFICATION = 0;
 	private static final int WAKE_TIMEOUT = 5 * 1000;
 	private Scanner mScanner = null;

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -1,0 +1,174 @@
+package org.mozilla.mozstumbler;
+
+import java.util.Calendar;
+
+import android.app.AlarmManager;
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.os.Binder;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.RemoteException;
+import android.util.Log;
+
+public class ScannerService extends Service {
+
+	private static final String LOGTAG = "BackgroundService";
+	private static final int NOTIFICATION = 0;
+	private static final int WAKE_TIMEOUT = 5 * 1000;
+	private Scanner mScanner = null;
+	private LooperThread mLooper = null;
+	private PendingIntent mWakeIntent = null;
+
+	class LooperThread extends Thread {
+		public Handler mHandler;
+
+		public void run() {
+			Looper.prepare();
+			mHandler = new Handler();
+			Looper.loop();
+		}
+	}
+
+	public class ScannerServiceBinder extends Binder {
+		ScannerService getService() {
+			return ScannerService.this;
+		}
+	}
+
+	@Override
+	public void onCreate() {
+		super.onCreate();
+		Log.d(LOGTAG, "onCreate");
+
+		mScanner = new Scanner(this);
+		mLooper = new LooperThread();
+		mLooper.start();
+	}
+
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+		Log.d(LOGTAG, "onDestroy");
+
+		mLooper.interrupt();
+		mLooper = null;
+		mScanner = null;
+
+		NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+		nm.cancel(NOTIFICATION);
+
+		// TODO Toast.makeText(this, R.string.local_service_stopped,
+		// Toast.LENGTH_SHORT).show();
+	}
+
+	public void postNotification() {
+
+		if (mLooper.mHandler == null)
+			return;
+
+		mLooper.mHandler.post(new Runnable() {
+			@Override
+			public void run() {
+
+				NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+				Context ctx = getApplicationContext();
+				Intent notificationIntent = new Intent(ctx, MainActivity.class);
+				PendingIntent contentIntent = PendingIntent.getActivity(ctx,
+						NOTIFICATION, notificationIntent,
+						PendingIntent.FLAG_CANCEL_CURRENT);
+
+				Resources res = ctx.getResources();
+				Notification.Builder builder = new Notification.Builder(ctx);
+
+				builder.setContentIntent(contentIntent)
+						.setSmallIcon(R.drawable.ic_launcher)
+						.setOngoing(true)
+						.setAutoCancel(false)
+						.setContentTitle(res.getString(R.string.service_name))
+						.setContentText(
+								res.getString(R.string.service_scanning));
+				Notification n = builder.build();
+
+				nm.notify(NOTIFICATION, n);
+			}
+		});
+	}
+
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId) {
+		// keep running!
+		return Service.START_STICKY;
+	}
+
+	@Override
+	public IBinder onBind(Intent intent) {
+		Log.d(LOGTAG, "onBind");
+
+		return new ScannerServiceInterface.Stub() {
+
+			@Override
+			public boolean isScanning() throws RemoteException {
+				return mScanner.isScanning();
+			};
+
+			@Override
+			public void startScanning() throws RemoteException {
+				if (mScanner.isScanning() == true) {
+					return;
+				}
+
+				mLooper.mHandler.post(new Runnable() {
+					@Override
+					public void run() {
+						mScanner.startScanning();
+
+						// keep us awake.
+						Context cxt = getApplicationContext();
+						Calendar cal = Calendar.getInstance();
+						Intent intent = new Intent(cxt, ScannerService.class);
+						mWakeIntent = PendingIntent.getService(cxt, 0, intent,
+								0);
+						AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+						alarm.setRepeating(AlarmManager.RTC_WAKEUP,
+								cal.getTimeInMillis(), WAKE_TIMEOUT,
+								mWakeIntent);
+
+					}
+				});
+			};
+
+			@Override
+			public void stopScanning() throws RemoteException {
+
+				if (mScanner.isScanning() == false) {
+					return;
+				}
+
+				mLooper.mHandler.post(new Runnable() {
+					@Override
+					public void run() {
+						AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+						alarm.cancel(mWakeIntent);
+
+						NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+						nm.cancel(NOTIFICATION);
+
+						mScanner.stopScanning();
+					}
+				});
+			}
+
+			@Override
+			public void showNotification() throws RemoteException {
+				postNotification();
+			};
+		};
+	}
+}

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -1,0 +1,9 @@
+package org.mozilla.mozstumbler;
+
+interface ScannerServiceInterface {
+    boolean isScanning();
+    void startScanning();
+    void stopScanning();
+    
+    void showNotification();
+}


### PR DESCRIPTION
Chris, this is a pretty big change.  It attempts to do the following:

1) factors out stuff from the main activity into a new Service.
2) implements a basic notification item
2a) this seems to be required and what we're suppose to do if we have a background service running for any long period of time
3) creates a alarm that wakes us up if the service somehow dies (hard to test -- needs more testing)
4) creates a runnable looper thread in the service so that we can do things that normally require a looper (like geo/cell/wifi APIs.)
5) I've moved the service into it's own process.  So, I needed to add a bit of IPC via aidl.  (Totally amazing eclipse makes this.  Makes me want to cry when I think at mozilla/chrome style ipdl.)
