### PR TITLE
Display Froyo-compatible notification when scanning starts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,5 +44,5 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs = ['-Xlint:all,-deprecation', '-Werror']
+    options.compilerArgs = ['-Xlint:all', '-Werror']
 }

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -140,15 +140,6 @@ public final class MainActivity extends Activity {
     @Override
     protected void onStop() {
         super.onStop();
-        try {
-            if (mConnectionRemote.isScanning()) {
-                mConnectionRemote.showNotification();
-            }
-        } catch (RemoteException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-
         unbindService(mConnection);
         mConnection = null;
         mConnectionRemote = null;
@@ -228,9 +219,7 @@ public final class MainActivity extends Activity {
         if (Build.VERSION.SDK_INT < 9) {
             return;
         }
-
         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().build());
-
         StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build());
     }
 }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -23,6 +23,7 @@ public final class ScannerService extends Service {
     private static final String LOGTAG          = ScannerService.class.getName();
     private static final int    NOTIFICATION_ID = 0;
     private static final int    WAKE_TIMEOUT    = 5 * 1000;
+
     private Scanner             mScanner;
     private Reporter            mReporter;
     private LooperThread        mLooper;
@@ -128,10 +129,6 @@ public final class ScannerService extends Service {
                         mWakeIntent = PendingIntent.getService(cxt, 0, intent, 0);
                         AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
                         alarm.setRepeating(AlarmManager.RTC_WAKEUP, cal.getTimeInMillis(), WAKE_TIMEOUT, mWakeIntent);
-                        Intent i = new Intent(MESSAGE_TOPIC);
-                        i.putExtra(Intent.EXTRA_SUBJECT, "Notification");
-                        i.putExtra(Intent.EXTRA_TEXT, getString(R.string.start_scanning));
-                        sendBroadcast(i);
                     }
                 });
             };
@@ -152,11 +149,6 @@ public final class ScannerService extends Service {
                         nm.cancel(NOTIFICATION_ID);
 
                         mScanner.stopScanning();
-
-                        Intent i = new Intent(MESSAGE_TOPIC);
-                        i.putExtra(Intent.EXTRA_SUBJECT, "Notification");
-                        i.putExtra(Intent.EXTRA_TEXT, getString(R.string.stop_scanning));
-                        sendBroadcast(i);
                     }
                 });
             }
@@ -177,5 +169,12 @@ public final class ScannerService extends Service {
         n.setLatestEventInfo(context, contentTitle, contentText, contentIntent);
         n.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
         return n;
+    }
+
+    private void sendToast(String message) {
+        Intent i = new Intent(MESSAGE_TOPIC);
+        i.putExtra(Intent.EXTRA_SUBJECT, "Notification");
+        i.putExtra(Intent.EXTRA_TEXT, message);
+        sendBroadcast(i);
     }
 }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -168,6 +168,7 @@ public final class ScannerService extends Service {
         };
     }
 
+    @SuppressWarnings("deprecation")
     private static Notification buildNotification(Context context, int icon,
                                                   String contentTitle,
                                                   String contentText,

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -4,8 +4,5 @@ interface ScannerServiceInterface {
     boolean isScanning();
     void startScanning();
     void stopScanning();
-    
-    void showNotification();
-    
     int numberOfReportedLocations();
 }


### PR DESCRIPTION
This PR fixes #27.
1. The `Notification.Builder` code is only supported in API Level 11+. This PR creates the notification using a (deprecated) `Notification` constructor instead of `Notification.Builder`.
2. This PR also displays the notification icon when scanning starts, not when `MainActivity.onStop()` is called. Displaying the notification immediately visually ties the notification's lifetime with the scanning period.
3. The new notification makes the toasts redundant, so I removed the calls (but left the toast code so we can use it for other service alerts).
