### PR TITLE
Update Android gradle plugin to 0.6.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.7'
+        classpath 'com.android.tools.build:gradle:0.6.+'
     }
 }
 


### PR DESCRIPTION
Android Studio 0.3.0 requires Android gradle plugin >= 0.6.0
