### PR TITLE
Android Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 .gradle
 .settings
+.idea
+*.iml
 assets
 bin
 gen

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
     }
 }
 
@@ -17,12 +17,12 @@ repositories {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.0.3'
+    buildToolsVersion '19.1.0'
 
     dependencies {
         compile "org.osmdroid:osmdroid-android:4.1"
         compile 'org.slf4j:slf4j-android:1.7.7'
-        compile "com.android.support:support-v4:19.0.+"
+        compile "com.android.support:support-v4:19.1.+"
     }
 
     sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 07 00:40:13 EST 2014
+#Thu Jun 19 18:58:26 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
This will block on Travis upgrading to the Android Build tools version 19.1.0.

Upgrades to gradle, gradle android plugin, and android build tools. Required for Android Studio 0.6+

Also ignore AS files (.idea and .iml)
