### PR TITLE
Remove stuff

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -34,5 +34,5 @@
            android:layout_toLeftOf="@+id/toggle_scanning"
            android:text="@string/gps_fixes"
            android:textAppearance="?android:attr/textAppearanceSmall" />
-       
+
 </RelativeLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,5 +11,5 @@
     <string name="none_reported">Nothing reported.</string>
     <string name="reported_sofar">%1$d locations reported.</string>
     <string name="gps_fixes">gps fixes: %1$d</string>
-    
+
 </resources>

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -174,7 +174,7 @@ public class MainActivity extends Activity {
 
         String fixesString = getResources().getString(R.string.gps_fixes);
         fixesString = String.format(fixesString, mGpsFixes);
-  
+
         TextView fixesTextView = (TextView) findViewById(R.id.gps_fixes);
         fixesTextView.setText(fixesString);
     }

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -54,9 +54,6 @@ class Reporter {
             locInfo.put("lat", location.getLatitude());
             locInfo.put("accuracy", (int) location.getAccuracy());
             locInfo.put("altitude", (int) location.getAltitude());
-            locInfo.put("token", token); // TODO: Remove "token" property after server support X-Token header (ichnaea
-                                         // issue #9).
-
             locInfo.put("cell", cellInfo);
             if (radioType == TelephonyManager.PHONE_TYPE_GSM)
                 locInfo.put("radio", "gsm");

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -62,11 +62,6 @@ class Scanner implements LocationListener {
         mWifiScanResults = getWifiManager().getScanResults();
         mWifiScanResultsTime = System.currentTimeMillis();
 
-        if (mWifiScanResults == null) {
-          Log.d(LOGTAG, "WifiReceiver found null data");
-          return;
-        }
-
         Log.d(LOGTAG, "WifiReceiver new data at " + mWifiScanResultsTime);
 
         // TODO does this even work?  Aren't we just setting

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -97,7 +97,7 @@ class Scanner implements LocationListener {
                                   GEO_MIN_UPDATE_TIME,
                                   GEO_MIN_UPDATE_DISTANCE,
                                   getLocationListener());
-  
+
         mGPSListener = new GpsStatus.Listener() {
             public void onGpsStatusChanged(int event) {
               if (event == GpsStatus.GPS_EVENT_SATELLITE_STATUS) {
@@ -129,13 +129,13 @@ class Scanner implements LocationListener {
 
         WifiManager wm = getWifiManager();
         mWifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_SCAN_ONLY,
-                                      "MozStumbler");      
+                                      "MozStumbler");
         mWifiLock.acquire();
-        
+
         if (!wm.isWifiEnabled()) {
             wm.setWifiEnabled(true);
-        } 
-        
+        }
+
         mWifiReceiver = new WifiReceiver();
         IntentFilter i = new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
         mContext.registerReceiver(mWifiReceiver, i);
@@ -171,7 +171,7 @@ class Scanner implements LocationListener {
             tm.listen(mPhoneStateListener, PhoneStateListener.LISTEN_NONE);
             mPhoneStateListener = null;
         }
-        
+
         mWifiLock.release();
         mWifiLock = null;
 


### PR DESCRIPTION
We don't actually need to null check `getScanResults()`'s return value. I confirmed that it never returns null and it returns a new copy we can freely modify. `getScanResults()` returns a zero-length `ArrayList` when there are no scan results.

https://github.com/android/platform_frameworks_base/blob/6f2b31fcf57e4e7f5cd8af9b66619c8f5825a850/wifi/java/android/net/wifi/WifiStateMachine.java#L887

This PR also removes the "token" JSON property to fix #48.
