### PR TITLE
Don't send the user token header if the user has not set a nickname

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -101,7 +101,10 @@ public final class MainActivity extends Activity {
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     String newNickname = v.getText().toString().trim();
-                    mPrefs.setNickname(newNickname);
+                    String placeholderText = getResources().getString(R.string.enter_nickname);
+                    if (!newNickname.equals(placeholderText)) {
+                        mPrefs.setNickname(newNickname);
+                    }
                 }
                 return false;
             }

--- a/src/org/mozilla/mozstumbler/Prefs.java
+++ b/src/org/mozilla/mozstumbler/Prefs.java
@@ -45,11 +45,19 @@ final class Prefs {
     }
 
     String getNickname() {
-        return getStringPref(NICKNAME_PREF);
+        String nickname = getStringPref(NICKNAME_PREF);
+
+        // Remove old empty nickname prefs.
+        if (nickname != null && nickname.length() == 0) {
+            deleteNickname();
+            nickname = null;
+        }
+
+        return nickname;
     }
 
     void setNickname(String nickname) {
-        if (nickname != null) {
+        if (nickname != null && nickname.length() > 0) {
             setStringPref(NICKNAME_PREF, nickname);
         } else {
             deleteNickname();
@@ -67,7 +75,7 @@ final class Prefs {
     String getReports() {
       return getStringPref(REPORTS_PREF);
     }
- 
+
     private String getStringPref(String key) {
         return mPrefs.getString(key, null);
     }

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -84,13 +84,12 @@ class Reporter {
                     URL url = new URL(LOCATION_URL);
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                     try {
-                        String token = mPrefs.getToken().toString();
-
                         urlConnection.setDoOutput(true);
-                        urlConnection.setRequestProperty(TOKEN_HEADER, token);
 
                         String nickname = mPrefs.getNickname();
                         if (nickname != null) {
+                            String token = mPrefs.getToken().toString();
+                            urlConnection.setRequestProperty(TOKEN_HEADER, token);
                             urlConnection.setRequestProperty(NICKNAME_HEADER, nickname);
                         }
 


### PR DESCRIPTION
The server already ignores the user token header if the HTTP request does not include a nickname header.
