### PR TITLE
Add X-Token and X-Nickname request headers

### DIFF
--- a/src/org/mozilla/mozstumbler/Prefs.java
+++ b/src/org/mozilla/mozstumbler/Prefs.java
@@ -2,6 +2,8 @@ package org.mozilla.mozstumbler;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Build.VERSION;
 import android.util.Log;
 
 import java.util.UUID;
@@ -9,6 +11,7 @@ import java.util.UUID;
 final class Prefs {
     private static final String     LOGTAG     = Prefs.class.getName();
     private static final String     PREFS_FILE = Prefs.class.getName();
+    private static final String     NICKNAME_PREF = "nickname";
     private static final String     TOKEN_PREF = "token";
 
     private final SharedPreferences mPrefs;
@@ -40,6 +43,30 @@ final class Prefs {
 
     void deleteToken() {
         deleteStringPref(TOKEN_PREF);
+    }
+
+    String getNickname() {
+        String nickname = getStringPref(NICKNAME_PREF);
+        if (nickname == null) {
+            // Generate a semi-anonymous nickname.
+            nickname = Build.MODEL + " (Android " + VERSION.RELEASE + ")";
+            setNickname(nickname);
+        }
+
+        Log.d(LOGTAG, "nickname: " + nickname);
+        return nickname;
+    }
+
+    void setNickname(String nickname) {
+        if (nickname != null) {
+            setStringPref(NICKNAME_PREF, nickname);
+        } else {
+            deleteNickname();
+        }
+    }
+
+    void deleteNickname() {
+        deleteStringPref(NICKNAME_PREF);
     }
 
     private String getStringPref(String key) {

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -25,6 +25,7 @@ import java.util.Date;
 class Reporter {
     private static final String LOGTAG       = Reporter.class.getName();
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
+    private static final String NICKNAME_HEADER = "X-Nickname";
     private static final String TOKEN_HEADER = "X-Token";
 
     private final Prefs         mPrefs;
@@ -87,11 +88,13 @@ class Reporter {
 
         new Thread(new Runnable() {
             public void run() {
+                String nickname = mPrefs.getNickname();
                 try {
                     URL url = new URL(LOCATION_URL);
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                     try {
                         urlConnection.setDoOutput(true);
+                        urlConnection.setRequestProperty(NICKNAME_HEADER, nickname);
                         urlConnection.setRequestProperty(TOKEN_HEADER, token);
 
                         JSONArray batch = new JSONArray();

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -25,6 +25,7 @@ import java.util.Date;
 class Reporter {
     private static final String LOGTAG       = Reporter.class.getName();
     private static final String LOCATION_URL = "https://location.services.mozilla.com/v1/submit";
+    private static final String TOKEN_HEADER = "X-Token";
 
     private final Prefs         mPrefs;
     private final MessageDigest mSHA1;
@@ -41,6 +42,7 @@ class Reporter {
 
     @SuppressLint("SimpleDateFormat")
     void reportLocation(Location location, Collection<ScanResult> scanResults, int radioType, JSONArray cellInfo) {
+        final String token = mPrefs.getToken().toString();
         final JSONObject locInfo = new JSONObject();
         try {
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
@@ -49,7 +51,7 @@ class Reporter {
             locInfo.put("lat", location.getLatitude());
             locInfo.put("accuracy", (int) location.getAccuracy());
             locInfo.put("altitude", (int) location.getAltitude());
-            locInfo.put("token", mPrefs.getToken());
+            locInfo.put("token", token); // FIXME: Remove "token" property after server support X-Token header (ichnaea issue #9).
 
             locInfo.put("cell", cellInfo);
             if (radioType == TelephonyManager.PHONE_TYPE_GSM)
@@ -90,6 +92,8 @@ class Reporter {
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                     try {
                         urlConnection.setDoOutput(true);
+                        urlConnection.setRequestProperty(TOKEN_HEADER, token);
+
                         JSONArray batch = new JSONArray();
                         batch.put(locInfo);
                         JSONObject wrapper = new JSONObject();
@@ -102,7 +106,6 @@ class Reporter {
                         out.flush();
 
                         Log.d(LOGTAG, "uploaded data: " + data + " to " + LOCATION_URL);
-
                     } catch (JSONException jsonex) {
                         Log.e(LOGTAG, "error wrapping data as a batch", jsonex);
                     } catch (Exception ex) {


### PR DESCRIPTION
@hannosch recommends (in mozilla/ichnaea#9) replacing our `token` JSON property with `X-Token` and `X-Nickname` request headers.
1. This PR adds an `X-Token` header without removing the `token` JSON property. We can remove the JSON property after the server understands `X-Token` headers. This should allow users to upgrade to new client versions without losing their token (and score). The server may want to continue looking for both to ensure for a short period to avoid losing tokens for laggards who have not upgraded their clients.
2. This PR adds an `X-Nickname` header but does not add any UI to read or write the nickname! That is issue #18. As a temporary hack, I generate a semi-unique but personally recognizable nickname by concatenating the user's device model and Android OS version. For example, my generated nickname is "Nexus 4 (Android 4.2.2)".
