### PR TITLE
Remove batch processing logic from Reporter

### DIFF
--- a/src/org/mozilla/mozstumbler/DateTimeUtils.java
+++ b/src/org/mozilla/mozstumbler/DateTimeUtils.java
@@ -8,7 +8,7 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.TimeZone;
 
-final class DateTimeUtils {
+public final class DateTimeUtils {
     private static final DateFormat sLocaleFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
     private static final DateFormat sISO8601Format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
@@ -26,7 +26,7 @@ final class DateTimeUtils {
         return sISO8601Format.format(date);
     }
 
-    static String formatTime(long time) {
+    public static String formatTime(long time) {
         return formatDate(new Date(time));
     }
 

--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -333,11 +333,6 @@ public final class MainActivity extends FragmentActivity {
                 startActivity(intent);
                 return true;
             case R.id.action_upload_observations:
-                try {
-                    mConnectionRemote.flushReporterBuffer();
-                } catch (RemoteException re) {
-                    Log.i(LOGTAG, "remote exception ", re);
-                }
                 UploadReportsDialog newFragment = new UploadReportsDialog();
                 newFragment.show(getSupportFragmentManager(), "UploadReportsDialog");
                 return true;

--- a/src/org/mozilla/mozstumbler/ScannerService.java
+++ b/src/org/mozilla/mozstumbler/ScannerService.java
@@ -142,11 +142,6 @@ public final class ScannerService extends Service {
             return mScanner.isGeofenced();
         }
 
-        @Override
-        public void flushReporterBuffer() throws RemoteException {
-            mReporter.queueReport(true);
-        }
-
     };
 
     private final class LooperThread extends Thread {

--- a/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
+++ b/src/org/mozilla/mozstumbler/ScannerServiceInterface.aidl
@@ -13,5 +13,4 @@ interface ScannerServiceInterface {
     int getCurrentCellInfoCount();
     boolean isGeofenced();
     void checkPrefs();
-    void flushReporterBuffer();
 }

--- a/src/org/mozilla/mozstumbler/provider/Database.java
+++ b/src/org/mozilla/mozstumbler/provider/Database.java
@@ -12,7 +12,7 @@ import static org.mozilla.mozstumbler.provider.DatabaseContract.*;
 
 public class Database extends SQLiteOpenHelper {
     private static final String LOGTAG = Database.class.getName();
-    private static final int DATABASE_VERSION = 1;
+    private static final int DATABASE_VERSION = 2;
     private static final String DATABASE_NAME = "stumbler.db";
     static final String TABLE_REPORTS = "reports";
     static final String TABLE_STATS = "stats";
@@ -23,14 +23,7 @@ public class Database extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + TABLE_REPORTS + " ("
-                + BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
-                + ReportsColumns.OBSERVATION_COUNT + " INTEGER NOT NULL,"
-                + ReportsColumns.WIFI_COUNT + " INTEGER NOT NULL,"
-                + ReportsColumns.CELL_COUNT + " INTEGER NOT NULL,"
-                + ReportsColumns.RETRY_NUMBER + " INTEGER NOT NULL DEFAULT 0,"
-                + ReportsColumns.REPORT + " BLOB NOT NULL)");
-
+        createTableReports(db);
         db.execSQL("CREATE TABLE " + TABLE_STATS + " ("
                 + BaseColumns._ID + " INTEGER PRIMARY KEY,"
                 + StatsColumns.KEY + " VARCHAR(80) UNIQUE NOT NULL,"
@@ -46,9 +39,34 @@ public class Database extends SQLiteOpenHelper {
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         Log.d(LOGTAG, "onUpgrade() from " + oldVersion + " to " + newVersion);
 
-        if (newVersion != DATABASE_VERSION) {
+        int version = oldVersion;
+        switch (version) {
+            case 1:
+                db.execSQL("DROP TABLE IF EXISTS " + TABLE_REPORTS);
+                createTableReports(db);
+                version = 2;
+        }
+
+        if (version != DATABASE_VERSION) {
             db.execSQL("DROP TABLE IF EXISTS " + TABLE_REPORTS);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_STATS);
             onCreate(db);
         }
+    }
+
+    private void createTableReports(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + TABLE_REPORTS + " ("
+                + BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
+                + ReportsColumns.TIME + " INTEGER NOT NULL,"
+                + ReportsColumns.LAT + " REAL NOT NULL,"
+                + ReportsColumns.LON + " REAL NOT NULL,"
+                + ReportsColumns.ALTITUDE + " INTEGER,"
+                + ReportsColumns.ACCURACY + " INTEGER,"
+                + ReportsColumns.RADIO + " VARCHAR(8) NOT NULL,"
+                + ReportsColumns.CELL + " TEXT NOT NULL,"
+                + ReportsColumns.WIFI + " TEXT NOT NULL,"
+                + ReportsColumns.CELL_COUNT + " INTEGER NOT NULL,"
+                + ReportsColumns.WIFI_COUNT + " INTEGER NOT NULL,"
+                + ReportsColumns.RETRY_NUMBER + " INTEGER NOT NULL DEFAULT 0)");
     }
 }

--- a/src/org/mozilla/mozstumbler/provider/DatabaseContract.java
+++ b/src/org/mozilla/mozstumbler/provider/DatabaseContract.java
@@ -16,8 +16,14 @@ public final class DatabaseContract {
     private static final String PATH_SYNC_STATS = "sync_stats";
 
     interface ReportsColumns {
-        String REPORT = "report";
-        String OBSERVATION_COUNT = "observation_count";
+        String LAT = "lat";
+        String LON = "lon";
+        String TIME = "time";
+        String ACCURACY = "accuracy";
+        String ALTITUDE = "altitude";
+        String RADIO = "radio";
+        String CELL = "cell";
+        String WIFI = "wifi";
         String CELL_COUNT = "cell_count";
         String WIFI_COUNT = "wifi_count";
         String RETRY_NUMBER = "retry";
@@ -41,10 +47,10 @@ public final class DatabaseContract {
                 + "vnd.mozstumbler.reports_summary";
         public static final String DEFAULT_SORT = _ID;
 
-        public static final String TOTAL_REPORT_COUNT = "total_report_count";
         public static final String TOTAL_OBSERVATION_COUNT = "total_observation_count";
         public static final String TOTAL_CELL_COUNT = "total_cell_count";
         public static final String TOTAL_WIFI_COUNT = "total_wifi_count";
+        public static final String MAX_ID = "max_id";
 
         public static Uri buildReportUri(long reportId) {
             return ContentUris.withAppendedId(CONTENT_URI, reportId);


### PR DESCRIPTION
Save each observation as a single row in the database ('Reports' table).

I'm also restored reporting of wifis and cells in one observation, since memory should not be a problem now.
