### PR TITLE
Switch from osmdroid 4.1 to mapbox-android-sdk 0.3.0

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="0.20.5" >
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="9"
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,12 @@ android {
     buildToolsVersion '19.1.0'
 
     dependencies {
-        compile "org.osmdroid:osmdroid-android:4.1"
-        compile 'org.slf4j:slf4j-android:1.7.7'
+        compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.3.0@aar'){
+            transitive=true
+        }
+        compile ('com.cocoahero.android:geojson:1.0.0@aar'){
+            transitive=true
+        }
         compile "com.android.support:support-v4:19.1.+"
     }
 

--- a/res/layout/activity_map.xml
+++ b/res/layout/activity_map.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MapActivity" >
-    <org.osmdroid.views.MapView
+    <com.mapbox.mapboxsdk.views.MapView
                  android:id="@+id/map"
                  android:layout_width="match_parent"
                  android:layout_height="match_parent"

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -2,6 +2,8 @@ package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -11,7 +13,9 @@ import android.view.Window;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.overlay.GpsLocationProvider;
+import com.mapbox.mapboxsdk.overlay.TilesOverlay;
 import com.mapbox.mapboxsdk.overlay.UserLocationOverlay;
+import com.mapbox.mapboxsdk.tileprovider.MapTileLayerBasic;
 import com.mapbox.mapboxsdk.tileprovider.tilesource.MapboxTileLayer;
 import com.mapbox.mapboxsdk.tileprovider.tilesource.TileLayer;
 import com.mapbox.mapboxsdk.tileprovider.tilesource.WebSourceTileLayer;
@@ -38,8 +42,11 @@ public final class MapActivity extends Activity {
         setContentView(R.layout.activity_map);
 
         mMap = (MapView) this.findViewById(R.id.map);
-        mMap.setTileSource(mlsCoverageTileLayer());
-        mMap.addTileSource(getTileSource());
+        mMap.setTileSource(getTileSource());
+
+        TilesOverlay coverageTilesOverlay = mlsCoverageTilesOverlay(this, mMap);
+        mMap.getOverlays().add(coverageTilesOverlay);
+
         mUserLocationOverlay = addLocationOverlay(this, mMap);
 
         float zoomLevel = 13; // Default to the max that the Coverage Map provides
@@ -106,6 +113,13 @@ public final class MapActivity extends Activity {
             return openStreetMapTileLayer();
         }
         return new MapboxTileLayer(BuildConfig.TILE_SERVER_URL);
+    }
+
+    private static TilesOverlay mlsCoverageTilesOverlay(Context context, MapView mapView) {
+        final MapTileLayerBasic coverageTileProvider = new MapTileLayerBasic(context, mlsCoverageTileLayer(), mapView);
+        final TilesOverlay coverageTileOverlay = new TilesOverlay(coverageTileProvider);
+        coverageTileOverlay.setLoadingBackgroundColor(Color.TRANSPARENT);
+        return coverageTileOverlay;
     }
 
     private static TileLayer openStreetMapTileLayer() {

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -2,101 +2,34 @@ package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Point;
-import android.net.wifi.ScanResult;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.Window;
-import android.widget.Toast;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.mozilla.mozstumbler.service.blocklist.BSSIDBlockList;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.overlay.GpsLocationProvider;
+import com.mapbox.mapboxsdk.overlay.UserLocationOverlay;
+import com.mapbox.mapboxsdk.tileprovider.tilesource.MapboxTileLayer;
+import com.mapbox.mapboxsdk.tileprovider.tilesource.TileLayer;
+import com.mapbox.mapboxsdk.tileprovider.tilesource.WebSourceTileLayer;
+import com.mapbox.mapboxsdk.views.MapView;
+
 import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.R;
-import org.mozilla.mozstumbler.client.MainActivity;
-import org.mozilla.mozstumbler.service.scanners.WifiScanner;
-import org.mozilla.mozstumbler.service.scanners.cellscanner.CellInfo;
-import org.mozilla.mozstumbler.service.scanners.cellscanner.CellScanner;
-import org.osmdroid.tileprovider.BitmapPool;
-import org.osmdroid.tileprovider.MapTileProviderBasic;
-import org.osmdroid.tileprovider.tilesource.ITileSource;
-import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
-import org.osmdroid.tileprovider.tilesource.XYTileSource;
-import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.MapView;
-import org.osmdroid.views.overlay.ItemizedIconOverlay;
-import org.osmdroid.views.overlay.ItemizedOverlay;
-import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
-import org.osmdroid.views.overlay.OverlayItem;
-import org.osmdroid.views.overlay.SafeDrawOverlay;
-import org.osmdroid.views.overlay.TilesOverlay;
-import org.osmdroid.views.safecanvas.ISafeCanvas;
-import org.osmdroid.views.safecanvas.SafePaint;
 
 public final class MapActivity extends Activity {
     private static final String LOGTAG = MapActivity.class.getName();
 
-    private static final String STATUS_OK           = "ok";
-    private static final String STATUS_NOT_FOUND    = "not_found";
-    private static final String STATUS_FAILED       = "failed";
-    private static final String COVERAGE_URL        = "https://location.services.mozilla.com/tiles/";
+    private static final String COVERAGE_URL = "https://location.services.mozilla.com/tiles/{z}/{x}/{y}.png";
     private static final int MENU_REFRESH           = 1;
-    private static final int MAX_ZOOM_NEEDED        = 17;
-    private static final float ZOOM_SCALE_FACT      = -0.0002f;
+    private static final String CENTER_KEY = "center";
+    private static final String ZOOM_KEY = "zoom";
 
     private MapView mMap;
-    private AccuracyCircleOverlay mAccuracyOverlay;
-    private ItemizedOverlay<OverlayItem> mPointOverlay;
-
-    private ReporterBroadcastReceiver mReceiver;
-
-    private List<ScanResult> mWifiData;
-    private List<CellInfo> mCellData;
-
-    private class ReporterBroadcastReceiver extends BroadcastReceiver {
-        private boolean mDone;
-
-        public void reset()
-        {
-            mMap.getOverlays().remove(mAccuracyOverlay);
-            mMap.getOverlays().remove(mPointOverlay);
-            mDone = false;
-        }
-
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            if (mDone) {
-                return;
-            }
-
-            String action = intent.getAction();
-
-            if (action.equals(WifiScanner.ACTION_WIFIS_SCANNED)) {
-                mWifiData = intent.getParcelableArrayListExtra(WifiScanner.ACTION_WIFIS_SCANNED_ARG_RESULTS);
-            } else if (action.equals(CellScanner.ACTION_CELLS_SCANNED)) {
-                mCellData = intent.getParcelableArrayListExtra(CellScanner.ACTION_CELLS_SCANNED_ARG_CELLS);
-            }
-
-            new GetLocationAndMapItTask().execute("");
-            mDone = true;
-        }
-    }
+    private UserLocationOverlay mUserLocationOverlay;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -104,26 +37,43 @@ public final class MapActivity extends Activity {
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         setContentView(R.layout.activity_map);
 
-        mWifiData = Collections.emptyList();
-
         mMap = (MapView) this.findViewById(R.id.map);
-        mMap.setTileSource(getTileSource());
-        mMap.setBuiltInZoomControls(true);
-        mMap.setMultiTouchControls(true);
+        mMap.setTileSource(mlsCoverageTileLayer());
+        mMap.addTileSource(getTileSource());
+        mUserLocationOverlay = addLocationOverlay(this, mMap);
 
-        TilesOverlay coverageTilesOverlay = CoverageTilesOverlay(this);
-        mMap.getOverlays().add(coverageTilesOverlay);
-
-        mReceiver = new ReporterBroadcastReceiver();
-        IntentFilter intentFilter = new IntentFilter();
-        intentFilter.addAction(WifiScanner.ACTION_WIFIS_SCANNED);
-        intentFilter.addAction(CellScanner.ACTION_CELLS_SCANNED);
-        LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver,
-                intentFilter);
-
-        mMap.getController().setZoom(2);
+        float zoomLevel = 13; // Default to the max that the Coverage Map provides
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey(CENTER_KEY)) {
+                LatLng center = savedInstanceState.getParcelable(CENTER_KEY);
+                if (center != null) {
+                    mMap.setCenter(center);
+                }
+            }
+            if (savedInstanceState.containsKey(ZOOM_KEY)) {
+                zoomLevel = savedInstanceState.getFloat(ZOOM_KEY);
+            }
+        }
+        mMap.setZoom(zoomLevel);
 
         Log.d(LOGTAG, "onCreate");
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        bundle.putParcelable(CENTER_KEY, mMap.getCenter());
+        bundle.putFloat(ZOOM_KEY, mMap.getZoomLevel());
+    }
+
+    private static UserLocationOverlay addLocationOverlay(Activity activity, MapView mapView) {
+        UserLocationOverlay userLocationOverlay = new UserLocationOverlay(
+                new GpsLocationProvider(activity), mapView);
+        userLocationOverlay.enableMyLocation();
+        userLocationOverlay.setDrawAccuracyEnabled(true);
+        mapView.setCenter(userLocationOverlay.getMyLocation());
+        mapView.getOverlays().add(userLocationOverlay);
+        return userLocationOverlay;
     }
 
     @TargetApi(11)
@@ -141,9 +91,8 @@ public final class MapActivity extends Activity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case MENU_REFRESH:
-                if (mReceiver != null) {
-                    mReceiver.reset();
-                    setProgressBarIndeterminateVisibility(true);
+                if (mUserLocationOverlay != null) {
+                    mMap.setCenter(mUserLocationOverlay.getMyLocation());
                     return true;
                 }
                 return false;
@@ -152,185 +101,26 @@ public final class MapActivity extends Activity {
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
-    private static OnlineTileSourceBase getTileSource() {
+    private static TileLayer getTileSource() {
         if (BuildConfig.TILE_SERVER_URL == null) {
-            return TileSourceFactory.DEFAULT_TILE_SOURCE;
+            return openStreetMapTileLayer();
         }
-        return new XYTileSource("MozStumbler Tile Store",
-                                null,
-                                1, 20, 256,
-                                ".png",
-                                new String[] { BuildConfig.TILE_SERVER_URL });
+        return new MapboxTileLayer(BuildConfig.TILE_SERVER_URL);
     }
 
-    private static TilesOverlay CoverageTilesOverlay(Context context) {
-        final MapTileProviderBasic coverageTileProvider = new MapTileProviderBasic(context);
-        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
-                null,
-                1, 13, 256,
-                ".png",
-                new String[] { COVERAGE_URL });
-        coverageTileProvider.setTileSource(coverageTileSource);
-        final TilesOverlay coverageTileOverlay = new TilesOverlay(coverageTileProvider,context);
-        coverageTileOverlay.setLoadingBackgroundColor(Color.TRANSPARENT);
-        return coverageTileOverlay;
+    private static TileLayer openStreetMapTileLayer() {
+        return new WebSourceTileLayer("openstreetmap",
+                "http://tile.openstreetmap.org/{z}/{x}/{y}.png").setName("OpenStreetMap")
+                .setAttribution("© OpenStreetMap Contributors")
+                .setMinimumZoomLevel(1)
+                .setMaximumZoomLevel(18);
     }
 
-    private void positionMapAt(float lat, float lon, float accuracy) {
-        GeoPoint point = new GeoPoint(lat, lon);
-        int zoomLevel = Math.round(accuracy*ZOOM_SCALE_FACT+MAX_ZOOM_NEEDED);
-        if (zoomLevel < 0) {
-            zoomLevel = 0;
-        } else if (zoomLevel > MAX_ZOOM_NEEDED) {
-            zoomLevel = MAX_ZOOM_NEEDED; // this code will only execute if accuracy is negative, which "should" never happen...
-        }
-        mMap.getController().setZoom(zoomLevel);
-        mMap.getController().animateTo(point);
-        mPointOverlay = getMapMarker(point);
-        mAccuracyOverlay = new AccuracyCircleOverlay(MapActivity.this, point, accuracy);
-        mMap.getOverlays().add(mPointOverlay); // You are here!
-        mMap.getOverlays().add(mAccuracyOverlay);
-        mMap.invalidate();
-    }
-
-    private static class AccuracyCircleOverlay extends SafeDrawOverlay {
-        private GeoPoint mPoint;
-        private float mAccuracy;
-
-        public AccuracyCircleOverlay(Context ctx, GeoPoint point, float accuracy) {
-            super(ctx);
-            //this.mPoint = (GeoPoint) point.clone();
-            this.mPoint = point;
-            this.mAccuracy = accuracy;
-        }
-
-        protected void drawSafe(ISafeCanvas c, MapView osmv, boolean shadow) {
-            if (shadow || mPoint == null) {
-                return;
-            }
-            MapView.Projection pj = osmv.getProjection();
-            Point center = pj.toPixels(mPoint, null);
-            float radius = pj.metersToEquatorPixels(mAccuracy);
-            SafePaint circle = new SafePaint();
-            circle.setARGB(0, 100, 100, 255);
-
-            // Fill
-            circle.setAlpha(40);
-            circle.setStyle(Paint.Style.FILL);
-            c.drawCircle(center.x, center.y, radius, circle);
-
-            // Border
-            circle.setAlpha(165);
-            circle.setStyle(Paint.Style.STROKE);
-            c.drawCircle(center.x, center.y, radius, circle);
-        }
-    }
-
-    private ItemizedOverlay<OverlayItem> getMapMarker(GeoPoint point) {
-        ArrayList<OverlayItem> items = new ArrayList<OverlayItem>();
-        items.add(new OverlayItem(null, null, point));
-        return new ItemizedOverlayWithFocus<OverlayItem>(
-            MapActivity.this,
-            items,
-            new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
-                @Override
-                public boolean onItemSingleTapUp(int index, OverlayItem item) { return false; }
-                @Override
-                public boolean onItemLongPress(int index, OverlayItem item) { return false; }
-            });
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-
-        Intent i = new Intent(MainActivity.ACTION_UNPAUSE_SCANNING);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(i);
-        Log.d(LOGTAG, "onStart");
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-
-        Log.d(LOGTAG, "onStop");
-        mMap.getTileProvider().clearTileCache();
-        BitmapPool.getInstance().clearBitmapPool();
-        if (mReceiver != null) {
-            LocalBroadcastManager.getInstance(this).unregisterReceiver(mReceiver);
-            mReceiver = null;
-        }
-    }
-
-    private final class GetLocationAndMapItTask extends AsyncTask<String, Void, String> {
-        private String mStatus="";
-        private float mLat = 0;
-        private float mLon = 0;
-        private float mAccuracy = 0;
-
-        @Override
-        public String doInBackground(String... params) {
-            Log.d(LOGTAG, "requesting location...");
-
-            JSONObject wrapper;
-            try {
-                wrapper = new JSONObject("{}");
-                if (mCellData != null) {
-                    wrapper.put("radio", mCellData.get(0).getRadio());
-                    JSONArray cellData = new JSONArray();
-                    for (CellInfo info : mCellData) {
-                        JSONObject item = info.toJSONObject();
-                        cellData.put(item);
-                    }
-                    wrapper.put("cell", cellData);
-                }
-                if (mWifiData != null) {
-                    JSONArray wifiData = new JSONArray();
-                    for (ScanResult result : mWifiData) {
-                        JSONObject item = new JSONObject();
-                        item.put("key", BSSIDBlockList.canonicalizeBSSID(result.BSSID));
-                        item.put("frequency", result.frequency);
-                        item.put("signal", result.level);
-                        wifiData.put(item);
-                    }
-                    wrapper.put("wifi", wifiData);
-                }
-            } catch (JSONException jsonex) {
-                Log.w(LOGTAG, "json exception", jsonex);
-                return "";
-            }
-            String data = wrapper.toString();
-            byte[] bytes = data.getBytes();
-            Searcher searcher = new Searcher();
-            if (searcher.cleanSend(bytes)) {
-                mStatus = searcher.getStatus();
-                mLat = searcher.getLat();
-                mLon = searcher.getLon();
-                mAccuracy = searcher.getAccuracy();
-            } else {
-                mStatus = STATUS_FAILED;
-            }
-            searcher.close();
-            Log.d(LOGTAG, "Upload status: " + mStatus);
-            return mStatus;
-        }
-
-        @Override
-        protected void onPostExecute(String result) {
-            if (STATUS_OK.equals(mStatus)) {
-                positionMapAt(mLat, mLon, mAccuracy);
-            } else if (STATUS_NOT_FOUND.equals(mStatus)) {
-                Toast.makeText(MapActivity.this,
-                        getResources().getString(R.string.location_not_found),
-                        Toast.LENGTH_LONG).show();
-            } else {
-                Toast.makeText(MapActivity.this,
-                        getResources().getString(R.string.location_lookup_error),
-                        Toast.LENGTH_LONG).show();
-                Log.e(LOGTAG, "", new IllegalStateException("mStatus=" + mStatus));
-            }
-            setProgressBarIndeterminateVisibility(false);
-        }
+    private static TileLayer mlsCoverageTileLayer() {
+        return new WebSourceTileLayer("mozilla", COVERAGE_URL)
+                .setName("Mozilla Location Service Coverage Map")
+                .setAttribution("© Mozilla Location Services Contributors")
+                .setMinimumZoomLevel(1)
+                .setMaximumZoomLevel(13);
     }
 }


### PR DESCRIPTION
WIP: adding an additional tile source doesn't seem to combine them.  Asked Mapbox support about this, as it may be necessary to make one of the tile sources into an Overlay.

This requires dropping support for Android API level 8, so for mapbox integration, it will need to be 9+.

Also removed the querying of MLS for position info.  That can be added back in a separate activity, as this Map Activity should be used by stumblers to determine where in their area has already been stumbled.  The testing of MLS responses was never clear in the MapActivity.

The "Refresh" button now refreshes the map back to the user's location.  This is useful if they start to pan around the map a bunch and get lost.
