### PR TITLE
Downgrade to gradle 1.9 to fix fdroid builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ StoreFile=<path to file>
 StorePassword=<password>
 KeyAlias=<key alias>
 KeyPassword=<password>
-MozAPIKey=test
 TileServerURL=<OSM Tile Server>
 ```
 For the OSM (Open Street Maps) Tile Server, you have several options:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.7.+'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip


### PR DESCRIPTION
fdroid's build system appears to still be using gradle 1.9:

https://f-droid.org/wiki/page/org.mozilla.mozstumbler/lastbuild

```
Cleaning Gradle project...
Could not build app org.mozilla.mozstumbler due to BuildException: 'Error cleaning org.mozilla.mozstumbler:0.10.2'
==== detail begin ====
Available gradle versions: 1.4 1.6 1.7 1.8 1.9
Found 1.10 via gradle plugin version 0.8
/opt/gradle/bin/gradle: line 18: /opt/gradle/versions/1.10/bin/gradle: No such file or directory
==== detail end ====
```
