### PR TITLE
Update SSIDBlockList.java

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -61,9 +61,9 @@ final class SSIDBlockList {
         "Telekom_ICE", // Deutsche Bahn on-train WiFi
         "TPE-Free Bus", // Taipei City on-bus WiFi (Taiwan)
         "THSR-VeeTIME", // Taiwan High Speed Rail on-train WiFi
-        "tmobile", //Nederlandse Spoorwegen on-train WiFi by T-Mobile (Netherlands)
         "TriangleTransitWiFi_", // Triangle Transit on-bus WiFi
         "VR-junaverkko", // VR on-train WiFi (Finland)
+        "WiFi in de trein", //Nederlandse Spoorwegen on-train WiFi (Netherlands)
     };
 
     private static final String[] SUFFIX_LIST = {


### PR DESCRIPTION
Rename of NS train wifi (source: http://tweakers.net/nieuws/95116/ns-neemt-wifi-in-de-trein-over-van-t-mobile.html)
