### PR TITLE
Upgrade to gradle 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
     - ANDROID_SDK_VERSION=22.0.5
     - ANDROID_BUILD_TOOLS_VERSION=18.0.1
     - ANDROID_OS_VERSION=4.3
-    - GRADLE_VERSION=1.6
+    - GRADLE_VERSION=1.7
 
     # Install Android SDK
     - sudo apt-get update -qq

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.4'
+        classpath 'com.android.tools.build:gradle:0.5.6'
     }
 }
 


### PR DESCRIPTION
Homebrew just upgrade gradle 1.6 to 1.7, so I had to update our version requirements to build successfully.
