### PR TITLE
Disable hardware acceleration to reduce memory usage

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -33,7 +33,8 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:supportsRtl="true" >
+        android:supportsRtl="true"
+        android:hardwareAccelerated="false" >
         <activity
             android:name="org.mozilla.mozstumbler.MainActivity"
             android:label="@string/app_name" >
@@ -49,8 +50,7 @@
 
         <activity
             android:name="org.mozilla.mozstumbler.MapActivity"
-            android:label="@string/app_name"
-            android:hardwareAccelerated="false" >
+            android:label="@string/app_name" >
         </activity>
 
         <activity


### PR DESCRIPTION
This significantly reduces initial memory usage. From 29MB to 5MB on Nexus 5
