### PR TITLE
Poland Koleje Slaskie train hotspot blocklist

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -54,6 +54,7 @@ final class SSIDBlockList {
         "TPE-Free Bus", // Taipei City on-bus WiFi (Taiwan)
         "THSR-VeeTIME", // Taiwan High Speed Rail on-train WiFi
         "CapitalBus", // Capital Bus on-bus WiFi (Taiwan)
+        "Hot-Spot-KS", // Koleje Slaskie transportation services (Poland)
     };
 
     private static final String[] SUFFIX_LIST = {


### PR DESCRIPTION
Koleje Śląskie, local authorities subsidiary railway service in Poland has several trains with wifi hotspots. They are named by "Hot-Spot-KS*" where \* is an rolling stock number.
