### PR TITLE
Only show dialog to enable GPS on program launch

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -135,6 +135,8 @@ public final class MainActivity extends FragmentActivity {
 
         getSupportLoaderManager().initLoader(0, null, mSyncStatsLoaderCallbacks);
 
+        checkGps();
+
         Log.d(LOGTAG, "onCreate");
     }
 
@@ -165,8 +167,6 @@ public final class MainActivity extends FragmentActivity {
     @Override
     protected void onStart() {
         super.onStart();
-
-        checkGps();
 
         mReceiver = new ServiceBroadcastReceiver();
         mReceiver.register();


### PR DESCRIPTION
Show the dialog prompting to enable GPS when the program is launched. Do
not show it when returning back to the main screen.

This is a fix for issue #280.
