### PR TITLE
Prune SSID blocklist

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -13,7 +13,6 @@ final class SSIDBlockList {
         "Clear Spot",
         "ClearSPOT",
         "ClearSpot",
-        "Ericsson",
         "Galaxy Note",
         "Galaxy S",
         "Galaxy Tab",
@@ -23,6 +22,8 @@ final class SSIDBlockList {
         "Laptop",
         "MIFI",
         "MiFi",
+        "MOBILE",
+        "Mobile",
         "PhoneAP",
         "SAMSUNG",
         "SCH-I",
@@ -30,8 +31,7 @@ final class SSIDBlockList {
         "Samsung",
         "Sprint",
         "Verizon",
-        "VirginMobile MiFi2200",
-        "WaveLAN Network",
+        "VirginMobile",
         "barnacle", // Android Barnacle Wifi Tether
         "docomo",
         "hellomoto",
@@ -42,6 +42,7 @@ final class SSIDBlockList {
         "ipad",
         "laptop",
         "mifi",
+        "mobile",
         "myLGNet",
         "myTouch 4G Hotspot",
         "samsung",
@@ -49,43 +50,34 @@ final class SSIDBlockList {
         "webOS Network",
 
         // Transportation Wi-Fi
+        "AIRBUS FREE WIFI",
+        "AmtrakConnect",
         "GBUS",
         "GBusWifi",
         "SF Shuttle Wireless",
         "SST-PR-1", // Sears Home Service van hotspot?!
         "Shuttle",
         "Trimble ",
-        "VTA Free Wi-Fi", // VTA light rail
+        "VTA Free Wi-Fi",
         "ac_transit_wifi_bus",
         "airbusA380",
         "amtrak_",
         "shuttle",
-
-        // "Viral" SSIDs that infect some Windows laptops
-        "Adhoc",
-        "Free Internet Access",
-        "Free Internet!",
-        "Jet Blue hot spot",
-        "US Airways Free WiFi",
-        "adhoc",
-        "hpsetup",
-        "tsunami",
     };
 
     private static final String[] SUFFIX_LIST = {
         // Mobile devices
         " ASUS",
         "-ASUS",
+        "_ASUS",
         "Laptop",
+        "MIFI",
         "MacBook",
         "MacBook Pro",
-        "MIFI",
         "MiFi",
         "Mifi",
         "MyWi",
         "Tether",
-        "_ASUS",
-
         "iPad",
         "iPhone",
         "ipad",

--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -4,34 +4,100 @@ import android.net.wifi.ScanResult;
 
 final class SSIDBlockList {
     private static final String[] PREFIX_LIST = {
-            // Mobile devices
-            "ASUS", "AndroidAP", "AndroidTether", "CLEAR Spot", "CLEARSpot", "Clear Spot", "ClearSPOT", "ClearSpot",
-            "Ericsson", "Galaxy Note", "Galaxy S", "Galaxy Tab", "HTC ", "HelloMoto", "LG VS910 4G", "Laptop", "MIFI",
-            "MiFi", "PhoneAP", "SAMSUNG", "SCH-I", "SPRINT", "Samsung", "Sprint", "Verizon",
-            "VirginMobile MiFi2200",
-            "WaveLAN Network",
-            "barnacle",                 // Android Barnacle Wifi Tether
-            "docomo", "hellomoto", "iDockUSA", "iHub_", "iPad", "iPhone", "ipad", "laptop", "mifi", "myLGNet",
-            "myTouch 4G Hotspot", "samsung", "sprint", "webOS Network",
+        // Mobile devices
+        "ASUS",
+        "AndroidAP",
+        "AndroidTether",
+        "CLEAR Spot",
+        "CLEARSpot",
+        "Clear Spot",
+        "ClearSPOT",
+        "ClearSpot",
+        "Ericsson",
+        "Galaxy Note",
+        "Galaxy S",
+        "Galaxy Tab",
+        "HTC ",
+        "HelloMoto",
+        "LG VS910 4G",
+        "Laptop",
+        "MIFI",
+        "MiFi",
+        "PhoneAP",
+        "SAMSUNG",
+        "SCH-I",
+        "SPRINT",
+        "Samsung",
+        "Sprint",
+        "Verizon",
+        "VirginMobile MiFi2200",
+        "WaveLAN Network",
+        "barnacle", // Android Barnacle Wifi Tether
+        "docomo",
+        "hellomoto",
+        "iDockUSA",
+        "iHub_",
+        "iPad",
+        "iPhone",
+        "ipad",
+        "laptop",
+        "mifi",
+        "myLGNet",
+        "myTouch 4G Hotspot",
+        "samsung",
+        "sprint",
+        "webOS Network",
 
-            // Transportation Wi-Fi
-            "GBUS", "GBusWifi", "SF Shuttle Wireless",
-            "SST-PR-1",                 // Sears Home Service van hotspot?!
-            "Shuttle", "Trimble ",
-            "VTA Free Wi-Fi",           // VTA light rail
-            "ac_transit_wifi_bus", "airbusA380", "amtrak_", "shuttle",
+        // Transportation Wi-Fi
+        "GBUS",
+        "GBusWifi",
+        "SF Shuttle Wireless",
+        "SST-PR-1", // Sears Home Service van hotspot?!
+        "Shuttle",
+        "Trimble ",
+        "VTA Free Wi-Fi", // VTA light rail
+        "ac_transit_wifi_bus",
+        "airbusA380",
+        "amtrak_",
+        "shuttle",
 
-            // "Viral" SSIDs that infect some Windows laptops
-            "Adhoc", "Free Internet Access", "Free Internet!", "Jet Blue hot spot", "US Airways Free WiFi", "adhoc",
-            "hpsetup", "tsunami",            };
+        // "Viral" SSIDs that infect some Windows laptops
+        "Adhoc",
+        "Free Internet Access",
+        "Free Internet!",
+        "Jet Blue hot spot",
+        "US Airways Free WiFi",
+        "adhoc",
+        "hpsetup",
+        "tsunami",
+    };
 
     private static final String[] SUFFIX_LIST = {
-            // Mobile devices
-            " ASUS", "-ASUS", "Laptop", "MacBook", "MacBook Pro", "MIFI", "MiFi", "Mifi", "MyWi", "Tether", "_ASUS",
-            "iPad", "iPhone", "ipad", "iphone", "laptop", "macbook", "mifi", "tether",
+        // Mobile devices
+        " ASUS",
+        "-ASUS",
+        "Laptop",
+        "MacBook",
+        "MacBook Pro",
+        "MIFI",
+        "MiFi",
+        "Mifi",
+        "MyWi",
+        "Tether",
+        "_ASUS",
 
-            // Google's SSID opt-out
-            "_nomap",                        };
+        "iPad",
+        "iPhone",
+        "ipad",
+        "iphone",
+        "laptop",
+        "macbook",
+        "mifi",
+        "tether",
+
+        // Google's SSID opt-out
+        "_nomap",
+    };
 
     private SSIDBlockList() {
     }


### PR DESCRIPTION
Remove some SSIDs for networks that should already be detected by our ad hoc BSSID checks and add some more mobile prefixes I see in my stumbler logs.
