### PR TITLE
Update SSIDBlockList.java

### DIFF
--- a/src/org/mozilla/mozstumbler/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/SSIDBlockList.java
@@ -71,7 +71,7 @@ final class SSIDBlockList {
         "KOLUMBUS", // Stavanger public transport on-bus WiFi (Norway)
         "Kystbussen_Kundennett", // Kystbussen on-bus WiFi (Norway)
         "MAVSTART-WiFi", // Hungarian State Railways onboard hotspot on InterCity trains (Hungary)
-        "MeinFernbus-", // MeinFernbus on-bus WiFi (Germany)
+        "MeinFernbus", // MeinFernbus on-bus WiFi (Germany)
         "Nateev-WiFi", // Nateev Express transportation services (Israel)
         "NationalExpress", // National Express on-bus WiFi (United Kingdom)
         "Norgesbuss", // Norgesbuss on-bus WiFi (Norway)


### PR DESCRIPTION
I encountered the SSIDs "MeinFernbus1" and "MeinFernbus2" recently. There is no ambiguity without the "-" as Fernbus means "long distance bus" in german.
