### PR TITLE
New Android Studio 0.8.1 requires a newer gradle plugin 0.12+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 


### PR DESCRIPTION
Hopefully these revisions will slow now that AS is in beta.
