### PR TITLE
Bug 1024708 - Pre: Add MPLv2 license headers to code that ships with Fennec.

### DIFF
--- a/src/org/mozilla/mozstumbler/service/AbstractCommunicator.java
+++ b/src/org/mozilla/mozstumbler/service/AbstractCommunicator.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.os.Build;

--- a/src/org/mozilla/mozstumbler/service/PassiveServiceStarter.java
+++ b/src/org/mozilla/mozstumbler/service/PassiveServiceStarter.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.content.BroadcastReceiver;

--- a/src/org/mozilla/mozstumbler/service/Prefs.java
+++ b/src/org/mozilla/mozstumbler/service/Prefs.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.annotation.SuppressLint;

--- a/src/org/mozilla/mozstumbler/service/Reporter.java
+++ b/src/org/mozilla/mozstumbler/service/Reporter.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.content.BroadcastReceiver;

--- a/src/org/mozilla/mozstumbler/service/Scanner.java
+++ b/src/org/mozilla/mozstumbler/service/Scanner.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/service/SharedConstants.java
+++ b/src/org/mozilla/mozstumbler/service/SharedConstants.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import org.mozilla.mozstumbler.service.datahandling.ContentResolverInterface;

--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service;
 
 import android.app.Service;

--- a/src/org/mozilla/mozstumbler/service/blocklist/BSSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/service/blocklist/BSSIDBlockList.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.blocklist;
 
 import android.net.wifi.ScanResult;

--- a/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
+++ b/src/org/mozilla/mozstumbler/service/blocklist/SSIDBlockList.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.blocklist;
 
 import android.net.wifi.ScanResult;

--- a/src/org/mozilla/mozstumbler/service/datahandling/ContentResolverInterface.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/ContentResolverInterface.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.OperationApplicationException;

--- a/src/org/mozilla/mozstumbler/service/datahandling/Database.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/Database.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/service/datahandling/DatabaseContract.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/DatabaseContract.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.ContentProviderOperation;

--- a/src/org/mozilla/mozstumbler/service/datahandling/DbCommunicator.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/DbCommunicator.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.UriMatcher;

--- a/src/org/mozilla/mozstumbler/service/datahandling/ServerContentResolver.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/ServerContentResolver.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.ContentValues;

--- a/src/org/mozilla/mozstumbler/service/datahandling/StumblerBundle.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/StumblerBundle.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.location.Location;

--- a/src/org/mozilla/mozstumbler/service/datahandling/StumblerBundleReceiver.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/StumblerBundleReceiver.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.datahandling;
 
 import android.content.ContentValues;

--- a/src/org/mozilla/mozstumbler/service/scanners/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/GPSScanner.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/service/scanners/LocationBlockList.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/LocationBlockList.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners;
 
 import android.location.Location;

--- a/src/org/mozilla/mozstumbler/service/scanners/WifiScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/WifiScanner.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners;
 
 import android.content.BroadcastReceiver;

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellInfo.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellInfo.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners.cellscanner;
 
 import android.os.Build;

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScanner.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners.cellscanner;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScannerNoWCDMA.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/CellScannerNoWCDMA.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners.cellscanner;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/service/scanners/cellscanner/ScreenMonitor.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/cellscanner/ScreenMonitor.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.scanners.cellscanner;
 
 import android.content.BroadcastReceiver;

--- a/src/org/mozilla/mozstumbler/service/sync/AsyncUploader.java
+++ b/src/org/mozilla/mozstumbler/service/sync/AsyncUploader.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.sync;
 
 import android.content.SyncResult;

--- a/src/org/mozilla/mozstumbler/service/sync/Submitter.java
+++ b/src/org/mozilla/mozstumbler/service/sync/Submitter.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.sync;
 
 import android.util.Log;

--- a/src/org/mozilla/mozstumbler/service/sync/UploadReports.java
+++ b/src/org/mozilla/mozstumbler/service/sync/UploadReports.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.sync;
 
 import android.content.OperationApplicationException;

--- a/src/org/mozilla/mozstumbler/service/utils/DateTimeUtils.java
+++ b/src/org/mozilla/mozstumbler/service/utils/DateTimeUtils.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.utils;
 
 import android.annotation.SuppressLint;

--- a/src/org/mozilla/mozstumbler/service/utils/NetworkUtils.java
+++ b/src/org/mozilla/mozstumbler/service/utils/NetworkUtils.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.service.utils;
 
 import android.content.Context;


### PR DESCRIPTION
Trivial, but needs to be done.  I have a tool that does this in one line if you want to land such license headers in more than just `service/`.
