### PR TITLE
Only Mozilla builds should try to download updated Mozilla builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     signingConfigs {
-      release
+        release
     }
 
     buildTypes {
@@ -47,7 +47,6 @@ android {
         }
 
         release {
-            debuggable true
             runProguard true
             proguardFile 'proguard.cfg'
             signingConfig signingConfigs.release
@@ -74,7 +73,7 @@ if (hasProperty('StoreFile')) {
 }
 
 String getMozillaApiKey() {
-    return project.hasProperty('MozAPIKey') ? '"' +  project['MozAPIKey'] + '"' : "\"test\"";
+    return project.hasProperty('MozAPIKey') ? '"' +  project['MozAPIKey'] + '"' : "null";
 }
 
 String getTileServerUrl() {
@@ -82,7 +81,6 @@ String getTileServerUrl() {
         return '"' + project['TileServerURL'] + '"';
     } else if (project.hasProperty('MapAPIKey')) {
         return "\"http://api.tiles.mapbox.com/v3/${project['MapAPIKey']}/\"";
-    } else {
-        return "null";
     }
+    return "null";
 }

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -116,7 +116,10 @@ public final class MainActivity extends Activity {
         setContentView(R.layout.activity_main);
 
         new Prefs(this).setDefaultValues();
-        Updater.checkForUpdates(this);
+
+        if (BuildConfig.MOZILLA_API_KEY != null) {
+            Updater.checkForUpdates(this);
+        }
 
         Log.d(LOGTAG, "onCreate");
     }

--- a/src/org/mozilla/mozstumbler/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/MapActivity.java
@@ -180,12 +180,6 @@ public final class MapActivity extends Activity {
     protected void onStop() {
         super.onStop();
 
-        Context context = getApplicationContext();
-        Intent i = new Intent(ScannerService.MESSAGE_TOPIC);
-        i.putExtra(Intent.EXTRA_SUBJECT, "Scanner");
-        i.putExtra("enable", 0);
-        context.sendBroadcast(i);
-
         Log.d(LOGTAG, "onStop");
         mMap.getTileProvider().clearTileCache();
         if (mReceiver != null) {

--- a/src/org/mozilla/mozstumbler/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/MapActivity.java
@@ -85,7 +85,6 @@ public final class MapActivity extends Activity {
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -94,20 +93,8 @@ public final class MapActivity extends Activity {
         mWifiData = Collections.emptyList();
         MOZSTUMBLER_USER_AGENT_STRING = NetworkUtils.getUserAgentString(this);
 
-        OnlineTileSourceBase tileSource;
-        if (BuildConfig.TILE_SERVER_URL == null) {
-            tileSource = TileSourceFactory.DEFAULT_TILE_SOURCE;
-        } else {
-            tileSource = new XYTileSource("MozStumbler Tile Store",
-                                          null,
-                                          1, 20, 256,
-                                          ".png",
-                                          BuildConfig.TILE_SERVER_URL);
-        }
-
         mMap = (MapView) this.findViewById(R.id.map);
-
-        mMap.setTileSource(tileSource);
+        mMap.setTileSource(getTileSource());
         mMap.setBuiltInZoomControls(true);
         mMap.setMultiTouchControls(true);
 
@@ -118,6 +105,18 @@ public final class MapActivity extends Activity {
         registerReceiver(mReceiver, new IntentFilter(ScannerService.MESSAGE_TOPIC));
 
         Log.d(LOGTAG, "onCreate");
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private static OnlineTileSourceBase getTileSource() {
+        if (BuildConfig.TILE_SERVER_URL == null) {
+            return TileSourceFactory.DEFAULT_TILE_SOURCE;
+        }
+        return new XYTileSource("MozStumbler Tile Store",
+                                null,
+                                1, 20, 256,
+                                ".png",
+                                BuildConfig.TILE_SERVER_URL);
     }
 
     private static class AccuracyCircleOverlay extends SafeDrawOverlay {


### PR DESCRIPTION
Fix #325. This change will avoid the problem where F-Droid's MozStumbler builds try to download and install Mozilla-signed updates from GitHub. F-Droid's package manager will update their MozStumbler builds.

Also, fix a bug where exiting the map view puts the GPS scanner and the "Start/Stop Scanning" button in an inconsistent state.
