### PR TITLE
Gradle, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,29 @@
 language: java
 jdk: oraclejdk7
 
-before_script:
+before_install:
+    # Install Android SDK
     - sudo apt-get update -qq
-    - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch; fi
-    - wget http://dl.google.com/android/android-sdk_r21.0.1-linux.tgz
-    - tar -xzf android-sdk_r21.0.1-linux.tgz
+    - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+    - wget https://dl.google.com/android/android-sdk_r22.0.4-linux.tgz
+    - tar xzf android-sdk_r22.0.4-linux.tgz
     - export ANDROID_HOME=$PWD/android-sdk-linux
-    - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/build-tools
-    - android update sdk --no-ui --force --filter platform-tools,extra-android-support,android-17,sysimg-17,extra-google-google_play_services
-    - android update project --path . --name MozStumbler --target android-17
+    - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
 
-script: 
-    - ant clean
-    - ant debug
+    # Install Android SDK components
+    - echo yes | android update sdk --filter platform-tools,android-18,extra-android-support --no-ui --force > /dev/null
+
+    # Install Android build tools
+    - wget https://dl-ssl.google.com/android/repository/build-tools_r18-linux.zip
+    - unzip build-tools_r18-linux.zip -d $ANDROID_HOME
+    - mkdir -p $ANDROID_HOME/build-tools/
+    - mv $ANDROID_HOME/android-4.3 $ANDROID_HOME/build-tools/18.0.0
+
+    # Install Gradle
+    - wget http://services.gradle.org/distributions/gradle-1.6-bin.zip
+    - unzip gradle-1.6-bin.zip
+    - export GRADLE_HOME=$PWD/gradle-1.6
+    - export PATH=$GRADLE_HOME/bin:$PATH
+
+script:
+    - gradle build -q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+MozStumbler
+
+```
+brew install gradle
+gradle build
+gradle installRelease
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,32 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.5.4'
+    }
+}
+
+apply plugin: 'android'
+
+android {
+    compileSdkVersion 18
+    buildToolsVersion '18.0.0'
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+    }
+}
+
+dependencies {
+    compile fileTree(dir: 'libs', include: '*.jar')
+}

--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
 }
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs = ['-Xlint:all,-deprecation', '-Werror']
+}

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,18 @@ android {
             assets.srcDirs = ['assets']
         }
     }
+
+    buildTypes {
+        debug {
+            jniDebugBuild true
+        }
+
+        release {
+            runProguard true
+            proguardFile 'proguard.cfg'
+            signingConfig signingConfigs.debug // FIXME: Use a real certificate
+        }
+    }
 }
 
 dependencies {

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -12,9 +12,9 @@
 
 # Add any project specific keep options here:
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-allowaccessmodification
+-optimizationpasses 99
+-optimizations !code/allocation/variable
+
+-dontobfuscate
+-dontwarn android.support.**

--- a/project.properties
+++ b/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-18

--- a/project.properties
+++ b/project.properties
@@ -6,9 +6,6 @@
 # To customize properties used by the Ant build system edit
 # "ant.properties", and override values to adapt the script to your
 # project structure.
-#
-# To enable ProGuard to shrink and obfuscate your code, uncomment this (available properties: sdk.dir, user.home):
-#proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
 target=android-18


### PR DESCRIPTION
My build.gradle and .travis.yml are shorter than yours, but still pass. I didn't need to set sdk.dir in local.properties and I don't download the large sysimg-18 emulator images.

https://travis-ci.org/cpeterso/MozStumbler/builds/9570305

If we don't care about supporting Eclipse users, we can probably delete `bin/.gitignore`. We might be able to delete `libs/android-support-v4.jar` now because people can/should install it with the Android SDK updater.
