### PR TITLE
Add DeinBus on-bus WiFi (Germany)

### DIFF
--- a/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
@@ -37,6 +37,7 @@ public final class SSIDBlockList {
         "Mobile Hotspot", // BlackBerry OS 10
 
         // Transportation Wi-Fi
+        ".DeinBus.de", // DeinBus on-bus WiFi (Germany)
         "ac_transit_wifi_bus",
         "ADAC_Postbus", // ADAC Postbus on-bus WiFi (Germany)
         "Afifi", // Nazareen express transportation services (Israel)


### PR DESCRIPTION
The full SSID is ".DeinBus.de-Datenautobahn".
