### PR TITLE
Log reason LocationBlocklist rejected a location fix

### DIFF
--- a/src/org/mozilla/mozstumbler/DateTimeUtils.java
+++ b/src/org/mozilla/mozstumbler/DateTimeUtils.java
@@ -1,0 +1,29 @@
+package org.mozilla.mozstumbler;
+
+import android.annotation.SuppressLint;
+
+import java.util.Date;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+final class DateTimeUtils {
+    private static final DateFormat mISO8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+
+    static final long MILLISECONDS_PER_DAY = 86400000; // milliseconds/day
+
+    private DateTimeUtils() {
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    static String formatDate(Date date) {
+        return mISO8601Format.format(date);
+    }
+
+    static String formatTime(long time) {
+        return formatDate(new Date(time));
+    }
+
+    static String formatCurrentTime() {
+        return formatTime(System.currentTimeMillis());
+    }
+}

--- a/src/org/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/LocationBlockList.java
@@ -3,7 +3,7 @@ package org.mozilla.mozstumbler;
 import android.location.Location;
 
 final class LocationBlockList {
-    private static final long   MILLISECONDS_PER_DAY = 86400000; // milliseconds/day
+    private static final String LOGTAG = LocationBlockList.class.getName();
     private static final double MAX_ALTITUDE         = 8848;     // Mount Everest's altitude in meters
     private static final double MIN_ALTITUDE         = -418;     // Dead Sea's altitude in meters
     private static final float  MAX_SPEED            = 340.29f;  // Mach 1 in meters/second
@@ -21,7 +21,7 @@ final class LocationBlockList {
         final double longitude = location.getLongitude();
         final float speed = location.getSpeed();
         final long timestamp = location.getTime();
-        final long tomorrow = System.currentTimeMillis() + MILLISECONDS_PER_DAY;
+        final long tomorrow = System.currentTimeMillis() + DateTimeUtils.MILLISECONDS_PER_DAY;
 
         return inaccuracy < 0 || inaccuracy > MAX_INACCURACY || altitude < MIN_ALTITUDE || altitude > MAX_ALTITUDE
                 || bearing < 0 || bearing > 360 || latitude < -180 || latitude > 180 || longitude < -180

--- a/src/org/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/LocationBlockList.java
@@ -1,6 +1,7 @@
 package org.mozilla.mozstumbler;
 
 import android.location.Location;
+import android.util.Log;
 
 final class LocationBlockList {
     private static final String LOGTAG = LocationBlockList.class.getName();
@@ -23,9 +24,45 @@ final class LocationBlockList {
         final long timestamp = location.getTime();
         final long tomorrow = System.currentTimeMillis() + DateTimeUtils.MILLISECONDS_PER_DAY;
 
-        return inaccuracy < 0 || inaccuracy > MAX_INACCURACY || altitude < MIN_ALTITUDE || altitude > MAX_ALTITUDE
-                || bearing < 0 || bearing > 360 || latitude < -180 || latitude > 180 || longitude < -180
-                || longitude > 180 || (latitude == 0 && longitude == 0) || speed < 0 || speed > MAX_SPEED
-                || timestamp < MIN_TIMESTAMP || timestamp > tomorrow;
+        boolean block = false;
+
+        if (latitude == 0 && longitude == 0) {
+           block = true;
+           Log.w(LOGTAG, "Bogus latitude,longitude: 0,0");
+        } else if (latitude < -180 || latitude > 180) {
+           block = true;
+           Log.w(LOGTAG, "Bogus latitude: " + latitude);
+        } else if (longitude < -180 || longitude > 180) {
+           block = true;
+           Log.w(LOGTAG, "Bogus longitude: " + longitude);
+        }
+
+        if (inaccuracy < 0 || inaccuracy > MAX_INACCURACY) {
+           block = true;
+           Log.w(LOGTAG, "Bogus inaccuracy: " + inaccuracy + " meters");
+        }
+
+        if (altitude < MIN_ALTITUDE || altitude > MAX_ALTITUDE) {
+           block = true;
+           Log.w(LOGTAG, "Bogus altitude: " + altitude + " meters");
+        }
+
+        if (bearing < 0 || bearing > 360) {
+           block = true;
+           Log.w(LOGTAG, "Bogus bearing: " + bearing + " degrees");
+        }
+
+        if (speed < 0 || speed > MAX_SPEED) {
+           block = true;
+           Log.w(LOGTAG, "Bogus speed: " + speed + " meters/second");
+        }
+
+        if (timestamp < MIN_TIMESTAMP || timestamp > tomorrow) {
+           block = true;
+           Log.w(LOGTAG, "Bogus timestamp: " + timestamp
+                         + " (" + DateTimeUtils.formatTime(timestamp) + ")");
+        }
+
+        return block;
     }
 }

--- a/src/org/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/LocationBlockList.java
@@ -5,11 +5,11 @@ import android.util.Log;
 
 final class LocationBlockList {
     private static final String LOGTAG = LocationBlockList.class.getName();
-    private static final double MAX_ALTITUDE         = 8848;     // Mount Everest's altitude in meters
-    private static final double MIN_ALTITUDE         = -418;     // Dead Sea's altitude in meters
-    private static final float  MAX_SPEED            = 340.29f;  // Mach 1 in meters/second
-    private static final float  MAX_INACCURACY       = 500;      // meter radius
-    private static final long   MIN_TIMESTAMP        = 946684801; // 2000-01-01 00:00:01
+    private static final double MAX_ALTITUDE    = 8848;     // Mount Everest's altitude in meters
+    private static final double MIN_ALTITUDE    = -418;     // Dead Sea's altitude in meters
+    private static final float  MAX_SPEED       = 340.29f;  // Mach 1 in meters/second
+    private static final float  MAX_INACCURACY  = 500;      // meter radius
+    private static final long   MIN_TIMESTAMP   = 946684801; // 2000-01-01 00:00:01
 
     private LocationBlockList() {
     }

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -19,8 +19,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 
@@ -47,13 +45,11 @@ class Reporter {
         }
     }
 
-    @SuppressLint("SimpleDateFormat")
     void reportLocation(Location location, Collection<ScanResult> scanResults, int radioType, JSONArray cellInfo) {
         final String token = mPrefs.getToken().toString();
         final JSONObject locInfo = new JSONObject();
         try {
-            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
-            locInfo.put("time", df.format(new Date(location.getTime())));
+            locInfo.put("time", DateTimeUtils.formatTime(location.getTime()));
             locInfo.put("lon", location.getLongitude());
             locInfo.put("lat", location.getLatitude());
             locInfo.put("accuracy", (int) location.getAccuracy());

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -185,10 +185,10 @@ class Scanner implements LocationListener {
         WifiManager wm = getWifiManager();
         try {
             wm.setWifiEnabled(true);
-          }
-          catch (SecurityException ex) {
-              Log.e(LOGTAG, "Could not get permission for enabling wifi!");
-          }
+        }
+        catch (SecurityException ex) {
+            Log.e(LOGTAG, "Could not get permission for enabling wifi!");
+        }
         
         wm.startScan();
         Collection<ScanResult> scanResults = wm.getScanResults();

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -178,7 +178,6 @@ class Scanner implements LocationListener {
         return tm.getPhoneType();
     }
 
-    @SuppressLint("SimpleDateFormat")
     private void collectAndReportLocInfo(Location location) {
         JSONArray cellInfo = new JSONArray();
         int radioType = getCellInfo(cellInfo);


### PR DESCRIPTION
We currently reject location fix's with an [in]accuracy greater than 500 meter radius, i.e. we can't place with user within a 1 km area. I was getting some ~700 meter fixes and I didn't know why they were being rejected, so I added these log messages.
