### PR TITLE
MainActivity ui update: change to ensure it runs on the main thread

### DIFF
--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -68,7 +68,7 @@ public final class MainActivity extends FragmentActivity {
         }
         setGeofenceText();
 
-        updateUI();
+        updateUiOnMainThread();
     }
 
     @Override
@@ -117,7 +117,16 @@ public final class MainActivity extends FragmentActivity {
         }
     }
 
-    protected void updateUI() {
+    protected void updateUiOnMainThread() {
+        this.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                updateUI();
+            }
+        });
+    }
+
+    private void updateUI() {
         StumblerService service = getApp().getService();
         if (service == null) {
             return;
@@ -148,9 +157,8 @@ public final class MainActivity extends FragmentActivity {
         currentCellInfo = service.getCurrentCellInfoCount();
         isGeofenced = service.isGeofenced();
 
-        String lastLocationString = (mGpsFixes > 0 && locationsScanned > 0)
-                                    ? formatLocation(latitude, longitude)
-                                    : "-";
+        String lastLocationString = (mGpsFixes > 0 && locationsScanned > 0)?
+                                    formatLocation(latitude, longitude) : "-";
 
         formatTextView(R.id.gps_satellites, R.string.gps_satellites, mGpsFixes, mGpsSats);
         formatTextView(R.id.last_location, R.string.last_location, lastLocationString);

--- a/src/org/mozilla/mozstumbler/client/MainApp.java
+++ b/src/org/mozilla/mozstumbler/client/MainApp.java
@@ -87,7 +87,7 @@ public class MainApp extends Application {
                 mStumblerService = serviceBinder.getService();
                 Log.d(LOGTAG, "Service connected");
                 if (mMainActivity != null) {
-                    mMainActivity.updateUI();
+                    mMainActivity.updateUiOnMainThread();
                 }
             }
 
@@ -199,7 +199,7 @@ public class MainApp extends Application {
             }
 
             if (mMainActivity != null) {
-                mMainActivity.updateUI();
+                mMainActivity.updateUiOnMainThread();
             }
         }
     }


### PR DESCRIPTION
Wrap the update in a main thread runnable. Allows for safe updating of the ui from secondary thread.
