### PR TITLE
Change leaderboard link to jump to the user

### DIFF
--- a/src/org/mozilla/mozstumbler/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/MainActivity.java
@@ -329,7 +329,10 @@ public final class MainActivity extends FragmentActivity {
                 startActivity(new Intent(getApplication(), PreferencesScreen.class));
                 return true;
             case R.id.action_view_leaderboard:
-                Intent openLeaderboard = new Intent(Intent.ACTION_VIEW, Uri.parse(LEADERBOARD_URL));
+                Uri.Builder builder = Uri.parse(LEADERBOARD_URL).buildUpon();
+                builder.fragment(mPrefs.getNickname());
+                Uri leaderboardUri = builder.build();
+                Intent openLeaderboard = new Intent(Intent.ACTION_VIEW, leaderboardUri);
                 startActivity(openLeaderboard);
                 return true;
             case R.id.action_test_mls:


### PR DESCRIPTION
Add the user's nickname as the fragment of the URL, i.e.
https://location.services.mozilla.com/leaders#divergentdave. This fixes
mozilla/Mozstumbler#561.
