### PR TITLE
Report BSSIDs, not SHA1(BSSID+SSID) hashes

### DIFF
--- a/src/org/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/BSSIDBlockList.java
@@ -10,14 +10,13 @@ final class BSSIDBlockList {
     private static final String  NULL_BSSID        = "000000000000";
     private static final String  WILDCARD_BSSID    = "ffffffffffff";
     private static final Pattern BSSID_PATTERN     = Pattern.compile("([0-9a-f]{12})");
-    private static final String  AD_HOC_HEX_VALUES = "26aeAE";
 
     private BSSIDBlockList() {
     }
 
     static boolean contains(ScanResult scanResult) {
         String BSSID = scanResult.BSSID;
-        return BSSID == null || isAdHocBSSID(BSSID) || !isCanonicalBSSID(BSSID) || NULL_BSSID.equals(BSSID)
+        return BSSID == null || !isCanonicalBSSID(BSSID) || NULL_BSSID.equals(BSSID)
                 || WILDCARD_BSSID.equals(BSSID);
     }
 
@@ -40,14 +39,5 @@ final class BSSIDBlockList {
 
     private static boolean isCanonicalBSSID(String BSSID) {
         return BSSID_PATTERN.matcher(BSSID).matches();
-    }
-
-    private static boolean isAdHocBSSID(String BSSID) {
-        // We filter out any ad-hoc devices. Ad-hoc devices are identified by
-        // having a 2,6,a or e in the second nybble.
-        // See http://en.wikipedia.org/wiki/MAC_address -- ad hoc networks
-        // have the last two bits of the second nybble set to 10.
-        char secondNybble = BSSID.charAt(1);
-        return AD_HOC_HEX_VALUES.indexOf(secondNybble) != -1;
     }
 }

--- a/src/org/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/BSSIDBlockList.java
@@ -7,9 +7,9 @@ import java.util.regex.Pattern;
 
 final class BSSIDBlockList {
 
-    private static final String  NULL_BSSID        = "00:00:00:00:00:00";
-    private static final String  WILDCARD_BSSID    = "ff:ff:ff:ff:ff:ff";
-    private static final Pattern BSSID_PATTERN     = Pattern.compile("([0-9a-f]{2}:){5}[0-9a-f]{2}");
+    private static final String  NULL_BSSID        = "000000000000";
+    private static final String  WILDCARD_BSSID    = "ffffffffffff";
+    private static final Pattern BSSID_PATTERN     = Pattern.compile("([0-9a-f]{12})");
     private static final String  AD_HOC_HEX_VALUES = "26aeAE";
 
     private BSSIDBlockList() {
@@ -22,13 +22,20 @@ final class BSSIDBlockList {
     }
 
     static String canonicalizeBSSID(String BSSID) {
-        if (BSSID == null || isCanonicalBSSID(BSSID)) {
+        if (BSSID == null) {
+            return "";
+        }
+
+        if (isCanonicalBSSID(BSSID)) {
             return BSSID;
         }
 
         // Some devices may return BSSIDs with '-' or '.' delimiters.
-        BSSID = BSSID.toLowerCase(Locale.US).replace('-', ':').replace('.', ':');
-        return isCanonicalBSSID(BSSID) ? BSSID : null;
+        BSSID = BSSID.toLowerCase(Locale.US).replace(":", "")
+                                            .replace("-", "")
+                                            .replace(".", "");
+
+        return isCanonicalBSSID(BSSID) ? BSSID : "";
     }
 
     private static boolean isCanonicalBSSID(String BSSID) {

--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -3,115 +3,11 @@ package org.mozilla.mozstumbler;
 import android.net.wifi.ScanResult;
 
 final class SSIDBlockList {
-    private static final String[] PREFIX_LIST = {
-        // Mobile devices
-        "ASUS",
-        "AndroidAP",
-        "AndroidTether",
-        "CLEAR Spot",
-        "CLEARSpot",
-        "Clear Spot",
-        "ClearSPOT",
-        "ClearSpot",
-        "Galaxy Note",
-        "Galaxy S",
-        "Galaxy Tab",
-        "HTC ",
-        "HelloMoto",
-        "LG VS910 4G",
-        "Laptop",
-        "MIFI",
-        "MiFi",
-        "MOBILE",
-        "Mobile",
-        "PhoneAP",
-        "SAMSUNG",
-        "SCH-I",
-        "SPRINT",
-        "Samsung",
-        "Sprint",
-        "Verizon",
-        "VirginMobile",
-        "barnacle", // Android Barnacle Wifi Tether
-        "docomo",
-        "hellomoto",
-        "iDockUSA",
-        "iHub_",
-        "iPad",
-        "iPhone",
-        "ipad",
-        "laptop",
-        "mifi",
-        "mobile",
-        "myLGNet",
-        "myTouch 4G Hotspot",
-        "samsung",
-        "sprint",
-        "webOS Network",
-
-        // Transportation Wi-Fi
-        "AIRBUS FREE WIFI",
-        "AmtrakConnect",
-        "GBUS",
-        "GBusWifi",
-        "SF Shuttle Wireless",
-        "SST-PR-1", // Sears Home Service van hotspot?!
-        "Shuttle",
-        "Trimble ",
-        "VTA Free Wi-Fi",
-        "ac_transit_wifi_bus",
-        "airbusA380",
-        "amtrak_",
-        "shuttle",
-    };
-
-    private static final String[] SUFFIX_LIST = {
-        // Mobile devices
-        " ASUS",
-        "-ASUS",
-        "_ASUS",
-        "Laptop",
-        "MIFI",
-        "MacBook",
-        "MacBook Pro",
-        "MiFi",
-        "Mifi",
-        "MyWi",
-        "Tether",
-        "iPad",
-        "iPhone",
-        "ipad",
-        "iphone",
-        "laptop",
-        "macbook",
-        "mifi",
-        "tether",
-
-        // Google's SSID opt-out
-        "_nomap",
-    };
-
     private SSIDBlockList() {
     }
 
     static boolean contains(ScanResult scanResult) {
         String SSID = scanResult.SSID;
-        if (SSID == null || SSID.length() == 0) {
-            return true; // blocked!
-        }
-
-        for (String prefix : PREFIX_LIST) {
-            if (SSID.startsWith(prefix)) {
-                return true; // blocked!
-            }
-        }
-
-        for (String suffix : SUFFIX_LIST) {
-            if (SSID.endsWith(suffix)) {
-                return true; // blocked!
-            }
-        }
-
-        return false; // OK
+        return SSID == null || "".equals(SSID) || SSID.endsWith("_nomap");
     }
 }

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -69,17 +69,9 @@ class Scanner implements LocationListener {
 
         Log.d(LOGTAG, "WifiReceiver new data at " + mWifiScanResultsTime);
 
-        // TODO does this even work?  Aren't we just setting
-        // a copy (scanResult) to store the correct BSSID?
-
         for (ScanResult scanResult : mWifiScanResults) {
-          Log.d(LOGTAG, "   scanResult = " + scanResult.BSSID);
-
-          String BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
-          if (BSSID == null) {
-            Log.e(LOGTAG, "", new IllegalArgumentException("Unexpected BSSID: " + scanResult.BSSID));
-          }
-          scanResult.BSSID = BSSID;
+          scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
+          Log.d(LOGTAG, "   scanResult.BSSID = \"" + scanResult.BSSID + "\"");
         }
       }
     }


### PR DESCRIPTION
Also, stop filtering ad-hoc BSSIDs and mobile device SSIDs.
