### PR TITLE
Fixes to communicator package as suggested by @illarionov

### DIFF
--- a/src/org/mozilla/mozstumbler/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/MapActivity.java
@@ -45,7 +45,6 @@ public final class MapActivity extends Activity {
     private static final String COVERAGE_URL        = "https://location.services.mozilla.com/tiles/";
 
     private MapView mMap;
-    private Context mContext;
 
     private ReporterBroadcastReceiver mReceiver;
 
@@ -154,7 +153,6 @@ public final class MapActivity extends Activity {
         super.onStart();
 
         Context context = getApplicationContext();
-        mContext = context;
         Intent i = new Intent(ScannerService.MESSAGE_TOPIC);
         i.putExtra(Intent.EXTRA_SUBJECT, "Scanner");
         i.putExtra("enable", 1);
@@ -206,7 +204,7 @@ public final class MapActivity extends Activity {
             }
             String data = wrapper.toString();
             byte[] bytes = data.getBytes();
-            Searcher searcher = new Searcher(mContext);
+            Searcher searcher = new Searcher(MapActivity.this);
             if (searcher.cleanSend(bytes)) {
                 mStatus = searcher.getStatus();
                 mLat = searcher.getLat();
@@ -224,11 +222,11 @@ public final class MapActivity extends Activity {
             if (STATUS_OK.equals(mStatus)) {
                 positionMapAt(mLat, mLon);
             } else if (STATUS_NOT_FOUND.equals(mStatus)) {
-                Toast.makeText(mContext,
+                Toast.makeText(MapActivity.this,
                         getResources().getString(R.string.location_not_found),
                         Toast.LENGTH_LONG).show();
             } else {
-                Toast.makeText(mContext,
+                Toast.makeText(MapActivity.this,
                         getResources().getString(R.string.location_lookup_error),
                         Toast.LENGTH_LONG).show();
                 Log.e(LOGTAG, "", new IllegalStateException("mStatus=" + mStatus));

--- a/src/org/mozilla/mozstumbler/communicator/AbstractCommunicator.java
+++ b/src/org/mozilla/mozstumbler/communicator/AbstractCommunicator.java
@@ -104,6 +104,8 @@ abstract class AbstractCommunicator {
             sendData(zipData(data));
         } catch (IOException e) {
             Log.e(LOGTAG, "Couldn't compress and send data, falling back to plain-text: ", e);
+            close();
+            setHeaders();
             sendData(data);
         }
     }

--- a/src/org/mozilla/mozstumbler/communicator/Submitter.java
+++ b/src/org/mozilla/mozstumbler/communicator/Submitter.java
@@ -1,6 +1,7 @@
 package org.mozilla.mozstumbler.communicator;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.apache.http.conn.ConnectTimeoutException;
 import org.mozilla.mozstumbler.preferences.Prefs;
@@ -10,9 +11,9 @@ import java.net.HttpURLConnection;
 
 public class Submitter extends AbstractCommunicator {
     private static final String SUBMIT_URL = "https://location.services.mozilla.com/v1/submit";
+    private static final String LOGTAG = Submitter.class.getName();
     private static final int CORRECT_RESPONSE = HttpURLConnection.HTTP_NO_CONTENT;
     private final String mNickname;
-    private boolean isTemp = false;
 
     public Submitter(Context ctx) {
         super(ctx);
@@ -39,12 +40,9 @@ public class Submitter extends AbstractCommunicator {
             this.send(data);
             result = true;
         } catch (IOException ex) {
-            isTemp = true;
+            Log.e(LOGTAG,"Error submitting: ", ex);
         }
         return result;
     }
 
-    public boolean isErrorTemporary() {
-        return isTemp;
-    }
 }

--- a/src/org/mozilla/mozstumbler/communicator/Submitter.java
+++ b/src/org/mozilla/mozstumbler/communicator/Submitter.java
@@ -38,15 +38,8 @@ public class Submitter extends AbstractCommunicator {
         try {
             this.send(data);
             result = true;
-        } catch (HttpErrorException ex) {
-            if (ex.isTemporary())
-            {
-                isTemp = true;
-            }
-        } catch (ConnectTimeoutException ex) {
-            isTemp = true;
         } catch (IOException ex) {
-            isTemp = false;
+            isTemp = true;
         }
         return result;
     }

--- a/src/org/mozilla/mozstumbler/sync/SyncAdapter.java
+++ b/src/org/mozilla/mozstumbler/sync/SyncAdapter.java
@@ -38,7 +38,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
     private static final String LOGTAG = SyncAdapter.class.getName();
     private static final boolean DBG = BuildConfig.DEBUG;
-    private final Context mContext;
     private static final int REQUEST_BATCH_SIZE = 50;
     private static final int MAX_RETRY_COUNT = 3;
 
@@ -66,7 +65,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 
     public SyncAdapter(Context context, boolean autoInitialize) {
         super(context, autoInitialize);
-        mContext = context;
         mPrefs = new Prefs(context);
         mContentResolver = context.getContentResolver();
     }
@@ -82,7 +80,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             boolean autoInitialize,
             boolean allowParallelSyncs) {
         super(context, autoInitialize, allowParallelSyncs);
-        mContext = context;
         mPrefs = new Prefs(context);
         mContentResolver = context.getContentResolver();
     }
@@ -112,7 +109,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
                 .build();
         queueMinId = 0;
         queueMaxId = getMaxId();
-        Submitter submitter = new Submitter(mContext);
+        Submitter submitter = new Submitter(getContext());
         for (; queueMinId < queueMaxId; ) {
             BatchRequestStats batch = null;
             Cursor cursor = mContentResolver.query(uri, null,
@@ -122,27 +119,32 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             if (cursor == null) {
                 break;
             }
-            batch = getRequestBody(cursor);
-            if (batch == null) {
-                break;
-            }
 
-            if (submitter.cleanSend(batch.body)) {
-                deleteObservations(batch.minId, batch.maxId);
-                uploadedObservations += batch.observations;
-                uploadedWifis += batch.wifis;
-                uploadedCells += batch.cells;
-            } else {
-                syncResult.stats.numIoExceptions += 1;
-                if (submitter.isErrorTemporary()) {
-                   increaseRetryCounter(cursor, syncResult);
-                } else {
-                    deleteObservations(batch.minId, batch.maxId);
+            try {
+                batch = getRequestBody(cursor);
+                if (batch == null) {
+                    break;
                 }
-            }
-            submitter.close();
 
-            cursor.close();
+
+                if (submitter.cleanSend(batch.body)) {
+                    deleteObservations(batch.minId, batch.maxId);
+                    uploadedObservations += batch.observations;
+                    uploadedWifis += batch.wifis;
+                    uploadedCells += batch.cells;
+                } else {
+                    syncResult.stats.numIoExceptions += 1;
+                    if (submitter.isErrorTemporary()) {
+                        increaseRetryCounter(cursor, syncResult);
+                    } else {
+                        deleteObservations(batch.minId, batch.maxId);
+                    }
+                }
+            } finally {
+                cursor.close();
+                submitter.close();
+            }
+
             if (batch != null) {
                 queueMinId = batch.maxId;
             } else {

--- a/src/org/mozilla/mozstumbler/sync/SyncAdapter.java
+++ b/src/org/mozilla/mozstumbler/sync/SyncAdapter.java
@@ -134,11 +134,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
                     uploadedCells += batch.cells;
                 } else {
                     syncResult.stats.numIoExceptions += 1;
-                    if (submitter.isErrorTemporary()) {
-                        increaseRetryCounter(cursor, syncResult);
-                    } else {
-                        deleteObservations(batch.minId, batch.maxId);
-                    }
+                    increaseRetryCounter(cursor, syncResult);
                 }
             } finally {
                 cursor.close();


### PR DESCRIPTION
Fixes to communicator package as suggested by @illarionov …
- Changing context scope.
- Moving closing cursor and submitter command into `finally{}`
- Deciding that all `IOException` can be temporary (reduces data discarding).
- Cleanup if gzip fails: the `AbstractCommunicator` has to clean up first.
