### PR TITLE
aligned translations to source file

### DIFF
--- a/res/values-bn-rBD/strings.xml
+++ b/res/values-bn-rBD/strings.xml
@@ -42,11 +42,14 @@
     <string name="gps_alert_msg">জিপিএস বন্ধ আছে। আপনি কি সেটিংস থেকে তা চালু করতে চান?</string>
     <string name="yes">হ্যাঁ</string>
     <string name="no">না</string>
-	<string name="about_legal_aosp">এই এপ্লিকেশনের কিছু কিছু আইকন বা গ্রাফিক্স সংক্রান্ত কাজ Android Open Source Project থেকে নেয়া হয়েছে এবং তা Creative Commons 2.5 Attribution License এর আওতায় ব্যবহৃত হয়েছে।</string>
 
     <string name="about_version">সংস্করণ %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">ম্যাপিং প্রোভাইডার সম্পর্কে আরও জানুন</string>
     <string name="about_more">আরও</string>
+	<string name="about_legal_aosp">এই এপ্লিকেশনের কিছু কিছু আইকন বা গ্রাফিক্স সংক্রান্ত কাজ Android Open Source Project থেকে নেয়া হয়েছে এবং তা Creative Commons 2.5 Attribution License এর আওতায় ব্যবহৃত হয়েছে।</string>
 	
 	<string name="upload_observations_sent_title">আপলোডকৃত</string>
     <string name="upload_observations_last_upload_time_title">সর্বশেষ আপলোডের সময়:</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">ওয়াই-ফাই বন্ধ থাকলেও এক্সেস পয়েন্টগুলো স্ক্যান করা হবে।</string>
 
     <string name="refresh_map">অবস্থান রিফ্রেশ কর</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">No</string>
 
     <string name="about_version">Versió %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Apren més sobre el nostre proveïdor de dades de mapa…</string>
     <string name="about_more">Més…</string>
     <!--translation missing <string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string>-->
@@ -80,6 +83,13 @@
     <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-cz/strings.xml
+++ b/res/values-cz/strings.xml
@@ -46,6 +46,9 @@
     <string name="no">Ne</string>
 
     <string name="about_version">Verze %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Zjistit více informací o mapových datech…</string>
     <string name="about_more">Více…</string>
     <!--<string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string> translation missing-->
@@ -79,7 +82,17 @@
     <string name="geofencing_desc">MozStumbler will pause scanning within 1 km of this lat/long position.</string>
     <string name="geofencing_on">Geofencing @ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Geofence this location</string>
+	
+	<string name="wifi_scan_always_title">Always scan Wi-Fi</string>
+    <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+
+    <string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -44,6 +44,8 @@
     <string name="no">Nein</string>
 
     <string name="about_version">Version %1$s</string>
+	<string name="about_openstreetmap">Kacheln der Kartenansicht © OpenStreetMap-Mitwirkende\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>
     <string name="about_mapbox">Mehr über unseren Kartenanbieter erfahren…</string>
     <string name="about_more">Mehr…</string>
     <string name="about_legal_aosp">Einige Symbole in dieser Anwendung wurden Werken entnommen, welche vom Android Open Source Project erstellt und verteilt werden. Sie werden in Übereinstimmung mit der Creative Commons - Attribution 2.5 Lizenz verwendet.</string>
@@ -81,5 +83,12 @@
     <string name="wifi_scan_always_summary">Zugangspunkte auch bei abgeschaltetem Wi-Fi scannen</string>
 
     <string name="refresh_map">Standort aktualisieren</string>
+	
+    <string name="title_activity_log">Protokoll</string>
+    <string name="hello_world">Hallo Welt!</string>
+    <string name="action_settings">Einstellungen</string>
+    <string name="action_view_log">Protokoll anzeigen</string>
+    <string name="scroll_to_start">Nach Oben scrollen</string>
+    <string name="scroll_to_end">Ans Ende scrollen</string>
 
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">No</string>
 
     <string name="about_version">Versión %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Aprenda más acerca de nuestro proveedor de cartografía…</string>
     <string name="about_more">Más…</string>
     <string name="about_legal_aosp">Algunos iconos en esta aplicación son reproducidos de trabajo creado y compartido por el Proyecto de código abierto de Android y se usa de acuerdo a los términos descritos en la Licencia 2.5 de Creative Commons.</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">Escanear Puntos de acceso incluso si el wifi está apagado</string>
 
     <string name="refresh_map">Recargar ubicación</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
     
 </resources>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">خیر</string>
 
     <string name="about_version">نسخهٔ %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">دربارهٔ فراهم آورندهٔ نقشهٔ ما بیشتر بدانید…</string>
     <string name="about_more">بیشتر…</string>
     <string name="about_legal_aosp">بیشتر آیکون‌ها استفاده‌شده در این برنامه از آثار ایجاد و به‌اشتراک‌گذاری‌شده توسط پروژهٔ متن‌باز اندروید گرفته یا بازتولیدشده‌است و بنا به شروط توضیح‌داده‌شده در مجوز Creative Commons 2.5 Attribution استفاده شده‌است.</string>
@@ -80,6 +83,14 @@
     <string name="wifi_scan_always_title">همیشه وای‌فای را اسکن کن</string>
     <string name="wifi_scan_always_summary">اسکن نقاط دسترسی وای‌فای حتی هنگامی که وای‌فای خاموش شده‌است</string>
     
-    <!--missing translation <string name="refresh_map">Refresh location</string>-->
+    <!--translations missing
+	<string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Ei</string>
 
     <string name="about_version">Versio %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Lisätietoja karttapalvelusta…</string>
     <string name="about_more">Lisätietoja…</string>
     <string name="about_legal_aosp">Tämä sovellus sisältää ikoneita Android Open Source -projektista. Käytössä olevat ikonit on lisensoitu Creative Commons 2.5 Attribution -lisenssillä.</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">Skannaa Wi-Fiä vaikka Wi-Fi olisi pois päältä</string>
 
     <string name="refresh_map">Päivitä sijainti</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Non</string>
 
     <string name="about_version">Version %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">En savoir plus sur notre fournisseur cartographique…</string>
     <string name="about_more">Plus…</string>
     <string name="about_legal_aosp">Certaines icônes de cette application sont une reproduction du travail créé et partagé par le projet Open Source Android et sont utilisées selon les termes décrits dans la licence Creative Commons - Attribution 2.5.</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">Détecter les points d\'accès même si le Wi-Fi est arrêté</string>
 
     <string name="refresh_map">Rafraichir la position</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
     
 </resources>

--- a/res/values-gr/strings.xml
+++ b/res/values-gr/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <string name="app_name">MozStumbler</string>
     <string name="action_about">Σχετικά με το MozStumbler</string>
     <string name="action_preferences">Ρυθμίσεις</string>
@@ -22,24 +23,34 @@
     <string name="last_upload_time">Τελευταία Ώρα Μεταφόρτωσης: %1$s</string>
     <string name="reports_sent">Απεσταλμένες Αναφορές  %1$d</string>
     <string name="service_scanning">Σάρωση για  Wi-Fi και κυψέλες τηλεφωνίας</string>
+
     <string name="enter_nickname">Εισάγετε Ψευδώνυμο (προαιρετικό)</string>
     <string name="enter_nickname_title">Ψευδώνυμο: </string>
     <string name="enter_nickname_longtext">Το ψευδώνυμό σας θα εμφανιστεί στο Πίνακα κατάταξης.</string>
+
     <string name="power_saving_mode">Λειτουργία εξοικονόμησης ενέργειας.</string>
     <string name="power_saving_mode_longtext">Όταν είναι ενεργοποιημένο, σάρωση θα συμβαίνει μόνο όταν βρίσκεστε σε κίνηση.</string>
+
     <string name="update_title">Θέλετε να ενημερώσετε το MozStumbler;</string>
     <string name="update_message">Εγκατεστημένη έκδοση: %1$s\n Τελευταία έκδοση: %2$s</string>
     <string name="update_now">Ενημέρωση τώρα</string>
     <string name="update_later">Ενημέρωση αργότερα</string>
+
     <string name="location_not_found">Η τοποθεσία δεν βρέθηκε</string>
     <string name="location_lookup_error">Σφάλμα εύρεσης τοποθεσίας</string>
+
     <string name="gps_alert_msg">Το GPS είναι απενεργοποιημένο. Θέλετε να πάτε στις ρυθμίσεις και να το ενεργοποιήσετε;</string>
     <string name="yes">Ναι</string>
     <string name="no">Όχι</string>
+
     <string name="about_version">Έκδοση:%1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Μάθετε περισσότερα σχετικά με τον παροχέα χαρτογράφησής μας…</string>
     <string name="about_more">Περισσότερα …</string>
     <string name="about_legal_aosp">Κάποια εικονογραφία σε αυτό το πρόγραμμα αναπαράγεται από το έργο που δημιουργείται και διαμοιράζεται από το Android Open Source Project και χρησιμοποιείτε σύμφωνα με τους όρους που περιγράφονται στην άδεια Creative Commons Attribution 2.5 .</string>
+
     <string name="upload_observations_sent_title">Αποστολή</string>
     <string name="upload_observations_last_upload_time_title">Τελευταία αποστολή:</string>
     <string name="upload_observations_observations_sent_title">Παρατηρήσεις:</string>
@@ -51,6 +62,7 @@
     <string name="upload_observations_cells_queued_title">Κυψέλες τηλεφωνίας:</string>
     <string name="upload_observations_button">Αποστολή</string>
     <string name="upload_observations_dialog_title">Αποστολή παρατηρήσεων</string>
+
     <string name="detected_activity">Εντοπίστηκε Δραστηριότητα: %1$s</string>
     <string name="detected_activity_in_vehicle">Κινείται (σε όχημά)</string>
     <string name="detected_activity_on_bicycle">Κινείται (σε ποδήλατο)</string>
@@ -58,14 +70,27 @@
     <string name="detected_activity_still">Ακίνητο</string>
     <string name="detected_activity_tilting">Κλίση</string>
     <string name="detected_activity_unknown">Άγνωστο</string>
+
     <string name="upload_wifi_only_title">Μεταφόρτωση μόνο μέσω Wi-Fi</string>
     <string name="upload_wifi_only_summary">Η επιλογή αυτή θα μειώσει τη χρήση των δεδομένων σας μέσω του δικτύου κινητής τηλεφωνίας.</string>
+
     <string name="geofencing_off">Geofencing: Απενεργοποιημένο</string>
     <string name="geofencing_explain">Το Geofencing θα καθοριστεί σε επόμενη έγκυρη θέση που λαμβάνει κατά τη διάρκεια της σάρωσης.</string>
     <string name="geofencing_desc">Το MozStumbler θα σταματήσει τη σάρωση σε απόσταση 1 km από τη θέση.</string>
     <string name="geofencing_on">Geofencing @ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Geofence αυτή τη θέση</string>
+
     <string name="wifi_scan_always_title">Μόνιμη σάρωση Wi-Fi</string>
     <string name="wifi_scan_always_summary">Σάρωση APs ακόμα και όταν το Wi-Fi είναι απενεργοποιημένο</string>
+
     <string name="refresh_map">Ανανέωση θέσης</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
+
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">नहीं</string>
 
     <string name="about_version">संस्करण %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">हमारे नक्शा प्रदाता के बारेमे अधिक जानें…</string>
     <string name="about_more">अधिक…</string>
     <string name="about_legal_aosp">इस अनुप्रयोगमें इस्तेमाल की गयी कुछ आकृतियाँ अँड्रॉइड मुक्त स्रोत परियोजना द्वारा बनाई गयी और विभाजित की गयी है तथा क्रिएटीव कॉमन्स २.५ विशेष प्रयोग शर्त अनुसार इस्तेमाल कि गयी है.</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">Wi-Fi बंद होनेपर भी प्रवेश बिंदु खोजें</string>
 
     <string name="refresh_map">स्थान अद्यतन करेंं</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">No</string>
     
     <string name="about_version">Versione %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Per maggiori informazioni sul nostro fornitore di mappe…</string>
     <string name="about_more">Ancora…</string>
     <string name="about_legal_aosp">Alcune icone in questa applicazione sono riprodotte da opere create e condivise dall\'Android Open Source Project e sono usate secondo i termini descritti dalla licenza Creative Commons 2.5 Attribution.</string>
@@ -77,9 +80,17 @@
     <string name="geofencing_on">Recinzione geografica \@ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Recinzione geografica in questa posizione</string>
     
-    <!--translations missing <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
+    <!--translations missing
+	<string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -1,86 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <string name="app_name">MozStumbler</string>
-  <string name="action_about">על אודות MozStumbler</string>
-  <string name="action_preferences">העדפות</string>
-  <string name="action_upload_observations">העלאת תצפיות</string>
-  <string name="start_scanning">התחלת הסריקה</string>
-  <string name="stop_scanning">עצירת הסריקה</string>
-  <string name="view_leaderboard">צפייה בלוח המובילים</string>
-  <string name="view_map">בדיקת שירות האיכון של Mozilla</string>
-  <string name="service_name">מאתר מוזילה</string>
-  <string name="activity_recognition_service">פעילות מאתר מוזילה לרישום מיקום</string>
-  <string name="wifi_access_points">נקודות גישה מסוג Wi-Fi שנסרקו: %1$d</string>
-  <string name="wifi_disabled">0 (ה־Wi-Fi כבוי)</string>
-  <string name="visible_wifi_access_points">נקודות Wi-Fi גלויות: %1$s</string>
-  <string name="cells_scanned">אנטנות שנסרקו: %1$d</string>
-  <string name="cells_visible">אנטנות גלויות: %1$d</string>
-  <string name="gps_satellites">לווייני GPS בשימוש / גלויים: %1$d/%2$d</string>
-  <string name="last_location">מיקום אחרון: %1$s</string>
-  <string name="coordinate">%1$.4f, %2$.4f</string>
-  <string name="locations_scanned">מיקומים שנסרקו: %1$d</string>
-  <string name="last_upload_time">מועד ההעלאה האחרון: %1$s</string>
-  <string name="reports_sent">דיווחים שנשלחו: %1$d</string>
-  <string name="service_scanning">מתבצעת סריקה לאיתור רשתות סלולריות ו־Wi-Fi</string>
+	<string name="app_name">MozStumbler</string>
+	<string name="action_about">על אודות MozStumbler</string>
+	<string name="action_preferences">העדפות</string>
+	<string name="action_upload_observations">העלאת תצפיות</string>
+	<string name="start_scanning">התחלת הסריקה</string>
+	<string name="stop_scanning">עצירת הסריקה</string>
+	<string name="view_leaderboard">צפייה בלוח המובילים</string>
+	<string name="view_map">בדיקת שירות האיכון של Mozilla</string>
+	<string name="service_name">מאתר מוזילה</string>
+	<string name="activity_recognition_service">פעילות מאתר מוזילה לרישום מיקום</string>
+	<string name="wifi_access_points">נקודות גישה מסוג Wi-Fi שנסרקו: %1$d</string>
+	<string name="wifi_disabled">0 (ה־Wi-Fi כבוי)</string>
+	<string name="visible_wifi_access_points">נקודות Wi-Fi גלויות: %1$s</string>
+	<string name="cells_scanned">אנטנות שנסרקו: %1$d</string>
+	<string name="cells_visible">אנטנות גלויות: %1$d</string>
+	<string name="gps_satellites">לווייני GPS בשימוש / גלויים: %1$d/%2$d</string>
+	<string name="last_location">מיקום אחרון: %1$s</string>
+	<string name="coordinate">%1$.4f, %2$.4f</string>
+	<string name="locations_scanned">מיקומים שנסרקו: %1$d</string>
+	<string name="last_upload_time">מועד ההעלאה האחרון: %1$s</string>
+	<string name="reports_sent">דיווחים שנשלחו: %1$d</string>
+	<string name="service_scanning">מתבצעת סריקה לאיתור רשתות סלולריות ו־Wi-Fi</string>
 
-  <string name="enter_nickname">הזנת שם המשתמש (רשות)</string>
-  <string name="enter_nickname_title">כינוי: </string>
-  <string name="enter_nickname_longtext">הכינוי שלך יופיע בלוח המובילים.</string>
+	<string name="enter_nickname">הזנת שם המשתמש (רשות)</string>
+	<string name="enter_nickname_title">כינוי: </string>
+	<string name="enter_nickname_longtext">הכינוי שלך יופיע בלוח המובילים.</string>
 
-  <string name="power_saving_mode">מצב חיסכון בסוללה</string>
-  <string name="power_saving_mode_longtext">כאשר מופעל, המאתר יסרוק רק כאשר אתה בתנועה.</string>
+	<string name="power_saving_mode">מצב חיסכון בסוללה</string>
+	<string name="power_saving_mode_longtext">כאשר מופעל, המאתר יסרוק רק כאשר אתה בתנועה.</string>
 
-  <string name="update_title">האם להוריד עדכון ל־MozStumbler?</string>
-  <string name="update_message">הגרסה המותקנת: %1$s\nהגרסה העדכנית: %2$s</string>
-  <string name="update_now">לעדכן כעת</string>
-  <string name="update_later">לעדכן מאוחר יותר</string>
+	<string name="update_title">האם להוריד עדכון ל־MozStumbler?</string>
+	<string name="update_message">הגרסה המותקנת: %1$s\nהגרסה העדכנית: %2$s</string>
+	<string name="update_now">לעדכן כעת</string>
+	<string name="update_later">לעדכן מאוחר יותר</string>
 
-  <string name="location_not_found">המיקום לא נמצא</string>
-  <string name="location_lookup_error">שגיאת איתור מיקום</string>
+	<string name="location_not_found">המיקום לא נמצא</string>
+	<string name="location_lookup_error">שגיאת איתור מיקום</string>
 
-  <string name="gps_alert_msg">האיכון כבוי. האם ברצונך לגשת להגדרות כדי להפעיל אותו?</string>
-  <string name="yes">כן</string>
-  <string name="no">לא</string>
+	<string name="gps_alert_msg">האיכון כבוי. האם ברצונך לגשת להגדרות כדי להפעיל אותו?</string>
+	<string name="yes">כן</string>
+	<string name="no">לא</string>
 
-  <string name="about_version">גרסה %1$s</string>
-  <string name="about_mapbox">מידע נוסף על ספק המיפוי שלנו…</string>
-  <string name="about_more">פרטים נוספים…</string>
-  <string name="about_legal_aosp">
-חלק מהסימנים ביישום זה נגזרו מיצירות שנוצרו עבור Android Open Source Project ונעשה בהם שימוש בכפוף לתנאים המתוארים ברישיון Creative Commons 2.5 ייחוס.</string>
+	<string name="about_version">גרסה %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+	<string name="about_mapbox_title">MapBox</string>-->
+	<string name="about_mapbox">מידע נוסף על ספק המיפוי שלנו…</string>
+	<string name="about_more">פרטים נוספים…</string>
+	<string name="about_legal_aosp">חלק מהסימנים ביישום זה נגזרו מיצירות שנוצרו עבור Android Open Source Project ונעשה בהם שימוש בכפוף לתנאים המתוארים ברישיון Creative Commons 2.5 ייחוס.</string>
 
-  <string name="upload_observations_sent_title">נשלח</string>
-  <string name="upload_observations_last_upload_time_title">תאריך העלאה אחרון:</string>
-  <string name="upload_observations_observations_sent_title">תצפיות:</string>
-  <string name="upload_observations_wifis_sent_title">נקודות גישת Wi-Fi:</string>
-  <string name="upload_observations_cells_sent_title">אנטנות:</string>
-  <string name="upload_observations_in_queue_title">בתור</string>
-  <string name="upload_observations_observations_queued_title">תצפיות:</string>
-  <string name="upload_observations_wifis_queued_title">נקודות גישת Wi-Fi:</string>
-  <string name="upload_observations_cells_queued_title">אנטנות:</string>
-  <string name="upload_observations_button">העלאה</string>
-  <string name="upload_observations_dialog_title">העלאת תצפיות</string>
+	<string name="upload_observations_sent_title">נשלח</string>
+	<string name="upload_observations_last_upload_time_title">תאריך העלאה אחרון:</string>
+	<string name="upload_observations_observations_sent_title">תצפיות:</string>
+	<string name="upload_observations_wifis_sent_title">נקודות גישת Wi-Fi:</string>
+	<string name="upload_observations_cells_sent_title">אנטנות:</string>
+	<string name="upload_observations_in_queue_title">בתור</string>
+	<string name="upload_observations_observations_queued_title">תצפיות:</string>
+	<string name="upload_observations_wifis_queued_title">נקודות גישת Wi-Fi:</string>
+	<string name="upload_observations_cells_queued_title">אנטנות:</string>
+	<string name="upload_observations_button">העלאה</string>
+	<string name="upload_observations_dialog_title">העלאת תצפיות</string>
 
-  <string name="detected_activity">זוהתה פעילות: %1$s</string>
-  <string name="detected_activity_in_vehicle">תנועה (ברכב)</string>
-  <string name="detected_activity_on_bicycle">תנועה (על אופניים)</string>
-  <string name="detected_activity_on_foot">תנועה (ברגל)</string>
-  <string name="detected_activity_still">עמידה</string>
-  <string name="detected_activity_tilting">טלטול</string>
-  <string name="detected_activity_unknown">לא ידוע</string>
+	<string name="detected_activity">זוהתה פעילות: %1$s</string>
+	<string name="detected_activity_in_vehicle">תנועה (ברכב)</string>
+	<string name="detected_activity_on_bicycle">תנועה (על אופניים)</string>
+	<string name="detected_activity_on_foot">תנועה (ברגל)</string>
+	<string name="detected_activity_still">עמידה</string>
+	<string name="detected_activity_tilting">טלטול</string>
+	<string name="detected_activity_unknown">לא ידוע</string>
 
-  <string name="upload_wifi_only_title">העלאה רק באמצעות Wi-Fi</string>
-  <string name="upload_wifi_only_summary">אפשרות זו תפחית את השימוש בנתונים של הרשת הסלולרית.</string>
+	<string name="upload_wifi_only_title">העלאה רק באמצעות Wi-Fi</string>
+	<string name="upload_wifi_only_summary">אפשרות זו תפחית את השימוש בנתונים של הרשת הסלולרית.</string>
 
-  <string name="geofencing_off">גידור גיאוגרפי: כבוי</string>
-  <string name="geofencing_explain">גידור גיאוגרפי יקבע עבור המיקום התקין במהלך הסריקה.</string>
-  <string name="geofencing_desc">MozStumbler יפסיק את הסריקה במרחק ק״מ אחד מהנקודה הזאת.</string>
-  <string name="geofencing_on">גידור גיאוגרפי @ %1$.3f, %2$.3f</string>
-  <string name="geofencing_enable">גידור גיאוגרפי של מיקום זה</string>
-  
-  <string name="wifi_scan_always_title">תמיד לסרוק Wi-Fi</string>
-    <string name="wifi_scan_always_summary">לסרוק נקודות גישה אפילו כשה־Wi-Fi כבוי</string>
+	<string name="geofencing_off">גידור גיאוגרפי: כבוי</string>
+	<string name="geofencing_explain">גידור גיאוגרפי יקבע עבור המיקום התקין במהלך הסריקה.</string>
+	<string name="geofencing_desc">MozStumbler יפסיק את הסריקה במרחק ק״מ אחד מהנקודה הזאת.</string>
+	<string name="geofencing_on">גידור גיאוגרפי @ %1$.3f, %2$.3f</string>
+	<string name="geofencing_enable">גידור גיאוגרפי של מיקום זה</string>
 
-    <string name="refresh_map">רענון המיקום</string>
+	<string name="wifi_scan_always_title">תמיד לסרוק Wi-Fi</string>
+	<string name="wifi_scan_always_summary">לסרוק נקודות גישה אפילו כשה־Wi-Fi כבוי</string>
+
+	<string name="refresh_map">רענון המיקום</string>
+
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+	<string name="hello_world">Hello world!</string>
+	<string name="action_settings">Settings</string>
+	<string name="action_view_log">View Log</string>
+	<string name="scroll_to_start">Scroll to Top</string>
+	<string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-mr/strings.xml
+++ b/res/values-mr/strings.xml
@@ -14,7 +14,6 @@
     <string name="wifi_access_points">तपासलेले Wi-Fi प्रवेश बिंदू: %1$d</string>
     <string name="wifi_disabled">० (Wi-Fi बंद आहे)</string>
     <string name="visible_wifi_access_points">दिसणारे Wi-Fi प्रवेश बिंदू:: %1$s</string>
-    
     <string name="cells_scanned">शोधलेले भ्रमणध्वनी जाळे: %1$d</string>
     <string name="cells_visible">दिसणारे भ्रमणध्वनी जाळे: %1$d</string>
     <string name="gps_satellites">वापरलेले/दिसणारे GPS उपग्रह: %1$d/%2$d</string>
@@ -45,10 +44,12 @@
     <string name="no">नाही</string>
 
     <string name="about_version">आवृत्ती %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">आमच्या नकाशा पुरवठादाराविषयी अधिक जाणून घ्या…</string>
     <string name="about_more">आणखी…</string>
     <string name="about_legal_aosp">या अनुप्रयोगामधे वापरण्यात आलेल्या काही प्रतिमा अँड्रॉइड मुक्त स्रोत प्रकल्पाने तयार करून विभागून दिलेल्या आहेत व त्या क्रिएटीव कॉमन्स २.५ विशेष परवाना अटींनुसार वापरल्या आहेत.</string>
-
     
     <string name="upload_observations_sent_title">पाठवलेली निरीक्षणे</string>
     <string name="upload_observations_last_upload_time_title">शेवटची निरीक्षणे पाठवण्याची वेळ:</string>
@@ -83,5 +84,13 @@
     <string name="wifi_scan_always_summary">Wi-Fi बंद असताना सुद्धा प्रवेश बिंदू शोधा</string>
 
     <string name="refresh_map">स्थळ अद्यतन करा</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Nei</string>
 
     <string name="about_version">Versjon %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Lær mer om vår kartleverandør…</string>
     <string name="about_more">Mer…</string>
     <string name="about_legal_aosp">Noen av ikonene i denne appen er gjenbruk av arbeid laget og delt av Androids åpen kildekode-prosjekt og blir brukt i henhold til Creative Commons 2.5-navngivelseslisensen.</string>
@@ -77,9 +80,17 @@
     <string name="geofencing_on">Geofencing @ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Geofence denne plasseringen</string>
 
-    <!--translations missing <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
+    <!--translations missing
+	<string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Nee</string>
 
     <string name="about_version">Versie %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Ontdek meer over mapbox…</string>
     <string name="about_more">Meer…</string>
     <string name="about_legal_aosp">Sommige iconografie in deze app is overgenomen uit het werk gemaakt en gedeeld door het Android Open Source Project en gebruikt volgens de voorwaarden zoals beschreven in de Creative Commons Attribution 2.5 License.</string>
@@ -78,9 +81,17 @@
     <string name="geofencing_on">Geofencing @ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Geofence deze lokatie</string>
 
-    <!--translations missing <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
+    <!--translations missing
+	<string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Nie</string>
 
     <string name="about_version">Wersja %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Więcej informacji o dostawcy map…</string>
     <string name="about_more">Więcej…</string>
     <string name="about_legal_aosp">Niektóre ikony w tej aplikacji pochodzą z Android Open Source Project i są używane zgodnie z warunkami licencji Creative Commons 2.5 Attribution.</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">Skanowanie punktów dostępowych nawet, jeśli Wi-Fi jest wyłączone</string>
 
     <string name="refresh_map">Odśwież położenie</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -46,6 +46,9 @@
     <string name="no">Não</string>
 
     <string name="about_version">Versão %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Saiba mais sobre o provedor de mapemento…</string>
     <string name="about_more">Mais…</string>
     <!--<string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string> translation missing-->
@@ -83,6 +86,13 @@
     <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">Нет</string>
 
     <string name="about_version">Версия %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">Информация о картографическом провайдере…</string>
     <string name="about_more">О проекте…</string>
     <string name="about_legal_aosp">Некоторые изображения в этом приложении созданы и опубликованы под лицензией AOSP (Android Open Source Project) и используются в соответствии с условиями, описанными в лицензии Creative Commons 2.5</string>
@@ -77,9 +80,17 @@
     <string name="geofencing_on">Геозона @ %1$.3f, %2$.3f</string>
     <string name="geofencing_enable">Установить геозону в текущем местоположении</string>
     
-    <!--translations missing <string name="wifi_scan_always_title">Always scan Wi-Fi</string>
+    <!--translations missing
+	<string name="wifi_scan_always_title">Always scan Wi-Fi</string>
     <string name="wifi_scan_always_summary">Scan APs even when Wi-Fi is turned off</string>
 
-    <string name="refresh_map">Refresh location</string>-->
+    <string name="refresh_map">Refresh location</string>
+	
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">否</string>
 
     <string name="about_version">版本 %1$s</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">了解我们的地图提供商…</string>
     <string name="about_more">更多…</string>
     <string name="about_legal_aosp">本应用中的部分图标是 Android 开源项目创作并以知识共享 2.5 署名许可协议分享的作品</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">即使 Wi-Fi 在关闭状态也扫描接入点</string>
 
     <string name="refresh_map">刷新位置</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -44,6 +44,9 @@
     <string name="no">不要</string>
 
     <string name="about_version">%1$s 版</string>
+	<!--translations missing
+	<string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
+    <string name="about_mapbox_title">MapBox</string>-->
     <string name="about_mapbox">了解我們的地圖資料提供者資訊…</string>
     <string name="about_more">更多…</string>
     <string name="about_legal_aosp">此應用程式中的某些圖示係重製自 Android Open Source Project 之創作，並依照創用 CC 姓名標示 2.5 版授權條款使用。</string>
@@ -81,5 +84,13 @@
     <string name="wifi_scan_always_summary">在 Wi-Fi 關閉時持續掃描基地台</string>
 
     <string name="refresh_map">重新整理位置</string>
+	
+	<!--translations missing
+	<string name="title_activity_log">Log</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_view_log">View Log</string>
+    <string name="scroll_to_start">Scroll to Top</string>
+    <string name="scroll_to_end">Scroll to End</string>-->
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="no">No</string>
 
     <string name="about_version">Version %1$s</string>
-    <string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org </string>
+    <string name="about_openstreetmap">Map view tiles © OpenStreetMap contributors\nhttp://www.openstreetmap.org</string>
     <string name="about_mapbox_title">MapBox</string>
     <string name="about_mapbox">Learn more about our mapping provider…</string>
     <string name="about_more">More…</string>


### PR DESCRIPTION
removed an unneccessary space at the end of about_openstreetmap in english source translation file
aligned translation files to english source translation file (added reminders for missing translations)
added line-breaks to values-gr
changed indent size from 2 to 4 in values-iw
removed unneccessary line-breaks in values-mr
