### PR TITLE
Add "Wi-Fi Access Points Visible" to main display

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -27,11 +27,20 @@
            android:textAppearance="?android:attr/textAppearanceMedium" />
 
        <TextView
-           android:id="@+id/wifi_access_points"
+           android:id="@+id/visible_wifi_access_points"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:layout_alignParentLeft="true"
            android:layout_below="@+id/locations_scanned"
+           android:text="@string/visible_wifi_access_points"
+           android:textAppearance="?android:attr/textAppearanceMedium" />
+
+       <TextView
+           android:id="@+id/wifi_access_points"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_alignParentLeft="true"
+           android:layout_below="@+id/visible_wifi_access_points"
            android:text="@string/wifi_access_points"
            android:textAppearance="?android:attr/textAppearanceMedium" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="view_map">Test Mozilla Location Service</string>
     <string name="service_name">Mozilla Stumbler</string>
     <string name="wifi_access_points">Wi-Fi Access Points Scanned: %1$d</string>
+    <string name="visible_wifi_access_points">Wi-Fi Access Points Visible: %1$d</string>
     <string name="gps_satellites">GPS Satellites Visible: %1$d</string>
     <string name="locations_scanned">Locations Scanned: %1$d</string>
     <string name="last_upload_time">Last Upload Time: %1$s</string>

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -189,11 +189,13 @@ public final class MainActivity extends Activity {
 
         int locationsScanned = 0;
         int APs = 0;
+        int visibleAPs = 0;
         long lastUploadTime = 0;
         long reportsSent = 0;
         try {
             locationsScanned = mConnectionRemote.getLocationCount();
             APs = mConnectionRemote.getAPCount();
+            visibleAPs = mConnectionRemote.getVisibleAPCount();
             lastUploadTime = mConnectionRemote.getLastUploadTime();
             reportsSent = mConnectionRemote.getReportsSent();
         } catch (RemoteException e) {
@@ -205,6 +207,7 @@ public final class MainActivity extends Activity {
                                       : "-";
 
         formatTextView(R.id.gps_satellites, R.string.gps_satellites, mGpsFixes);
+        formatTextView(R.id.visible_wifi_access_points, R.string.visible_wifi_access_points, visibleAPs);
         formatTextView(R.id.wifi_access_points, R.string.wifi_access_points, APs);
         formatTextView(R.id.locations_scanned, R.string.locations_scanned, locationsScanned);
         formatTextView(R.id.last_upload_time, R.string.last_upload_time, lastUploadTimeString);

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -74,6 +74,10 @@ class Scanner {
      return mWifiScanner.getAPCount();
   }
 
+  int getVisibleAPCount() {
+     return mWifiScanner.getVisibleAPCount();
+  }
+
   int getLocationCount() {
      return mGPSScanner.getLocationCount();
   }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -125,6 +125,11 @@ public final class ScannerService extends Service {
         }
 
         @Override
+        public int getVisibleAPCount() throws RemoteException {
+            return mScanner.getVisibleAPCount();
+        }
+
+        @Override
         public long getLastUploadTime() throws RemoteException {
             return mReporter.getLastUploadTime();
         }

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -7,6 +7,7 @@ interface ScannerServiceInterface {
     void stopScanning();
     int getLocationCount();
     int getAPCount();
+    int getVisibleAPCount();
     long getLastUploadTime();
     long getReportsSent();
 }

--- a/src/org/mozilla/mozstumbler/WifiScanner.java
+++ b/src/org/mozilla/mozstumbler/WifiScanner.java
@@ -30,10 +30,12 @@ public class WifiScanner extends BroadcastReceiver {
   private WifiLock               mWifiLock;
   private Timer                  mWifiScanTimer;
   private final Set<String>      mAPs = new HashSet<String>();
+  private int                    mVisibleAPs;
 
   WifiScanner(Context c) {
     mContext = c;
     mStarted = false;
+    mVisibleAPs = 0;
   }
 
   public void start() {
@@ -84,6 +86,7 @@ public class WifiScanner extends BroadcastReceiver {
     Collection<ScanResult> scanResults = getWifiManager().getScanResults();
 
     JSONArray wifiInfo = new JSONArray();
+    mVisibleAPs = 0;
     for (ScanResult scanResult : scanResults) {
       scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
       if (!shouldLog(scanResult)) {
@@ -100,6 +103,7 @@ public class WifiScanner extends BroadcastReceiver {
         Log.e(LOGTAG, "", jsonex);
       }
 
+      mVisibleAPs += 1;
       mAPs.add(scanResult.BSSID);
 
       Log.v(LOGTAG, "BSSID=" + scanResult.BSSID + ", SSID=\"" + scanResult.SSID + "\", Signal=" + scanResult.level);
@@ -119,6 +123,10 @@ public class WifiScanner extends BroadcastReceiver {
 
   public int getAPCount() {
     return mAPs.size();
+  }
+
+  public int getVisibleAPCount() {
+    return mVisibleAPs;
   }
 
   private static boolean shouldLog(ScanResult scanResult) {

--- a/src/org/mozilla/mozstumbler/WifiScanner.java
+++ b/src/org/mozilla/mozstumbler/WifiScanner.java
@@ -78,6 +78,7 @@ public class WifiScanner extends BroadcastReceiver {
       mContext.unregisterReceiver(this);
     }
     mStarted = false;
+    mVisibleAPs = 0;
   }
 
   public void onReceive(Context c, Intent intent) {

--- a/src/org/mozilla/mozstumbler/WifiScanner.java
+++ b/src/org/mozilla/mozstumbler/WifiScanner.java
@@ -34,8 +34,6 @@ public class WifiScanner extends BroadcastReceiver {
 
   WifiScanner(Context c) {
     mContext = c;
-    mStarted = false;
-    mVisibleAPs = 0;
   }
 
   public void start() {


### PR DESCRIPTION
This allows the user to see if any access points are currently visible,
as well as whether the number is changing which prevents stalled polls
from continuing.
