### PR TITLE
replaced Mozilla Location Service URL

### DIFF
--- a/src/org/mozilla/mozstumbler/AboutActivity.java
+++ b/src/org/mozilla/mozstumbler/AboutActivity.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.widget.TextView;
 
 public class AboutActivity extends Activity {
-    private static final String ABOUT_PAGE_URL = "https://wiki.mozilla.org/Services/Location/About";
+    private static final String ABOUT_PAGE_URL = "https://location.services.mozilla.com/";
     private static final String ABOUT_MAPBOX_URL = "https://www.mapbox.com/about/maps/";
 
     @Override


### PR DESCRIPTION
Changed Info URL about the Mozilla Location Service and Mozstumbler to the current/new URL to fix #426
