### PR TITLE
Restore ongoing notification with a min. priority (removed in acd2e0f)

### DIFF
--- a/res/values-cz/strings.xml
+++ b/res/values-cz/strings.xml
@@ -15,6 +15,7 @@
     <string name="locations_scanned">Prohledáno míst: %1$d</string>
     <string name="last_upload_time">Čas posledniho reportu: %1$s</string>
     <string name="reports_sent">Odesláno reportů: %1$d</string>
+    <string name="service_scanning">Vyhledávám Wi-Fi a mobilní sítě</string>
 
     <string name="enter_nickname">Vložte jméno (nepovinné)</string>
     <string name="enter_nickname_title">Jméno: </string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -14,6 +14,7 @@
     <string name="locations_scanned">Standorte gescannt: %1$d</string>
     <string name="last_upload_time">Datum der letzten Datenübermittlung: %1$s</string>
     <string name="reports_sent">Berichte gesendet: %1$d</string>
+    <string name="service_scanning">Scanne Wi-Fi und Mobilfunknetze</string>
 
     <string name="enter_nickname">Setze Nickname (optional)</string>
     <string name="enter_nickname_title">Nickname: </string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -14,6 +14,7 @@
     <string name="locations_scanned">Ubicaciones escaneadas: %1$d</string>
     <string name="last_upload_time">Último envío de datos: %1$s</string>
     <string name="reports_sent">Reportes enviados: %1$d</string>
+    <string name="service_scanning">Escaneando redes Wi-Fi y Móviles</string>
 
     <string name="enter_nickname">Ingresa tu apodo (opcional)</string>
     <string name="enter_nickname_title">Apodo: </string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -14,6 +14,7 @@
     <string name="locations_scanned">Emplacements enregistrés : %1$d</string>
     <string name="last_upload_time">Date du dernier envoi : %1$s</string>
     <string name="reports_sent">Rapports envoyés : %1$d</string>
+    <string name="service_scanning">Détection des réseaux Wi-Fi et cellulaires</string>
 
     <string name="enter_nickname">Saisir un pseudo (optionnel)</string>
     <string name="enter_nickname_title">Pseudo : </string>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -18,6 +18,7 @@
     <string name="coordinate">(%1$.4f, %2$.4f)</string>
     <string name="last_upload_time">अंतिम विवरण भेजने का समय: %1$s</string>
     <string name="reports_sent">भेजे गए विवरण: %1$d</string>
+    <string name="service_scanning">Wi -Fi एवं Cellular जाल खोज रहा है</string>
 
     <string name="enter_nickname">उपनाम डालें (वैकल्पिक)</string>
     <string name="enter_nickname_title">उपनाम: </string>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -12,6 +12,7 @@
     <string name="locations_scanned">מיקומים שנסרקו: %1$d</string>
     <string name="last_upload_time">מועד ההעלאה האחרון: %1$s</string>
     <string name="reports_sent">דיווחים שנשלחו: %1$d</string>
+    <string name="service_scanning">מתבצעת סריקה לאיתור רשתות סלולריות ו־Wi-Fi</string>
 
     <string name="enter_nickname">הזנת שם המשתמש (רשות)</string>
     <string name="enter_nickname_title">כינוי: </string>

--- a/res/values-mr/strings.xml
+++ b/res/values-mr/strings.xml
@@ -18,6 +18,7 @@
     <string name="locations_scanned">शोधलेल्या जागा: %1$d</string>
     <string name="last_upload_time">शेवटचा अहवाल पाठवण्याची वेळ: %1$s</string>
     <string name="reports_sent">पाठवलेले अहवाल: %1$d</string>
+    <string name="service_scanning">Wi-Fi आणि भ्रमणध्वनी जाळे शोधत आहे</string>
 
     <string name="enter_nickname">टोपणनाव टाका (ऐच्छिक)</string>
     <string name="enter_nickname_title">टोपणनाव: </string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -12,6 +12,7 @@
     <string name="locations_scanned">Gevonden lokaties: %1$d</string>
     <string name="last_upload_time">Laatste upload om: %1$s</string>
     <string name="reports_sent">Verzonden rapportages: %1$d</string>
+    <string name="service_scanning">Bezig met scannen van Wi-Fi en mobiele netwerken</string>
 
     <string name="enter_nickname">Alias (niet verplicht)</string>
     <string name="enter_nickname_title">Alias: </string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -12,6 +12,7 @@
     <string name="locations_scanned">Przeskanowane lokacje: %1$d</string>
     <string name="last_upload_time">Ostatnio wysłano o: %1$s</string>
     <string name="reports_sent">Wysłane raporty: %1$d</string>
+    <string name="service_scanning">Skanowanie w poszukiwaniu Wi-Fi i sieci komórkowych</string>
 
     <string name="enter_nickname">Wpisz Nickanme (opcjonalnie)</string>
     <string name="enter_nickname_title">Nickname: </string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -15,6 +15,7 @@
     <string name="locations_scanned">Localizações escaneadas: %1$d</string>
     <string name="last_upload_time">Horário do último upload: %1$s</string>
     <string name="reports_sent">Relatórios enviados: %1$d</string>
+    <string name="service_scanning">Escanear para redes Wi-Fi e Cellular</string>
 
     <string name="enter_nickname">Entre com seu nickname (opcional)</string>
     <string name="enter_nickname_title">Nickname: </string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -15,6 +15,7 @@
     <string name="locations_scanned">Отсканировано координат: %1$d</string>
     <string name="last_upload_time">Время последней отправки отчёта: %1$s</string>
     <string name="reports_sent">Отправлено отчётов: %1$d</string>
+    <string name="service_scanning">Сканирование Wi-Fi точек и базовых станций сотовых операторов</string>
 
     <string name="enter_nickname">Укажите свой псевдоним (не обязательно)</string>
     <string name="enter_nickname_title">Псевдоним: </string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -12,6 +12,7 @@
     <string name="locations_scanned">累计锁定位置: %1$d</string>
     <string name="last_upload_time">最近一次上传时间: %1$s</string>
     <string name="reports_sent">累计上传报告: %1$d</string>
+    <string name="service_scanning">扫描 Wi-Fi 和手机网络</string>
 
     <string name="enter_nickname">输入昵称 (可选)</string>
     <string name="enter_nickname_title">昵称: </string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -18,6 +18,7 @@
     <string name="locations_scanned">已掃描位置數量: %1$d</string>
     <string name="last_upload_time">前次資料上傳時間: %1$s</string>
     <string name="reports_sent">已傳送報告數量: %1$d</string>
+    <string name="service_scanning">正在掃描 Wi-Fi 與行動網路</string>
 
     <string name="enter_nickname">輸入暱稱 (非必填)</string>
     <string name="enter_nickname_title">暱稱: </string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="locations_scanned">Locations Scanned: %1$d</string>
     <string name="last_upload_time">Last Upload Time: %1$s</string>
     <string name="reports_sent">Reports Sent: %1$d</string>
+    <string name="service_scanning">Scanning for Wi-Fi and Cellular networks</string>
 
     <string name="enter_nickname">Enter Nickname (optional)</string>
     <string name="enter_nickname_title">Nickname: </string>


### PR DESCRIPTION
Start the service in a foreground state.

Why this notification has been removed? Removing startForeground() and making service a background was intentional?
