### PR TITLE
Followup to #639: Fix lifespan of CellScanner

### DIFF
--- a/src/org/mozilla/mozstumbler/client/DefaultCellScanner.java
+++ b/src/org/mozilla/mozstumbler/client/DefaultCellScanner.java
@@ -6,6 +6,9 @@ import android.telephony.CellIdentityWcdma;
 import android.telephony.CellInfoWcdma;
 import android.telephony.CellSignalStrengthWcdma;
 import android.telephony.TelephonyManager;
+import android.util.Log;
+
+import org.mozilla.mozstumbler.service.SharedConstants;
 import org.mozilla.mozstumbler.service.scanners.cellscanner.CellInfo;
 import org.mozilla.mozstumbler.service.scanners.cellscanner.CellScannerNoWCDMA;
 import java.util.List;
@@ -14,6 +17,7 @@ public class DefaultCellScanner extends CellScannerNoWCDMA {
 
     public DefaultCellScanner(Context context) {
         super(context);
+        LOGTAG = DefaultCellScanner.class.getName();
     }
 
     @TargetApi(18)
@@ -34,6 +38,9 @@ public class DefaultCellScanner extends CellScannerNoWCDMA {
                         strength.getAsuLevel());
                 cells.add(cell);
                 added = true;
+            }
+            else {
+                if (SharedConstants.isDebug) Log.d(LOGTAG, String.format("Invalid-> mnc:%d mcc:%d", ident.getMnc(), ident.getMcc()));
             }
         }
         if (!added) {

--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -133,8 +133,6 @@ public final class MainActivity extends FragmentActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        CellScanner.setCellScannerClass(new DefaultCellScanner(this), true);
-
         sLogMessageReceiver.register(this);
 
         if (SharedConstants.isDebug) enableStrictMode();
@@ -462,11 +460,15 @@ public final class MainActivity extends FragmentActivity {
     };
 
     private void startScanning() {
+        if (!mConnectionRemote.isScanning()) {
+            CellScanner.setCellScannerClass(new DefaultCellScanner(this));
+        }
         mConnectionRemote.startForeground(NOTIFICATION_ID, buildNotification());
         mConnectionRemote.startScanning();
     }
 
     private void stopScanning() {
+        CellScanner.setCellScannerClass(null);
         mConnectionRemote.stopForeground(true);
         mConnectionRemote.stopScanning();
     }

--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -114,7 +114,7 @@ public final class StumblerService extends Service {
         Prefs.createGlobalInstance(this);
         NetworkUtils.createGlobalInstance(this);
 
-        CellScanner.setCellScannerClass(new CellScannerNoWCDMA(this), false);
+        CellScanner.setCellScannerClass(new CellScannerNoWCDMA(this));
         mScanner = new Scanner(this);
         mReporter = new Reporter(this, mStumblerBundleReceiver);
 

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScanner.java
@@ -46,10 +46,7 @@ public class CellScanner {
     }
 
     /** Fennec doesn't support the apis needed for full scanning, we have different implementations.*/
-    public static void setCellScannerClass(CellScannerImpl cellScanner, boolean overrideExisting) {
-        if (!overrideExisting && sImpl != null)
-            return;
-
+    public static void setCellScannerClass(CellScannerImpl cellScanner) {
         sImpl = cellScanner;
     }
 

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScannerNoWCDMA.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScannerNoWCDMA.java
@@ -26,7 +26,7 @@ import java.util.List;
 /** Fennec does not yet support the api level for WCDMA import */
 public class CellScannerNoWCDMA implements CellScanner.CellScannerImpl {
 
-    protected static final String LOGTAG = CellScannerNoWCDMA.class.getName();
+    protected static String LOGTAG = CellScannerNoWCDMA.class.getName();
 
     protected  GetAllCellInfoScannerImpl mGetAllInfoCellScanner;
 


### PR DESCRIPTION
Fix for https://github.com/mozilla/MozStumbler/pull/639.

Introduced memory error, as by design both the service and the client are trying to create a cell scanner.
Create cell scanner in MainActivity startscanning, clear it on stopscanning. This is guaranteed to override the creation in the service, which creates the NoWCDMA scanner by default.

A further note on this split. It only makes sense in the context of Fennec, and for someone who wants to use the service on its own (as it is now designed) on SDK level 18, they won't get wcdma scanning, which is dumb. It won't be here for long in this form, please tolerate it for the time being.
