### PR TITLE
Consolidate NoticeDialog's negative and cancel code paths

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -88,12 +88,13 @@ public final class MainActivity extends Activity {
         setContentView(R.layout.activity_main);
 
         mPrefs = new Prefs(this);
-
-        new NoticeDialog(this, mPrefs).show();
+        if (!mPrefs.hasSeenNotice()) {
+            new NoticeDialog(this, mPrefs).show();
+        }
 
         EditText nicknameEditor = (EditText) findViewById(R.id.edit_nickname);
 
-        String nickname = mPrefs.getNickname(); // FIXME: StrictMode violation?
+        String nickname = mPrefs.getNickname();
         if (nickname != null) {
             nicknameEditor.setText(nickname);
         }

--- a/src/org/mozilla/mozstumbler/NoticeDialog.java
+++ b/src/org/mozilla/mozstumbler/NoticeDialog.java
@@ -16,9 +16,6 @@ public class NoticeDialog
     }
 
     public void show() {
-        if (mPrefs.getHasSeenNotice()) {
-            return;
-        }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity)
             .setTitle(mActivity.getString(R.string.app_name))

--- a/src/org/mozilla/mozstumbler/NoticeDialog.java
+++ b/src/org/mozilla/mozstumbler/NoticeDialog.java
@@ -5,8 +5,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 
-public class NoticeDialog
-{
+final class NoticeDialog {
     private Activity mActivity;
     private Prefs mPrefs;
 
@@ -16,6 +15,12 @@ public class NoticeDialog
     }
 
     public void show() {
+        final Dialog.OnCancelListener onCancel = new Dialog.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface di) {
+                mActivity.finish();
+            }
+        };
 
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity)
             .setTitle(mActivity.getString(R.string.app_name))
@@ -32,9 +37,10 @@ public class NoticeDialog
                                new Dialog.OnClickListener() {
                                  @Override
                                  public void onClick(DialogInterface di, int which) {
-                                     mActivity.finish();
+                                     onCancel.onCancel(di);
                                  }
-                             });
+                             })
+            .setOnCancelListener(onCancel);
         builder.create().show();
     }
 }

--- a/src/org/mozilla/mozstumbler/Prefs.java
+++ b/src/org/mozilla/mozstumbler/Prefs.java
@@ -64,7 +64,7 @@ final class Prefs {
         return getStringPref(REPORTS_PREF);
     }
 
-    boolean getHasSeenNotice() {
+    boolean hasSeenNotice() {
         int lastSeenVersion = getPrefs().getInt(NOTICE_PREF, 0);
         return lastSeenVersion == mCurrentVersion;
     }


### PR DESCRIPTION
If the user tapped the grayed-out app view behind the NoticeDialog, the dialog would be dismissed but neither the positive ("OK") or negative ("Cancel") button code paths would be called.

Also move the Prefs.hasSeenNotice() check outside of NoticeDialog to avoid unnecessary allocation of new NoticeDialog.
