### PR TITLE
 Temporarily disable map button on Gingerbread 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="stop_scanning">Stop Scanning</string>
     <string name="stop_scanning_upload">Stop Scanning &amp; Upload</string>
     <string name="view_leaderboard">View Leaderboard</string>
-    <string name="view_map">Locate Me</string>
+    <string name="view_map">Test Mozilla Location Service</string>
     <string name="service_name">Mozilla Stumbler</string>
     <string name="wifi_access_points">Wi-Fi Access Points Scanned: %1$d</string>
     <string name="gps_satellites">GPS Satellites Visible: %1$d</string>

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -9,7 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.net.Uri;
-import android.os.Build;
+import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -124,6 +124,12 @@ public final class MainActivity extends Activity {
         }
 
         nicknameEditor.addTextChangedListener(new NicknameWatcher());
+
+        // Temporarily disable map button on Gingerbread and older Honeycomb devices.
+        if (VERSION.SDK_INT < 12) {
+            Button mapButton = (Button) findViewById(R.id.view_map);
+            mapButton.setEnabled(false);
+        }
 
         Log.d(LOGTAG, "onCreate");
     }
@@ -266,7 +272,7 @@ public final class MainActivity extends Activity {
 
     @TargetApi(9)
     private void enableStrictMode() {
-        if (Build.VERSION.SDK_INT < 9) {
+        if (VERSION.SDK_INT < 9) {
             return;
         }
 


### PR DESCRIPTION
Band-aid fix #144.

Also rename "Locate Me" map button to "Test Mozilla Location Service" because some IRC users were confused, thinking "Locate Me" was a self-test of the device's GPS using Google Maps, not Mozilla's Location Service API.
