### PR TITLE
Fix lint issues with de translations

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">MozStumbler</string>
     <string name="action_about">Über MozStumbler</string>
     <string name="action_preferences">Einstellungen</string>
-    <string name="action_exit">Schliessen</string>
+    <string name="action_exit">Schließen</string>
     
     <string name="view_leaderboard">Zeige Rangliste</string>
     <string name="view_map">Teste Mozillas Ortungsdienst</string>
@@ -44,7 +44,7 @@
     <string name="detected_activity">Erkannte Aktivität: %1$s</string>
     <string name="detected_activity_in_vehicle">In Bewegung (Fahrzeug)</string>
     <string name="detected_activity_on_bicycle">In Bewegung (Fahrrad)</string>
-    <string name="detected_activity_on_foot">In Bewegung (zu Fuss)</string>
+    <string name="detected_activity_on_foot">In Bewegung (zu Fuß)</string>
     <string name="detected_activity_still">Stillstehend</string>
     <string name="detected_activity_tilting">Gekippt</string>
     <string name="detected_activity_unknown">Unbekannt</string>


### PR DESCRIPTION
lint really wants "Schliessen" to be "Schließen" and "Fuss" to be "Fuß".
This change makes lint happy.
