### PR TITLE
Determine whether the cell location is updated when the screen is off

### DIFF
--- a/src/org/mozilla/mozstumbler/cellscanner/DefaultCellScanner.java
+++ b/src/org/mozilla/mozstumbler/cellscanner/DefaultCellScanner.java
@@ -33,6 +33,7 @@ public class DefaultCellScanner implements CellScanner.CellScannerImpl {
 
     private static final GetAllCellInfoScannerImpl sGetAllInfoCellScanner;
 
+    private final ScreenMonitor mScreenMonitor;
     private final TelephonyManager mTelephonyManager;
 
     private final int mPhoneType;
@@ -66,6 +67,8 @@ public class DefaultCellScanner implements CellScanner.CellScannerImpl {
         }
         mSignalStrength = CellInfo.UNKNOWN_SIGNAL;
         mCdmaDbm = CellInfo.UNKNOWN_SIGNAL;
+
+        mScreenMonitor = new ScreenMonitor(context);
     }
 
     @Override
@@ -73,11 +76,13 @@ public class DefaultCellScanner implements CellScanner.CellScannerImpl {
         mSignalStrength = CellInfo.UNKNOWN_SIGNAL;
         mCdmaDbm = CellInfo.UNKNOWN_SIGNAL;
         mTelephonyManager.listen(mPhoneStateListener, PhoneStateListener.LISTEN_SIGNAL_STRENGTHS);
+        mScreenMonitor.start();
     }
 
     @Override
     public void stop() {
         mTelephonyManager.listen(mPhoneStateListener, PhoneStateListener.LISTEN_NONE);
+        mScreenMonitor.stop();
         mSignalStrength = CellInfo.UNKNOWN_SIGNAL;
         mCdmaDbm = CellInfo.UNKNOWN_SIGNAL;
     }
@@ -116,6 +121,10 @@ public class DefaultCellScanner implements CellScanner.CellScannerImpl {
         final CellLocation currentCell;
         currentCell = mTelephonyManager.getCellLocation();
         if (currentCell == null) {
+            return null;
+        }
+        mScreenMonitor.putLocation(currentCell);
+        if (!mScreenMonitor.isLocationValid()) {
             return null;
         }
         try {

--- a/src/org/mozilla/mozstumbler/cellscanner/ScreenMonitor.java
+++ b/src/org/mozilla/mozstumbler/cellscanner/ScreenMonitor.java
@@ -1,0 +1,112 @@
+package org.mozilla.mozstumbler.cellscanner;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.os.PowerManager;
+import android.telephony.CellLocation;
+import android.util.Log;
+
+import org.mozilla.mozstumbler.BuildConfig;
+
+/**
+ * Determine whether the cell location is updated when the screen is off
+ * https://code.google.com/p/android/issues/detail?id=10931
+ */
+public class ScreenMonitor {
+    private static final String LOGTAG = "ScreenOffWorkaround";
+    private static final boolean DBG = BuildConfig.DEBUG;
+
+    private static final String PREFS_FILE = ScreenMonitor.class.getName();
+    private static final String LOCATION_UPDATES_COUNT_PREF = "location_updates_count";
+    private static final long FIRST_LOCATION_MIN_TIME_MS = 2000;
+    private static final long NO_DATA = -1;
+
+    private final Context mContext;
+
+    private boolean mScreenIsOn;
+    private long mLocationUpdatesCount = NO_DATA;
+    private long mFirstChangeTimestamp;
+
+    private CellLocation mCellLocation;
+
+    public ScreenMonitor(Context context) {
+        mContext = context;
+    }
+
+    public void start() {
+        load();
+        PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+        mScreenIsOn = pm.isScreenOn();
+        Log.i(LOGTAG, "Total cell location updates when the screen is off: " +
+                (mLocationUpdatesCount == NO_DATA ? " no data" : mLocationUpdatesCount));
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_SCREEN_ON);
+        mContext.registerReceiver(mScreenReceiver, filter);
+    }
+
+    public void putLocation(CellLocation location) {
+        if (mScreenIsOn) return;
+
+        if (mFirstChangeTimestamp != 0) {
+            if (Math.abs(System.nanoTime() - mFirstChangeTimestamp) > FIRST_LOCATION_MIN_TIME_MS * 1e6) {
+                Log.i(LOGTAG, "Received the first cell location update when the screen is off");
+                mLocationUpdatesCount = 1;
+                mFirstChangeTimestamp = 0;
+            }
+        }
+
+        if (mCellLocation == null) {
+            mCellLocation = location;
+            if (mLocationUpdatesCount < 0) mLocationUpdatesCount = 0;
+        } else if (!mCellLocation.equals(location)) {
+            mCellLocation = location;
+            if (mFirstChangeTimestamp == 0) {
+                if (mLocationUpdatesCount <= 0) {
+                    mFirstChangeTimestamp = System.nanoTime();
+                    mLocationUpdatesCount = 0;
+                } else {
+                    mLocationUpdatesCount += 1;
+                }
+            }
+        }
+    }
+
+    public boolean isLocationValid() {
+        return mScreenIsOn || (mLocationUpdatesCount > 0);
+    }
+
+    public void stop() {
+        mContext.unregisterReceiver(mScreenReceiver);
+        persist();
+    }
+
+    private void persist() {
+        mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+                .edit()
+                .putLong(LOCATION_UPDATES_COUNT_PREF, mLocationUpdatesCount)
+                .commit();
+    }
+
+    private void load() {
+        SharedPreferences prefs = mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+        mLocationUpdatesCount = prefs.getLong(LOCATION_UPDATES_COUNT_PREF, NO_DATA);
+    }
+
+    final BroadcastReceiver mScreenReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                mScreenIsOn = false;
+                mCellLocation = null;
+            } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
+                mScreenIsOn = true;
+                mFirstChangeTimestamp = 0;
+                mCellLocation = null;
+            }
+        }
+    };
+}


### PR DESCRIPTION
I found that some phones do not update the current сell location when display is off. The `mTelephonyManager.getCellLocation()` returns the same value until the screen is turned on, though, in fact, the current cell changes. 
If you go with such phone at a high speed for a long time, the phone incorrectly reports signal from the cell tower over the long distance.
My solution is to watch for changes when the screen is off and do not take into account cell location data until it is at-least one change.
Related bug: https://code.google.com/p/android/issues/detail?id=10931
