### PR TITLE
Show notification when scanning

### DIFF
--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -21,7 +21,6 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.RemoteException;
-import android.support.v4.app.NotificationCompat;
 import android.text.format.DateFormat;
 import android.util.Log;
 
@@ -68,7 +67,7 @@ public final class ScannerService extends Service {
                     try {
                         CharSequence title = getResources().getText(R.string.service_name);
                         CharSequence text = getResources().getText(R.string.service_scanning);
-                        postNotification(title, text);
+                        postNotification(title, text, Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT);
 
                         mScanner.startScanning();
 
@@ -335,7 +334,7 @@ public final class ScannerService extends Service {
         cancelNotification();
     }
 
-    private void postNotification(final CharSequence title, final CharSequence text) {
+    private void postNotification(final CharSequence title, final CharSequence text, final int flags) {
         mLooper.post(new Runnable() {
             @Override
             public void run() {
@@ -345,7 +344,7 @@ public final class ScannerService extends Service {
                 PendingIntent contentIntent = PendingIntent.getActivity(ctx, NOTIFICATION_ID, notificationIntent,
                         PendingIntent.FLAG_CANCEL_CURRENT);
                 int icon = R.drawable.ic_status_scanning;
-                Notification n = buildNotification(ctx, icon, title, text, contentIntent);
+                Notification n = buildNotification(ctx, icon, title, text, contentIntent, flags);
                 startForeground(NOTIFICATION_ID, n);
             }
         });
@@ -371,14 +370,10 @@ public final class ScannerService extends Service {
     private static Notification buildNotification(Context context, int icon,
                                                   CharSequence contentTitle,
                                                   CharSequence contentText,
-                                                  PendingIntent contentIntent) {
-        return new NotificationCompat.Builder(context)
-                .setSmallIcon(icon)
-                .setContentTitle(contentTitle)
-                .setContentText(contentText)
-                .setContentIntent(contentIntent)
-                .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_MIN)
-                .build();
+                                                  PendingIntent contentIntent, int flags) {
+        Notification n = new Notification(icon, contentTitle, 0);
+        n.setLatestEventInfo(context, contentTitle, contentText, contentIntent);
+        n.flags |= flags;
+        return n;
     }
 }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -100,8 +100,7 @@ public final class ScannerService extends Service {
                     AlarmManager alarm = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
                     alarm.cancel(mWakeIntent);
 
-                    NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-                    nm.cancel(NOTIFICATION_ID);
+                    cancelNotification();
                     stopForeground(true);
 
                     mScanner.stopScanning();
@@ -333,9 +332,7 @@ public final class ScannerService extends Service {
         mReporter = null; 
 
         stopActivityTracking();
-
-        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        nm.cancel(NOTIFICATION_ID);
+        cancelNotification();
     }
 
     private void postNotification(final CharSequence title, final CharSequence text) {
@@ -352,6 +349,11 @@ public final class ScannerService extends Service {
                 startForeground(NOTIFICATION_ID, n);
             }
         });
+    }
+
+    private void cancelNotification() {
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        nm.cancel(NOTIFICATION_ID);
     }
 
     @Override


### PR DESCRIPTION
The `NotificationCompat.Builder` does not seem to actually do anything on my device, so I resurrected the older, proven `buildNotification()` method that does display the notification icon.
