### PR TITLE
Block Adelaide Metro Public WiFi

### DIFF
--- a/src/org/mozilla/mozstumbler/BSSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/BSSIDBlockList.java
@@ -22,6 +22,9 @@ final class BSSIDBlockList {
         "7cc537",
         "88c663",
         "8c7712",
+
+         // Adelaide Metro WiFi Network OUIs:
+        "a854b2",
     };
 
     private BSSIDBlockList() {


### PR DESCRIPTION
First reported by @micolous. Closes #458.
Decided to use BSSID instead of SSID due to a relatively common name of the SSID: `PublicWiFi`.
