### PR TITLE
Start scanning when we open the map view

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -227,9 +227,8 @@ public final class MainActivity extends Activity {
     public void onClick_ViewMap(View v) throws RemoteException {
         // We are starting Wi-Fi scanning because we want the the APs for our
         // geolocation request whose results we want to display on the map.
-        boolean scanning = mConnectionRemote.isScanning();
-        if (!scanning) {
-            mConnectionRemote.startWifiScanningOnly();
+        if (mConnectionRemote != null) {
+            mConnectionRemote.startScanning();
         }
 
         Log.d(LOGTAG, "onClick_ViewMap");


### PR DESCRIPTION
This is an expedient partial fix for issue #121. This PR will start all scanning (WiFi, cell, and GPS) and update the UI's "Start Scanning" to "Stop Scanning". This makes the UI clear that, when the user returns from the map view, that the scanning is running (and can be stopped by the "Stop Scanning" button).
