### PR TITLE
Resurrect SSIDBlockList.java

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -3,11 +3,86 @@ package org.mozilla.mozstumbler;
 import android.net.wifi.ScanResult;
 
 final class SSIDBlockList {
+    private static final String[] PREFIX_LIST = {
+        // Mobile devices
+        "AndroidAP",
+        "AndroidHotspot",
+        "Android Hotspot",
+        "barnacle", // Android tether app
+        "Galaxy Note",
+        "Galaxy S",
+        "Galaxy Tab",
+        "HTC ",
+        "iPhone",
+        "LG-MS770",
+        "LG-MS870",
+        "LG VS910 4G",
+        "LG Vortex",
+        "MIFI",
+        "MiFi",
+        "myLGNet",
+        "myTouch 4G Hotspot",
+        "PhoneAP",
+        "SCH-I",
+        "Sprint MiFi",
+        "Verizon ",
+        "Verizon-",
+        "VirginMobile MiFi",
+
+        // Transportation Wi-Fi
+        "ac_transit_wifi_bus",
+        "AmtrakConnect",
+        "Amtrak_",
+        "amtrak_",
+        "GBUS",
+        "GBusWifi",
+        "SF Shuttle Wireless",
+        "ShuttleWiFi",
+        "SST-PR-1", // Sears Home Service van hotspot?!
+        "wifi_rail", // BART
+    };
+
+    private static final String[] SUFFIX_LIST = {
+        // Mobile devices
+        "iPhone",
+        "iphone",
+        "MIFI",
+        "MIFI",
+        "MiFi",
+        "Mifi",
+        "mifi",
+        "mi-fi",
+        "MyWi",
+        "Phone",
+        "Portable Hotspot",
+        "Tether",
+        "tether",
+
+        // Google's SSID opt-out
+        "_nomap",
+    };
+
     private SSIDBlockList() {
     }
 
     static boolean contains(ScanResult scanResult) {
         String SSID = scanResult.SSID;
-        return SSID == null || "".equals(SSID) || SSID.endsWith("_nomap");
+        if (SSID == null) {
+            return true; // no SSID?
+        }
+
+        for (String prefix : PREFIX_LIST) {
+            if (SSID.startsWith(prefix)) {
+                return true; // blocked!
+            }
+        }
+
+        for (String suffix : SUFFIX_LIST) {
+            if (SSID.endsWith(suffix)) {
+                return true; // blocked!
+            }
+        }
+
+        return false; // OK
     }
 }


### PR DESCRIPTION
Add some known mobile phones and transit SSIDs to the block list, but not tablets and laptops because many are stationary. For those that do move, the server-side detection of moving APs will isolate them.
