### PR TITLE
Prevent crash

### DIFF
--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -137,7 +137,7 @@ public final class StumblerService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent.getBooleanExtra(ACTION_START_PASSIVE, false)) {
+        if (intent != null && intent.getBooleanExtra(ACTION_START_PASSIVE, false)) {
             if (SharedConstants.stumblerContentResolver == null) {
                 SharedConstants.stumblerContentResolver = new ServerContentResolver(this);
             }


### PR DESCRIPTION
While not using the stumbler, a dialog would still pop up saying that the stumbler
had crashed:

E/AndroidRuntime(25424): Caused by: java.lang.NullPointerException
E/AndroidRuntime(25424):        at org.mozilla.mozstumbler.service.StumblerService.onStartCommand(StumblerService.java:138)
E/AndroidRuntime(25424):        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2729)
E/AndroidRuntime(25424):        ... 10 more

This is annoying to users, so should be stopped.
