### PR TITLE
Add quickshuttle_

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -79,6 +79,7 @@ final class SSIDBlockList {
         "Oxford Tube", // Oxford Tube on-bus WiFi (United Kindom)
         "PostAuto", // Swiss municipial busses on-bus WiFi (German speaking part)
         "QbuzzWIFI", //Qbuzz on-bus WiFi (Netherlands)
+        "quickshuttle_", //Quick Shuttle on-bus WiFi (United States WA/Canada BC) 
         "SF Shuttle Wireless",
         "ShuttleWiFi",
         "Southwest WiFi", // Southwest Airlines in-flight WiFi


### PR DESCRIPTION
Observed a "Quick Shuttle" bus on road with complimentary wireless internet access advertised on its side traversing [an intersection near Seattle Premium Outlets](http://www.openstreetmap.org/node/50751933). Checked [WiGLE stumbler](https://github.com/wiglenet/wigle-wifi-wardriving) (already running) and saw "quickshuttle_1705" SSID in list.
See http://www.quickcoach.com/schedule.htm for service area.
