### PR TITLE
Change to using a pin-point (with accuracy circle) to indicate stumbler's GPS position

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -216,11 +216,28 @@ public final class MapActivity extends Activity {
     private static class AccuracyCircleOverlay extends Overlay {
         private GeoPoint mPoint;
         private float mAccuracy;
+        private Paint mCircleFillPaint = new Paint();
+        private Paint mCircleStrokePaint = new Paint();
+        private Paint mCenterPaint = new Paint();
+        private Paint mCenterStrokePaint = new Paint();
 
         public AccuracyCircleOverlay(Context ctx, Location location) {
             super(ctx);
             mPoint = new GeoPoint(location.getLatitude(), location.getLongitude());
             mAccuracy = location.getAccuracy();
+
+            mCircleFillPaint.setARGB(40, 100, 100, 255);
+            mCircleFillPaint.setStyle(Paint.Style.FILL);
+
+            mCircleStrokePaint.setARGB(165, 100, 100, 255);
+            mCircleStrokePaint.setStyle(Paint.Style.STROKE);
+
+            mCenterPaint.setARGB(255, 100, 100, 255);
+            mCenterPaint.setStyle(Paint.Style.FILL);
+
+            mCenterStrokePaint.setARGB(255, 255, 255, 255);
+            mCenterStrokePaint.setStyle(Paint.Style.STROKE);
+            mCenterStrokePaint.setStrokeWidth(5);
         }
 
         protected void draw(Canvas c, MapView osmv, boolean shadow) {
@@ -230,23 +247,16 @@ public final class MapActivity extends Activity {
             Projection pj = osmv.getProjection();
             Point center = pj.toPixels(mPoint, null);
             float radius = pj.metersToEquatorPixels(mAccuracy);
-            Paint circle = new Paint();
-            circle.setARGB(0, 100, 100, 255);
 
             // Fill
-            circle.setAlpha(40);
-            circle.setStyle(Paint.Style.FILL);
-            c.drawCircle(center.x, center.y, radius, circle);
+            c.drawCircle(center.x, center.y, radius, mCircleFillPaint);
 
             // Border
-            circle.setAlpha(165);
-            circle.setStyle(Paint.Style.STROKE);
-            c.drawCircle(center.x, center.y, radius, circle);
+            c.drawCircle(center.x, center.y, radius, mCircleStrokePaint);
 
             // Center
-            circle.setAlpha(255);
-            circle.setStyle(Paint.Style.FILL);
-            c.drawCircle(center.x, center.y, 10, circle);
+            c.drawCircle(center.x, center.y, 15, mCenterPaint);
+            c.drawCircle(center.x, center.y, 15, mCenterStrokePaint);
         }
 
         public void setLocation(final Location location) {

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -308,9 +308,7 @@ public final class MapActivity extends Activity {
             Log.d(LOGTAG, "requesting location...");
 
             StumblerService service = params[0];
-            final Location result = new Location("MozStumbler");
-            result.setLatitude(service.getLatitude());
-            result.setLongitude(service.getLongitude());
+            final Location result = service.getLocation();
             return result;
         }
 

--- a/src/org/mozilla/mozstumbler/service/Scanner.java
+++ b/src/org/mozilla/mozstumbler/service/Scanner.java
@@ -7,6 +7,7 @@ package org.mozilla.mozstumbler.service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.location.Location;
 import android.os.BatteryManager;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
@@ -150,6 +151,10 @@ public class Scanner {
 
     double getLongitude() {
         return mGPSScanner.getLongitude();
+    }
+
+    Location getLocation() {
+        return mGPSScanner.getLocation();
     }
 
     void checkPrefs() {

--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -7,6 +7,7 @@ package org.mozilla.mozstumbler.service;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
+import android.location.Location;
 import android.os.Binder;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -88,6 +89,10 @@ public final class StumblerService extends PersistentIntentService
 
     public double getLongitude() {
         return mScanner.getLongitude();
+    }
+
+    public Location getLocation() {
+        return mScanner.getLocation();
     }
 
     public int getWifiStatus() {

--- a/src/org/mozilla/mozstumbler/service/scanners/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/GPSScanner.java
@@ -133,6 +133,10 @@ public class GPSScanner implements LocationListener {
         return mLocation.getLongitude();
     }
 
+    public Location getLocation() {
+        return mLocation;
+    }
+
     public void checkPrefs() {
         if (mBlockList!=null) mBlockList.update_blocks();
 


### PR DESCRIPTION
This drops the ItemizedOverlay for indicating position, and re-introduces use of the AccuracyCircleOverlay, which is also given a mild make-over to draw the exact pin location and keep its Paint objects around rather than recreating them on each draw.

To get the accuracy circle, the full Location is now passed out from GPSScanner all the way back to the MapActivity, rather than grabbing the Latitude & Longitude piecemeal.

The center point could be improved further, and the accuracy circle often gets obscured by it, but hopefully it's an improvement over the old push-pin to indicate location.
