### PR TITLE
Add Gradle command-line build system and ProGuard optimizations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ jdk: oraclejdk7
 before_script:
     - sudo apt-get update -qq
     - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch; fi
+
+    # Install Gradle
+    - wget http://services.gradle.org/distributions/gradle-1.6-bin.zip
+    - unzip gradle-1.6-bin.zip
+    - export GRADLE_HOME=$PWD/gradle-1.6
+    - export PATH=$GRADLE_HOME/bin:$PATH
+
+    # Install Android SDK
     - wget http://dl.google.com/android/android-sdk_r21.0.1-linux.tgz
     - tar -xzf android-sdk_r21.0.1-linux.tgz
     - export ANDROID_HOME=$PWD/android-sdk-linux
@@ -12,5 +20,5 @@ before_script:
     - android update project --path . --name MozStumbler --target android-17
 
 script: 
-    - ant clean
-    - ant debug
+    - gradle clean
+    - gradle build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+MozStumbler
+
+```
+brew install gradle
+gradle build
+gradle installRelease
+```

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ android {
         }
 
         release {
+            runProguard true
+            proguardFile 'proguard.cfg'
             signingConfig signingConfigs.debug // FIXME: Use a real certificate
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,46 @@
+// http://tools.android.com/tech-docs/new-build-system/user-guide
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.4.2'
+    }
+}
+
+apply plugin: 'android'
+
+dependencies {
+    compile fileTree(dir: 'libs', include: '*.jar')
+}
+
+android {
+    compileSdkVersion 17
+    buildToolsVersion '17.0.0'
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        instrumentTest.setRoot('tests')
+    }
+
+    buildTypes {
+        debug {
+            jniDebugBuild true
+        }
+
+        release {
+            signingConfig signingConfigs.debug // FIXME: Use a real certificate
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.4.2'
+        classpath 'com.android.tools.build:gradle:0.5.4'
     }
 }
 

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -12,9 +12,10 @@
 
 # Add any project specific keep options here:
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-allowaccessmodification
+-optimizationpasses 99
+-optimizations !code/allocation/variable
+-verbose
+
+-dontobfuscate
+-dontwarn android.support.**

--- a/project.properties
+++ b/project.properties
@@ -6,9 +6,6 @@
 # To customize properties used by the Ant build system edit
 # "ant.properties", and override values to adapt the script to your
 # project structure.
-#
-# To enable ProGuard to shrink and obfuscate your code, uncomment this (available properties: sdk.dir, user.home):
-#proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
 target=android-17


### PR DESCRIPTION
I got fed up with Eclipse, so I investigate command-line build systems for Java and Android. Gradle is Android's new official build system. People can still use Eclipse if they like.

http://www.gradleware.com/resources/tech/android

http://tools.android.com/tech-docs/new-build-system/user-guide

I also enabled ProGuard optimizations for release builds. ProGuard shrinks our MozStumbler.apk from 258 KB to 70 KB. I didn't enable ProGuard obfuscation because we don't care about hiding our open source code and obfuscation makes exception stack traces more difficult to debug.
