### PR TITLE
Set upload dialog background to "light"

### DIFF
--- a/res/layout/dialog_upload_observations.xml
+++ b/res/layout/dialog_upload_observations.xml
@@ -8,6 +8,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@android:color/background_light"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
         android:paddingLeft="16dp"

--- a/src/org/mozilla/mozstumbler/UploadReportsDialog.java
+++ b/src/org/mozilla/mozstumbler/UploadReportsDialog.java
@@ -50,6 +50,9 @@ public class UploadReportsDialog extends DialogFragment {
         LayoutInflater inflater = getActivity().getLayoutInflater();
 
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.dialog_upload_observations, null);
+//      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) { // API14+ doesn't need it
+        rootView.setBackgroundResource(android.R.color.background_light);
+//      }
         mLastUpdateTimeView = (TextView) rootView.findViewById(R.id.last_upload_time_value);
         mObservationsSentView = (TextView) rootView.findViewById(R.id.observations_sent_value);
         mCellsSentView = (TextView) rootView.findViewById(R.id.cells_sent_value);

--- a/src/org/mozilla/mozstumbler/UploadReportsDialog.java
+++ b/src/org/mozilla/mozstumbler/UploadReportsDialog.java
@@ -50,9 +50,6 @@ public class UploadReportsDialog extends DialogFragment {
         LayoutInflater inflater = getActivity().getLayoutInflater();
 
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.dialog_upload_observations, null);
-//      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) { // API14+ doesn't need it
-        rootView.setBackgroundResource(android.R.color.background_light);
-//      }
         mLastUpdateTimeView = (TextView) rootView.findViewById(R.id.last_upload_time_value);
         mObservationsSentView = (TextView) rootView.findViewById(R.id.observations_sent_value);
         mCellsSentView = (TextView) rootView.findViewById(R.id.cells_sent_value);


### PR DESCRIPTION
Fixes #441.
It's possible only certain APIs (<14?) are affected by this. But to be on the safe side, we can simply set it here.

 Alternative is the .xml file, but I wanted to preserve the commented out area in case we want to make it API specific at some point.
