### PR TITLE
Remove user token

### DIFF
--- a/src/org/mozilla/mozstumbler/Prefs.java
+++ b/src/org/mozilla/mozstumbler/Prefs.java
@@ -14,7 +14,6 @@ final class Prefs {
     private static final String     LOGTAG        = Prefs.class.getName();
     private static final String     PREFS_FILE    = Prefs.class.getName();
     private static final String     NICKNAME_PREF = "nickname";
-    private static final String     TOKEN_PREF    = "token";
     private static final String     REPORTS_PREF  = "reports";
     private static final String     NOTICE_PREF   = "notice";
 
@@ -31,30 +30,6 @@ final class Prefs {
             mCurrentVersion = 0;
         }
         mContext = context;
-    }
-
-    UUID getToken() {
-        UUID token = null;
-
-        String pref = getStringPref(TOKEN_PREF);
-        if (pref != null) {
-            try {
-                token = UUID.fromString(pref);
-            } catch (IllegalArgumentException e) {
-                Log.e(LOGTAG, "bad token pref: " + pref, e);
-            }
-        }
-
-        if (token == null) {
-            token = UUID.randomUUID();
-            setStringPref(TOKEN_PREF, token.toString());
-        }
-
-        return token;
-    }
-
-    void deleteToken() {
-        deleteStringPref(TOKEN_PREF);
     }
 
     String getNickname() {

--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -32,7 +32,6 @@ class Reporter {
     private static final String LOGTAG          = Reporter.class.getName();
     private static final String LOCATION_URL    = "https://location.services.mozilla.com/v1/submit";
     private static final String NICKNAME_HEADER = "X-Nickname";
-    private static final String TOKEN_HEADER    = "X-Token";
     private static final String USER_AGENT_HEADER = "User-Agent";
     private static final int RECORD_BATCH_SIZE  = 100;
 
@@ -89,12 +88,10 @@ class Reporter {
         mReports = new JSONArray();
 
         String nickname = mPrefs.getNickname();
-        String token = mPrefs.getToken().toString();
-        spawnReporterThread(reports, nickname, token);
+        spawnReporterThread(reports, nickname);
     }
 
-    private static void spawnReporterThread(final JSONArray reports, final String nickname,
-                                            final String token) {
+    private static void spawnReporterThread(final JSONArray reports, final String nickname) {
         new Thread(new Runnable() {
             public void run() {
                 try {
@@ -107,7 +104,6 @@ class Reporter {
                         urlConnection.setRequestProperty(USER_AGENT_HEADER, MOZSTUMBLER_USER_AGENT_STRING);
 
                         if (nickname != null) {
-                            urlConnection.setRequestProperty(TOKEN_HEADER, token);
                             urlConnection.setRequestProperty(NICKNAME_HEADER, nickname);
                         }
 


### PR DESCRIPTION
The server and leaderboard no longer use clients' user tokens, so we can stop generating and sending them.
