### PR TITLE
Add Arcticbus on-bus wifi to blocklist

### DIFF
--- a/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
@@ -45,6 +45,7 @@ public final class SSIDBlockList {
         "AmtrakConnect",
         "Amtrak_",
         "amtrak_",
+        "Arcticbus Wifi", // Arcticbus on-bus WiFi (Sweden)
         "arriva", //Arriva Nederland on-train Wifi (Netherlands)
         "AutoPostale", // Swiss municipial busses on-bus WiFi (Italian speaking part)
         "Barcelona Bus Turistic ", // Barcelona tourisitic buses http://barcelonabusturistic.cat


### PR DESCRIPTION
This adds the on-bus wifi of buses owned by Arcticbus in northern Sweden to MozStumbler's blocklist.
