### PR TITLE
Persist the "Upload only on WiFi" and the "Geofencing" preference

### DIFF
--- a/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
+++ b/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
@@ -24,6 +24,7 @@ public class PreferencesScreen extends PreferenceActivity {
     private CheckBoxPreference mGeofenceSwitch;
     private Preference mGeofenceHere;
     private CheckBoxPreference mWifiScanAlwaysSwitch;
+    private CheckBoxPreference mWifiPreference;
 
     private static Prefs sPrefs;
 
@@ -41,7 +42,6 @@ public class PreferencesScreen extends PreferenceActivity {
 
         addPreferencesFromResource(R.xml.stumbler_preferences);
 
-        CheckBoxPreference mWifiPreference;
         mNicknamePreference = (EditTextPreference) getPreferenceManager().findPreference("nickname");
         mWifiPreference = (CheckBoxPreference) getPreferenceManager().findPreference("wifi_only");
         mGeofenceSwitch = (CheckBoxPreference) getPreferenceManager().findPreference("geofence_switch");
@@ -99,6 +99,14 @@ public class PreferencesScreen extends PreferenceActivity {
                     sPrefs.setGeofenceHere(false);
                     setGeofenceHereDesc(false);
                 }
+                return true;
+            }
+        });
+
+        mWifiPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                sPrefs.setUseWifiOnly(newValue.equals(true));
                 return true;
             }
         });

--- a/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
+++ b/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
@@ -99,6 +99,7 @@ public class PreferencesScreen extends PreferenceActivity {
                     sPrefs.setGeofenceHere(false);
                     setGeofenceHereDesc(false);
                 }
+                sPrefs.setGeofenceEnabled(newValue.equals(true));
                 return true;
             }
         });

--- a/src/org/mozilla/mozstumbler/service/Prefs.java
+++ b/src/org/mozilla/mozstumbler/service/Prefs.java
@@ -59,6 +59,10 @@ public final class Prefs {
     /// Setters
     ///
 
+    public void setUseWifiOnly(boolean state) {
+        setBoolPref(WIFI_ONLY, state);
+    }
+
     public void setGeofenceEnabled(boolean state) {
         setBoolPref(GEOFENCE_SWITCH, state);
     }


### PR DESCRIPTION
Prior to this change, the user couldn't de-select "Upload only on WiFi" setting and have it persist.  Going back into settings would show that the "Upload only on WiFi" setting was re-selected.

Geofence Enabled had a similar fate.  Sometimes it would not disable if the GeofenceEnabledHere was not false.
