### PR TITLE
Basic geofencing.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -57,8 +57,8 @@
     <string name="upload_wifi_only_summary">This option will reduce your data usage over the cellular network.</string>
 
     <string name="geofencing_off">Geofencing off (0,0)</string>
-    <string name="geofencing_title">Geofencing options</string>
-    <string name="geofencing_desc">By entering coordinates here, you instruct MozStumbler to ignore locations around certain point.</string>
+    <string name="geofencing_title">Geofencing settings</string>
+    <string name="geofencing_desc">MozStumbler will pause scanning within 1 km of this lat/long position.</string>
     <string name="geofencing_on">Geofencing active</string>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -55,4 +55,10 @@
 
     <string name="upload_wifi_only_title">Upload only on WiFi</string>
     <string name="upload_wifi_only_summary">This option will reduce your data usage over the cellular network.</string>
+
+    <string name="geofencing_off">Geofencing off (0,0)</string>
+    <string name="geofencing_title">Geofencing options</string>
+    <string name="geofencing_desc">By entering coordinates here, you instruct MozStumbler to ignore locations around certain point.</string>
+    <string name="geofencing_on">Geofencing active</string>
+
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -13,4 +13,11 @@
         android:summary="@string/upload_wifi_only_summary"
         android:defaultValue="false"/>
 
+
+    <EditTextPreference
+        android:key="geofence"
+        android:title="@string/geofencing_title"
+        android:summary="@string/geofencing_desc"
+        android:defaultValue="0,0"/>
+
 </PreferenceScreen>

--- a/src/org/mozilla/mozstumbler/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/GPSScanner.java
@@ -8,8 +8,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import org.mozilla.mozstumbler.preferences.Prefs;
 
 import android.location.LocationProvider;
 import android.os.Bundle;
@@ -30,12 +29,16 @@ public class GPSScanner implements LocationListener {
     private int mLocationCount;
     private double mLatitude;
     private double mLongitude;
+    private float mBlockedLat;
+    private float mBlockedLon;
+
 
     GPSScanner(Context context) {
         mContext = context;
     }
 
     public void start() {
+
         LocationManager lm = getLocationManager();
         lm.requestLocationUpdates(LocationManager.GPS_PROVIDER,
                                                             GEO_MIN_UPDATE_TIME,
@@ -70,6 +73,9 @@ public class GPSScanner implements LocationListener {
             };
 
         lm.addGpsStatusListener(mGPSListener);
+        Prefs prefs = new Prefs(mContext);
+        mBlockedLat = prefs.getLat();
+        mBlockedLon = prefs.getLon();
     }
 
     public void stop() {
@@ -102,7 +108,7 @@ public class GPSScanner implements LocationListener {
             return;
         }
 
-        if (LocationBlockList.contains(location)) {
+        if (LocationBlockList.contains(location,mBlockedLat,mBlockedLon)) {
             Log.w(LOGTAG, "Blocked location: " + location);
             reportLocationLost();
             return;

--- a/src/org/mozilla/mozstumbler/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/GPSScanner.java
@@ -29,8 +29,7 @@ public class GPSScanner implements LocationListener {
     private int mLocationCount;
     private double mLatitude;
     private double mLongitude;
-    private float mBlockedLat;
-    private float mBlockedLon;
+    private LocationBlockList mBlockList;
 
 
     GPSScanner(Context context) {
@@ -73,9 +72,7 @@ public class GPSScanner implements LocationListener {
             };
 
         lm.addGpsStatusListener(mGPSListener);
-        Prefs prefs = new Prefs(mContext);
-        mBlockedLat = prefs.getLat();
-        mBlockedLon = prefs.getLon();
+        mBlockList = new LocationBlockList(mContext);
     }
 
     public void stop() {
@@ -108,7 +105,7 @@ public class GPSScanner implements LocationListener {
             return;
         }
 
-        if (LocationBlockList.contains(location,mBlockedLat,mBlockedLon)) {
+        if (mBlockList.contains(location)) {
             Log.w(LOGTAG, "Blocked location: " + location);
             reportLocationLost();
             return;

--- a/src/org/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/LocationBlockList.java
@@ -1,7 +1,10 @@
 package org.mozilla.mozstumbler;
 
+import android.content.Context;
 import android.location.Location;
 import android.util.Log;
+
+import org.mozilla.mozstumbler.preferences.Prefs;
 
 
 final class LocationBlockList {
@@ -11,12 +14,24 @@ final class LocationBlockList {
     private static final float  MAX_SPEED       = 340.29f;   // Mach 1 in meters/second
     private static final float  MIN_ACCURACY    = 500;       // meter radius
     private static final long   MIN_TIMESTAMP   = 946684801; // 2000-01-01 00:00:01
-    private static final double  MIN_DIFF       = 0.01;      // arbitrary value giving enough privacy
+    private static final double GEOFENCE_RADIUS = 0.01;      // .01 degrees is approximately 1km
 
-    private LocationBlockList() {
+    private Context mContext;
+    private double mBlockedLat;
+    private double mBlockedLon;
+
+    LocationBlockList(Context context) {
+        mContext = context;
+        update_blocks();
     }
 
-    static boolean contains(Location location,float bLat, float bLon) {
+    public void update_blocks()    {
+        Prefs prefs = new Prefs(mContext);
+        mBlockedLat = prefs.getLat();
+        mBlockedLon = prefs.getLon();
+    }
+
+    public boolean contains(Location location) {
         final float inaccuracy = location.getAccuracy();
         final double altitude = location.getAltitude();
         final float bearing = location.getBearing();
@@ -68,9 +83,9 @@ final class LocationBlockList {
             Log.w(LOGTAG, "Bogus timestamp: " + timestamp + " (" + DateTimeUtils.formatTime(timestamp) + ")");
         }
 
-        if ( Math.abs(location.getLatitude()-(double)bLat)<MIN_DIFF && Math.abs(location.getLongitude()-(double)bLon)<MIN_DIFF) {
+        if ( Math.abs(location.getLatitude()-mBlockedLat) < GEOFENCE_RADIUS && Math.abs(location.getLongitude()-mBlockedLon) < GEOFENCE_RADIUS) {
             block = true;
-            Log.w(LOGTAG, "Hit the geofence: " + bLat +" / " + bLon);
+            Log.w(LOGTAG, "Hit the geofence: " + mBlockedLat +" / " + mBlockedLon);
         }
 
         return block;

--- a/src/org/mozilla/mozstumbler/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/LocationBlockList.java
@@ -3,6 +3,7 @@ package org.mozilla.mozstumbler;
 import android.location.Location;
 import android.util.Log;
 
+
 final class LocationBlockList {
     private static final String LOGTAG          = LocationBlockList.class.getName();
     private static final double MAX_ALTITUDE    = 8848;      // Mount Everest's altitude in meters
@@ -10,11 +11,12 @@ final class LocationBlockList {
     private static final float  MAX_SPEED       = 340.29f;   // Mach 1 in meters/second
     private static final float  MIN_ACCURACY    = 500;       // meter radius
     private static final long   MIN_TIMESTAMP   = 946684801; // 2000-01-01 00:00:01
+    private static final double  MIN_DIFF       = 0.01;      // arbitrary value giving enough privacy
 
     private LocationBlockList() {
     }
 
-    static boolean contains(Location location) {
+    static boolean contains(Location location,float bLat, float bLon) {
         final float inaccuracy = location.getAccuracy();
         final double altitude = location.getAltitude();
         final float bearing = location.getBearing();
@@ -64,6 +66,11 @@ final class LocationBlockList {
         if (timestamp < MIN_TIMESTAMP || timestamp > tomorrow) {
             block = true;
             Log.w(LOGTAG, "Bogus timestamp: " + timestamp + " (" + DateTimeUtils.formatTime(timestamp) + ")");
+        }
+
+        if ( Math.abs(location.getLatitude()-(double)bLat)<MIN_DIFF && Math.abs(location.getLongitude()-(double)bLon)<MIN_DIFF) {
+            block = true;
+            Log.w(LOGTAG, "Hit the geofence: " + bLat +" / " + bLon);
         }
 
         return block;

--- a/src/org/mozilla/mozstumbler/NetworkUtils.java
+++ b/src/org/mozilla/mozstumbler/NetworkUtils.java
@@ -43,7 +43,6 @@ final class NetworkUtils {
         return true; // Network is OK!
     }
     static boolean isWifiAvailable(Context context) {
-        boolean isWiFi;
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         if (cm == null) {
             Log.e(LOGTAG, "ConnectivityManager is null!");

--- a/src/org/mozilla/mozstumbler/preferences/PreferencesScreen.java
+++ b/src/org/mozilla/mozstumbler/preferences/PreferencesScreen.java
@@ -13,17 +13,21 @@ import android.preference.EditTextPreference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
-import android.text.TextUtils;
 import android.util.Log;
+import android.text.TextUtils;
+import android.widget.EditText;
 
 public class PreferencesScreen extends PreferenceActivity {
 
     private EditTextPreference mNicknamePreference;
+    private EditTextPreference mLatLonPreference;
+    private Prefs mPrefs;
 
     @SuppressWarnings("deprecation")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         getPreferenceManager().setSharedPreferencesName(Prefs.PREFS_FILE);
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.GINGERBREAD) {
             getPreferenceManager().setSharedPreferencesMode(MODE_MULTI_PROCESS);
@@ -32,10 +36,13 @@ public class PreferencesScreen extends PreferenceActivity {
         CheckBoxPreference mWifiPreference;
         mNicknamePreference = (EditTextPreference) getPreferenceManager().findPreference("nickname");
         mWifiPreference = (CheckBoxPreference) getPreferenceManager().findPreference("wifi_only");
-        Prefs prefs = new Prefs(this);
+        mLatLonPreference = (EditTextPreference) getPreferenceManager().findPreference("geofence");
 
-        setNicknamePreferenceTitle(prefs.getNickname());
-        mWifiPreference.setChecked(prefs.getWifi());
+        mPrefs = new Prefs(this);
+
+        setNicknamePreferenceTitle(mPrefs.getNickname());
+        mWifiPreference.setChecked(mPrefs.getWifi());
+        setGeoFencePreferenceTitle(mPrefs.getLatLon());
 
         setPreferenceListener();
     }
@@ -48,6 +55,25 @@ public class PreferencesScreen extends PreferenceActivity {
                 return true;
             }
         });
+
+        mLatLonPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                mPrefs.setLatLon(newValue.toString());
+                String nLatLon = mPrefs.getLatLon();
+                setGeoFencePreferenceTitle(nLatLon);
+                return true;
+            }
+        });
+    }
+
+    private void setGeoFencePreferenceTitle(String LatLon) {
+
+        if (TextUtils.equals(LatLon,"0,0")||TextUtils.equals(LatLon,"0.0,0.0")) {
+            mLatLonPreference.setTitle(R.string.geofencing_off);
+        } else {
+            mLatLonPreference.setTitle(R.string.geofencing_on);
+        }
     }
 
     private void setNicknamePreferenceTitle(String nickname) {

--- a/src/org/mozilla/mozstumbler/preferences/Prefs.java
+++ b/src/org/mozilla/mozstumbler/preferences/Prefs.java
@@ -56,32 +56,34 @@ public final class Prefs {
     }
 
     public String getLatLon() {
-        float la=getPrefs().getFloat(LAT_PREF,0);
-        float lo=getPrefs().getFloat(LON_PREF,0);
-        String LatLon = Float.toString(la).concat(",").concat(Float.toString(lo));
-        return LatLon;
+        float la = getPrefs().getFloat(LAT_PREF,0);
+        float lo = getPrefs().getFloat(LON_PREF,0);
+        return Float.toString(la).concat(",").concat(Float.toString(lo));
     }
+
     public float getLat() {
-        float Lat = getPrefs().getFloat(LAT_PREF,0);
-        return Lat;
+        return getPrefs().getFloat(LAT_PREF,0);
     }
 
     public float getLon() {
-        float Lon = getPrefs().getFloat(LON_PREF,0);
-        return Lon;
+        return getPrefs().getFloat(LON_PREF,0);
     }
+
     public void setLatLon(String LatLon) {
-        float la = 0;
-        float lo = 0;
+        float la;
+        float lo;
         try {
             la = Float.parseFloat(LatLon.substring(0,LatLon.indexOf(",")));
             lo = Float.parseFloat(LatLon.substring(LatLon.lastIndexOf(",")+1));
-        } catch (Exception err) {
-            Log.w(LOGTAG,"Messed up again: ".concat(err.toString()));
-            la = 0;
-            lo = 0;
+        } catch (NumberFormatException e) {
+            Log.w(LOGTAG,"",e);
+            return;
+        } catch (IndexOutOfBoundsException e) {
+            Log.w(LOGTAG,"",e);
+            return;
         }
-        setLatLonPref(la,lo);
+
+        setLatLonPref(la, lo);
     }
 
     private void setLatLonPref(float la, float lo) {
@@ -89,7 +91,7 @@ public final class Prefs {
         editor.putFloat(LAT_PREF,la);
         editor.putFloat(LON_PREF,lo);
         apply(editor);
-        Log.d(LOGTAG,Float.toString(la).concat(",").concat(Float.toString(lo)));
+        Log.d(LOGTAG, la + "," + lo);
     }
 
     public void setReports(String json) {

--- a/src/org/mozilla/mozstumbler/preferences/Prefs.java
+++ b/src/org/mozilla/mozstumbler/preferences/Prefs.java
@@ -22,6 +22,8 @@ public final class Prefs {
     private static final String     REPORTS_PREF  = "reports";
     private static final String     VALUES_VERSION_PREF = "values_version";
     private static final String     WIFI_ONLY = "wifi_only";
+    private static final String     LAT_PREF = "lat_pref";
+    private static final String     LON_PREF = "lon_pref";
 
     private final Context mContext;
 
@@ -51,6 +53,43 @@ public final class Prefs {
 
     public boolean getWifi() {
         return getBoolPref(WIFI_ONLY);
+    }
+
+    public String getLatLon() {
+        float la=getPrefs().getFloat(LAT_PREF,0);
+        float lo=getPrefs().getFloat(LON_PREF,0);
+        String LatLon = Float.toString(la).concat(",").concat(Float.toString(lo));
+        return LatLon;
+    }
+    public float getLat() {
+        float Lat = getPrefs().getFloat(LAT_PREF,0);
+        return Lat;
+    }
+
+    public float getLon() {
+        float Lon = getPrefs().getFloat(LON_PREF,0);
+        return Lon;
+    }
+    public void setLatLon(String LatLon) {
+        float la = 0;
+        float lo = 0;
+        try {
+            la = Float.parseFloat(LatLon.substring(0,LatLon.indexOf(",")));
+            lo = Float.parseFloat(LatLon.substring(LatLon.lastIndexOf(",")+1));
+        } catch (Exception err) {
+            Log.w(LOGTAG,"Messed up again: ".concat(err.toString()));
+            la = 0;
+            lo = 0;
+        }
+        setLatLonPref(la,lo);
+    }
+
+    private void setLatLonPref(float la, float lo) {
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putFloat(LAT_PREF,la);
+        editor.putFloat(LON_PREF,lo);
+        apply(editor);
+        Log.d(LOGTAG,Float.toString(la).concat(",").concat(Float.toString(lo)));
     }
 
     public void setReports(String json) {


### PR DESCRIPTION
This very basic interface allows to specify a point (in a format of `-10.005,10.02`) around which MozStumbler will not report the results. Exclusion zone is currently defined as +/- 0.01 deg lat/lon.

Geofencing works good :+1:
