### PR TITLE
Provide GPS Latitude & Longitude to user

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -18,11 +18,20 @@
            android:textAppearance="?android:attr/textAppearanceMedium" />
 
        <TextView
-           android:id="@+id/locations_scanned"
+           android:id="@+id/last_location"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:layout_alignParentLeft="true"
            android:layout_below="@+id/gps_satellites"
+           android:text="@string/last_location"
+           android:textAppearance="?android:attr/textAppearanceMedium" />
+
+       <TextView
+           android:id="@+id/locations_scanned"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_alignParentLeft="true"
+           android:layout_below="@+id/last_location"
            android:text="@string/locations_scanned"
            android:textAppearance="?android:attr/textAppearanceMedium" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="wifi_access_points">Wi-Fi Access Points Scanned: %1$d</string>
     <string name="visible_wifi_access_points">Wi-Fi Access Points Visible: %1$d</string>
     <string name="gps_satellites">GPS Satellites Visible: %1$d</string>
+    <string name="last_location">Last Location: %1$s</string>
+    <string name="coordinate">(%1$.4f, %2$.4f)</string>
     <string name="locations_scanned">Locations Scanned: %1$d</string>
     <string name="last_upload_time">Last Upload Time: %1$s</string>
     <string name="reports_sent">Reports Sent: %1$d</string>

--- a/src/org/mozilla/mozstumbler/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/GPSScanner.java
@@ -27,6 +27,8 @@ public class GPSScanner implements LocationListener {
     private GpsStatus.Listener    mGPSListener;
 
     private int mLocationCount;
+    private double mLatitude;
+    private double mLongitude;
 
     GPSScanner(Context context) {
         mContext = context;
@@ -82,6 +84,15 @@ public class GPSScanner implements LocationListener {
     public int getLocationCount() {
         return mLocationCount;
     }
+
+    public double getLatitude() {
+        return mLatitude;
+    }
+
+    public double getLongitude() {
+        return mLongitude;
+    }
+
     @Override
     public void onLocationChanged(Location location) {
         if (location == null) {
@@ -95,11 +106,14 @@ public class GPSScanner implements LocationListener {
 
         Log.d(LOGTAG, "New location: " + location);
 
+        mLongitude = location.getLongitude();
+        mLatitude = location.getLatitude();
+
         JSONObject locInfo = new JSONObject();
         try {
             locInfo.put("time", DateTimeUtils.formatTime(location.getTime()));
-            locInfo.put("lon", location.getLongitude());
-            locInfo.put("lat", location.getLatitude());
+            locInfo.put("lon", mLongitude);
+            locInfo.put("lat", mLatitude);
             locInfo.put("accuracy", (int) location.getAccuracy());
             locInfo.put("altitude", (int) location.getAltitude());
         } catch (JSONException jsonex) {

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -188,12 +188,16 @@ public final class MainActivity extends Activity {
         }
 
         int locationsScanned = 0;
+        double latitude = 0;
+        double longitude = 0;
         int APs = 0;
         int visibleAPs = 0;
         long lastUploadTime = 0;
         long reportsSent = 0;
         try {
             locationsScanned = mConnectionRemote.getLocationCount();
+            latitude = mConnectionRemote.getLatitude();
+            longitude = mConnectionRemote.getLongitude();
             APs = mConnectionRemote.getAPCount();
             visibleAPs = mConnectionRemote.getVisibleAPCount();
             lastUploadTime = mConnectionRemote.getLastUploadTime();
@@ -206,7 +210,12 @@ public final class MainActivity extends Activity {
                                       ? DateTimeUtils.formatTimeForLocale(lastUploadTime)
                                       : "-";
 
+        String lastLocationString = (mGpsFixes > 0 && locationsScanned > 0)
+                                    ? formatLocation(latitude, longitude)
+                                    : "-";
+
         formatTextView(R.id.gps_satellites, R.string.gps_satellites, mGpsFixes);
+        formatTextView(R.id.last_location, R.string.last_location, lastLocationString);
         formatTextView(R.id.visible_wifi_access_points, R.string.visible_wifi_access_points, visibleAPs);
         formatTextView(R.id.wifi_access_points, R.string.wifi_access_points, APs);
         formatTextView(R.id.locations_scanned, R.string.locations_scanned, locationsScanned);
@@ -291,5 +300,10 @@ public final class MainActivity extends Activity {
         String str = getResources().getString(stringId);
         str = String.format(str, args);
         textView.setText(str);
+    }
+
+    private String formatLocation(double latitude, double longitude) {
+        final String coordinateFormatString = getResources().getString(R.string.coordinate);
+        return String.format(coordinateFormatString, latitude, longitude);
     }
 }

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -81,4 +81,12 @@ class Scanner {
   int getLocationCount() {
      return mGPSScanner.getLocationCount();
   }
+
+  double getLatitude() {
+     return mGPSScanner.getLatitude();
+  }
+
+  double getLongitude() {
+     return mGPSScanner.getLongitude();
+  }
 }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -120,6 +120,16 @@ public final class ScannerService extends Service {
         }
 
         @Override
+        public double getLatitude() throws RemoteException {
+            return mScanner.getLatitude();
+        }
+
+        @Override
+        public double getLongitude() throws RemoteException {
+            return mScanner.getLongitude();
+        }
+
+        @Override
         public int getAPCount() throws RemoteException {
             return mScanner.getAPCount();
         }

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -6,6 +6,8 @@ interface ScannerServiceInterface {
     void startWifiScanningOnly();
     void stopScanning();
     int getLocationCount();
+    double getLatitude();
+    double getLongitude();
     int getAPCount();
     int getVisibleAPCount();
     long getLastUploadTime();


### PR DESCRIPTION
Issue #168 suggested a change to the "GPS Satellites Visible" count so the user was aware if a GPS fix has occurred.  This merge request provides an additional line of information informing the user of the current location as reported by the GPS.  That information is only displayed if there are currently visible satellites and at least one location has been observed.
