### PR TITLE
cursor was not checking cursor.getCount() > 0 before working with it,

### DIFF
--- a/src/org/mozilla/mozstumbler/service/sync/UploadReports.java
+++ b/src/org/mozilla/mozstumbler/service/sync/UploadReports.java
@@ -120,7 +120,7 @@ public class UploadReports {
     private long getMaxId() {
         Cursor c = mContentResolver.query(DatabaseContract.Reports.CONTENT_URI_SUMMARY,
                 new String[]{DatabaseContract.Reports.MAX_ID}, null, null, null);
-        if (c != null) {
+        if (c != null && c.getCount() > 0) {
             try {
                 if (c.moveToFirst()) {
                     return c.getLong(0);


### PR DESCRIPTION
could cause crash as seen in issue #696
