### PR TITLE
Stop scanning when we're on low battery.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,5 +12,6 @@
     <string name="locations_reported">Locations reported: %1$d</string>
     <string name="gps_fixes">GPS fixes: %1$d</string>
     <string name="enter_nickname">Enter Nickname</string>
+    <string name="battery_low_warning">Battery low, MozStumbler will stop scanning</string>
 
 </resources>

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -147,6 +147,12 @@ class Scanner implements LocationListener {
 
         // start some kind of timer repeating..
         mIsScanning = true;
+
+        // FIXME convey "start" event here?
+        // for now all we want is to update the UI anyway
+        Intent startIntent = new Intent(ScannerService.MESSAGE_TOPIC);
+        startIntent.putExtra(Intent.EXTRA_SUBJECT, "Scanner");
+        mContext.sendBroadcast(startIntent);
     }
 
     void stopScanning() {
@@ -177,6 +183,12 @@ class Scanner implements LocationListener {
         mWifiReceiver = null;
 
         mIsScanning = false;
+
+        // FIXME convey "stop" event here?
+        // for now all we want is to update the UI anyway
+        Intent stopIntent = new Intent(ScannerService.MESSAGE_TOPIC);
+        stopIntent.putExtra(Intent.EXTRA_SUBJECT, "Scanner");
+        mContext.sendBroadcast(stopIntent);
     }
 
     boolean isScanning() {

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -194,6 +194,10 @@ public final class ScannerService extends Service {
                 try {
                     if (mBinder.isScanning()) {
                         mBinder.stopScanning();
+
+                        String title = getResources().getString(R.string.service_name);
+                        String batteryLowWarning = getResources().getString(R.string.battery_low_warning);
+                        postNotification(title, batteryLowWarning, Notification.FLAG_AUTO_CANCEL);
                     }
                 } catch (RemoteException e) {
                     // TODO Copy-pasted catch block
@@ -230,7 +234,7 @@ public final class ScannerService extends Service {
         nm.cancel(NOTIFICATION_ID);
     }
 
-    private void postNotification() {
+    private void postNotification(final String title, final String text, final int flags) {
         mLooper.post(new Runnable() {
             @Override
             public void run() {
@@ -242,12 +246,8 @@ public final class ScannerService extends Service {
                 PendingIntent contentIntent = PendingIntent.getActivity(ctx, NOTIFICATION_ID, notificationIntent,
                         PendingIntent.FLAG_CANCEL_CURRENT);
 
-                Resources res = ctx.getResources();
-                String title = res.getString(R.string.service_name);
-                String text = res.getString(R.string.service_scanning);
-
                 int icon = R.drawable.ic_status_scanning;
-                Notification n = buildNotification(ctx, icon, title, text, contentIntent);
+                Notification n = buildNotification(ctx, icon, title, text, contentIntent, flags);
                 nm.notify(NOTIFICATION_ID, n);
             }
         });
@@ -269,10 +269,11 @@ public final class ScannerService extends Service {
     private static Notification buildNotification(Context context, int icon,
                                                   String contentTitle,
                                                   String contentText,
-                                                  PendingIntent contentIntent) {
+                                                  PendingIntent contentIntent,
+                                                  int flags) {
         Notification n = new Notification(icon, contentTitle, 0);
         n.setLatestEventInfo(context, contentTitle, contentText, contentIntent);
-        n.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
+        n.flags |= flags;
         return n;
     }
 }


### PR DESCRIPTION
This addresses issue #41.

This leaves some room for refactoring: we no longer have the main activity as a the service's sole controller that asks it to start and stop; we now also have the service stopping itself sometimes and we need that information to flow back to the UI. My solution here was straightforward (issue a "Scanner" intent to force an UI update), but we might want to re-think the information flow between the main activity and the server in the future.
