### PR TITLE
No time in timestamps sent to servers. Fixes issue #359

### DIFF
--- a/src/org/mozilla/mozstumbler/DateTimeUtils.java
+++ b/src/org/mozilla/mozstumbler/DateTimeUtils.java
@@ -10,7 +10,7 @@ import java.util.TimeZone;
 
 final class DateTimeUtils {
     private static final DateFormat sLocaleFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
-    private static final DateFormat sISO8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'", Locale.US);
+    private static final DateFormat sISO8601Format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
     static final long MILLISECONDS_PER_DAY = 86400000;  // milliseconds/day
 


### PR DESCRIPTION
This simple fix will implement the changes proposed by @hannosch. I checked [mozilla/ichnaea](https://github.com/mozilla/ichnaea/) and the server-side code in decimaljson.py should handle it without any problems. Feel free to commit whenever you decide to move forward.

Fixes issue #359
