### PR TITLE
Custom tile server

### DIFF
--- a/AndroidManifest.xml.in
+++ b/AndroidManifest.xml.in
@@ -66,6 +66,10 @@
             android:value="MY_MAP_API_KEY"/>
 
         <meta-data
+            android:name="org.mozilla.mozstumbler.TILE_SERVER_URL"
+            android:value="TILE_SERVER_URL"/>
+
+        <meta-data
             android:name="org.mozilla.mozstumbler.API_KEY"
             android:value="MY_MOZILLA_API_KEY"/>
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,24 @@ StorePassword=<password>
 KeyAlias=<key alias>
 KeyPassword=<password>
 MozAPIKey=test
-MapAPIKey=<your MapBox API key>
+TileServerURL=<OSM Tile Server>
 ```
+For the OSM (Open Street Maps) Tile Server, you have several options:
 
-To obtain a MapBox API Key:
+* *[MapBox](https://www.mapbox.com/)* (easy, secure) is a hosted OSM solution, allowing users to easily create beautiful maps and featuring full SSL. To use MapBox:
 
-1. ?
+  1. Visit [mapbox.com](https://www.mapbox.com/) and sign up
+  2. From the [MapBox Dashboad](https://www.mapbox.com/dashboard/) click the big blue "New Project" button
+  3. Customize your map as you please. The only requirement is that you allow public API access. To do this click on the gear in the white box at the top, select the "Advanced" option at the bottom, and uncheck the "Hide project from public API" box. Be sure to hit the save button after doing this.
+  4. Obtain the API key for your map (visible from the dashboard under Projects and Data, or in the URL of the editor)
+  5. Set `TileServerURL` in the `gradle.propeties` file to `https://a.tiles.mapbox.com/v3/<API key>/`. Do not miss the tailing slash, it will break things if you do.i
+
+  *Note that, for historical reasons, you can simply specify the API key in the `gradle.properties` file and not the full URL, using the `MapAPIKey` key*
+
+* *Another hosted solution* (difficulty varies, as does security). There are many OSM tile servers available. [This is a nice list of some](http://switch2osm.org/providers/).
+
+* Run your own Tile Server (advanced, as secure as you want)
+  You can, of course, run your own tileserver. [Switch2OSM](http://switch2osm.org/serving-tiles/) has several excellent guides on the subject and is a good place to get started
 
 To generate a signing key, search the internet for details.  This command is probably what you want:
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,11 +69,14 @@ if (hasProperty('StoreFile')) {
 // Generate AndroidManifest.xml
 String mozillaAPIKey = hasProperty('MozAPIKey') ? MozAPIKey : "FAKE_MOZILLA_API_KEY";
 String mapAPIKey     = hasProperty('MapAPIKey') ? MapAPIKey : "FAKE_MAP_API_KEY";
+String tileServerURL = hasProperty('TileServerURL') ? TileServerURL : "http://tile.openstreetmap.org/";
 
 File manifest = file("./AndroidManifest.xml.in")
 String content = manifest.getText('UTF-8')
 content = content.replaceAll(/MY_MOZILLA_API_KEY/, mozillaAPIKey)
+
 content = content.replaceAll(/MY_MAP_API_KEY/, mapAPIKey)
+content = content.replaceAll(/MY_TILE_SERVER/, tileServerURL)
 
 manifest = file("./AndroidManifest.xml")
 manifest.write(content, 'UTF-8')

--- a/src/org/mozilla/mozstumbler/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/MapActivity.java
@@ -105,7 +105,8 @@ public final class MapActivity extends Activity {
                                                            null,
                                                            0, 21, 128,
                                                            ".png",
-                                                           getMapBoxURL(context));
+                                                           getMapURL(context));
+
 
         mMap = (MapView) this.findViewById(R.id.map);
 
@@ -131,13 +132,18 @@ public final class MapActivity extends Activity {
         Log.d(LOGTAG, "onCreate");
     }
 
-    private static String getMapBoxURL(Context context) {
-        String apiKey = PackageUtils.getMetaDataString(context, "org.mozilla.mozstumbler.MAP_API_KEY");
-        if (apiKey == null || "FAKE_MAP_API_KEY".equals(apiKey)) {
-            Log.e(LOGTAG, "", new IllegalArgumentException("Need to specify MapAPIKey property in gradle.properties to use MapBox tiles"));
-        }
+    private static String getMapURL(Context context) {
+        String tileServerURL = PackageUtils.getMetaDataString(context, "org.mozilla.mozstumbler.TILE_SERVER_URL");
 
-        return "https://a.tiles.mapbox.com/v3/" + apiKey + "/";
+        if (tileServerURL == null || tileServerURL.equals("http://tile.openstreetmap.org/")) {
+            String apiKey = PackageUtils.getMetaDataString(context, "org.mozilla.mozstumbler.MAP_API_KEY");
+            if (apiKey == null || "FAKE_MAP_API_KEY".equals(apiKey)) {
+                tileServerURL = "http://tile.openstreetmap.org/";
+            } else {
+                tileServerURL = "https://a.tiles.mapbox.com/v3/" + apiKey + "/";
+            }
+        }
+        return tileServerURL;
     }
 
     private class AccuracyCircleOverlay extends SafeDrawOverlay {
@@ -274,9 +280,9 @@ public final class MapActivity extends Activity {
             if (mStatus != null && "ok".equals(mStatus)) {
                 positionMapAt(mLat, mLon, mAccuracy);
             } else if (mStatus != null && "not_found".equals(mStatus)) {
-            	Toast.makeText(getApplicationContext(),
-            		getResources().getString(R.string.location_not_found),
-            		Toast.LENGTH_LONG).show();
+                    Toast.makeText(getApplicationContext(),
+                            getResources().getString(R.string.location_not_found),
+                            Toast.LENGTH_LONG).show();
             } else {
                 Log.e(LOGTAG, "", new IllegalStateException("mStatus=" + mStatus));
             }


### PR DESCRIPTION
The current version uses OSM, but is locked to MapBox without some code changes. This pull allows any OSM tile server to be specified at build time. I also updated the README to better explain the process. I'm pretty new to Java/Android programming outside of school, so please let me know if this is breaking all the rules of what's normal/good practice/whatever. ~~I'm still trying to dig up a nice list of public(ish) tile servers, so the README can link to that instead, but I'd like to see what people thought of the code in the mean time~~ Edit: linked to the [switch2osm](http://switch2osm.org/providers/) list.
