### PR TITLE
Urgent fix.

### DIFF
--- a/src/org/mozilla/mozstumbler/Reporter.java
+++ b/src/org/mozilla/mozstumbler/Reporter.java
@@ -174,7 +174,9 @@ final class Reporter extends BroadcastReceiver {
             mWifiData.clear();
         }
 
-        mGpsPosition.setTime(System.currentTimeMillis());
+        if (mGpsPosition != null) {
+            mGpsPosition.setTime(System.currentTimeMillis());
+        }
     }
 
     void reportCollectedLocation(Location gpsPosition, Collection<ScanResult> wifiInfo, String radioType,


### PR DESCRIPTION
Prevents a `NullPointerException` happening once in a while.
