### PR TITLE
Display current and total cell info to the user

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -53,11 +53,29 @@
            android:textAppearance="?android:attr/textAppearanceSmall" />
 
        <TextView
-           android:id="@+id/visible_wifi_access_points"
+           android:id="@+id/current_cell_info"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:layout_alignParentLeft="true"
            android:layout_below="@+id/locations_scanned"
+           android:text="@string/current_cell_info"
+           android:textAppearance="?android:attr/textAppearanceSmall" />
+
+       <TextView
+           android:id="@+id/cell_info_scanned"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_alignParentLeft="true"
+           android:layout_below="@+id/current_cell_info"
+           android:text="@string/cell_info_scanned"
+           android:textAppearance="?android:attr/textAppearanceSmall" />
+
+       <TextView
+           android:id="@+id/visible_wifi_access_points"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_alignParentLeft="true"
+           android:layout_below="@+id/cell_info_scanned"
            android:text="@string/visible_wifi_access_points"
            android:textAppearance="?android:attr/textAppearanceSmall" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,8 +12,8 @@
     <string name="activity_recognition_service">Mozilla Stumbler Activity Recognition Intent Service</string>
     <string name="wifi_access_points">Wi-Fi Access Points Scanned: %1$d</string>
     <string name="visible_wifi_access_points">Wi-Fi Access Points Visible: %1$d</string>
-    <string name="cell_info_scanned">Cell Info Scanned: %1$d</string>
-    <string name="current_cell_info">Current Cell Info: %1$d</string>
+    <string name="cell_info_scanned">Cells Scanned: %1$d</string>
+    <string name="current_cell_info">Cells: %1$d</string>
     <string name="gps_satellites">GPS Satellites Visible: %1$d</string>
     <string name="last_location">Last Location: %1$s</string>
     <string name="coordinate">(%1$.4f, %2$.4f)</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="activity_recognition_service">Mozilla Stumbler Activity Recognition Intent Service</string>
     <string name="wifi_access_points">Wi-Fi Access Points Scanned: %1$d</string>
     <string name="visible_wifi_access_points">Wi-Fi Access Points Visible: %1$d</string>
+    <string name="cell_info_scanned">Cell Info Scanned: %1$d</string>
+    <string name="current_cell_info">Current Cell Info: %1$d</string>
     <string name="gps_satellites">GPS Satellites Visible: %1$d</string>
     <string name="last_location">Last Location: %1$s</string>
     <string name="coordinate">(%1$.4f, %2$.4f)</string>

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -220,6 +220,8 @@ public final class MainActivity extends Activity {
         double longitude = 0;
         int APs = 0;
         int visibleAPs = 0;
+        int cellInfoScanned = 0;
+        int currentCellInfo = 0;
         long lastUploadTime = 0;
         long reportsSent = 0;
         String detectedActivity = null;
@@ -231,6 +233,8 @@ public final class MainActivity extends Activity {
             longitude = mConnectionRemote.getLongitude();
             APs = mConnectionRemote.getAPCount();
             visibleAPs = mConnectionRemote.getVisibleAPCount();
+            cellInfoScanned = mConnectionRemote.getCellInfoCount();
+            currentCellInfo = mConnectionRemote.getCurrentCellInfoCount();
             lastUploadTime = mConnectionRemote.getLastUploadTime();
             reportsSent = mConnectionRemote.getReportsSent();
             detectedActivity = mConnectionRemote.getDetectedActivity();
@@ -260,6 +264,8 @@ public final class MainActivity extends Activity {
         formatTextView(R.id.last_location, R.string.last_location, lastLocationString);
         formatTextView(R.id.visible_wifi_access_points, R.string.visible_wifi_access_points, visibleAPs);
         formatTextView(R.id.wifi_access_points, R.string.wifi_access_points, APs);
+        formatTextView(R.id.current_cell_info, R.string.current_cell_info, currentCellInfo);
+        formatTextView(R.id.cell_info_scanned, R.string.cell_info_scanned, cellInfoScanned);
         formatTextView(R.id.locations_scanned, R.string.locations_scanned, locationsScanned);
         formatTextView(R.id.last_upload_time, R.string.last_upload_time, lastUploadTimeString);
         formatTextView(R.id.reports_sent, R.string.reports_sent, reportsSent);

--- a/src/org/mozilla/mozstumbler/Scanner.java
+++ b/src/org/mozilla/mozstumbler/Scanner.java
@@ -75,6 +75,14 @@ class Scanner {
      return mWifiScanner.getVisibleAPCount();
   }
 
+  int getCellInfoCount() {
+     return mCellScanner.getCellInfoCount();
+  }
+
+  int getCurrentCellInfoCount() {
+     return mCellScanner.getCurrentCellInfoCount();
+  }
+
   int getLocationCount() {
      return mGPSScanner.getLocationCount();
   }

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -135,6 +135,16 @@ public final class ScannerService extends Service {
         }
 
         @Override
+        public int getCellInfoCount() throws RemoteException {
+            return mScanner.getCellInfoCount();
+        }
+
+        @Override
+        public int getCurrentCellInfoCount() throws RemoteException {
+            return mScanner.getCurrentCellInfoCount();
+        }
+
+        @Override
         public long getLastUploadTime() throws RemoteException {
             return mReporter.getLastUploadTime();
         }

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -9,6 +9,8 @@ interface ScannerServiceInterface {
     double getLongitude();
     int getAPCount();
     int getVisibleAPCount();
+    int getCellInfoCount();
+    int getCurrentCellInfoCount();
     long getLastUploadTime();
     long getReportsSent();
     String getDetectedActivity();

--- a/src/org/mozilla/mozstumbler/cellscanner/CellInfo.java
+++ b/src/org/mozilla/mozstumbler/cellscanner/CellInfo.java
@@ -281,4 +281,39 @@ public class CellInfo implements Parcelable {
                 return null;
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof CellInfo))
+            return false;
+        CellInfo ci = (CellInfo) o;
+        return mRadio.equals(ci.mRadio)
+               && mCellRadio.equals(ci.mCellRadio)
+               && mMcc == ci.mMcc
+               && mMnc == ci.mMnc
+               && mCid == ci.mCid
+               && mLac == ci.mLac
+               && mSignal == ci.mSignal
+               && mAsu == ci.mAsu
+               && mTa == ci.mTa
+               && mPsc == ci.mPsc;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + mRadio.hashCode();
+        result = 31 * result + mCellRadio.hashCode();
+        result = 31 * result + mMcc;
+        result = 31 * result + mMnc;
+        result = 31 * result + mCid;
+        result = 31 * result + mLac;
+        result = 31 * result + mSignal;
+        result = 31 * result + mAsu;
+        result = 31 * result + mTa;
+        result = 31 * result + mPsc;
+        return result;
+    }
 }

--- a/src/org/mozilla/mozstumbler/cellscanner/CellScanner.java
+++ b/src/org/mozilla/mozstumbler/cellscanner/CellScanner.java
@@ -9,7 +9,9 @@ import org.json.JSONArray;
 import org.mozilla.mozstumbler.ScannerService;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -23,6 +25,8 @@ public class CellScanner {
     private final Context mContext;
     private CellScannerImpl mImpl;
     private Timer mCellScanTimer;
+    private final Set<CellInfo> mCells = new HashSet<CellInfo>();
+    private int mCurrentCellInfoCount;
 
     interface CellScannerImpl {
         public void start();
@@ -58,9 +62,11 @@ public class CellScanner {
                 Log.d(LOGTAG, "Cell Scanning Timer fired");
                 final long curTime = System.currentTimeMillis();
                 ArrayList<CellInfo> cells = new ArrayList<CellInfo>(mImpl.getCellInfo());
+                mCurrentCellInfoCount = cells.size();
                 if (cells.isEmpty()) {
                     return;
                 }
+                mCells.addAll(cells);
 
                 Intent intent = new Intent(ScannerService.MESSAGE_TOPIC);
                 intent.putExtra(Intent.EXTRA_SUBJECT, CELL_SCANNER_EXTRA_SUBJECT);
@@ -80,5 +86,13 @@ public class CellScanner {
             mImpl.stop();
             mImpl = null;
         }
+    }
+
+    public int getCellInfoCount() {
+        return mCells.size();
+    }
+
+    public int getCurrentCellInfoCount() {
+        return mCurrentCellInfoCount;
     }
 }


### PR DESCRIPTION
I like to see that even when I'm not getting WiFi APs, there's still valuable info being stumbled.  This is a first stab at satisfying issue #194 ... though that wanted individual cell tower, this is currently counting unique "Cell Info" which includes things like Signal Strength.

The equality and hashCode for CellInfo could be changed to exclude non-tower-identifying info if required.
