### PR TITLE
Put initialization of GPS broadcast reception in onStart()

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -102,12 +102,6 @@ public final class MapActivity extends Activity {
         }
         mMap.getController().setZoom(zoomLevel);
 
-        mReceiver = new ReporterBroadcastReceiver();
-        IntentFilter intentFilter = new IntentFilter();
-        intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);
-        LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver,
-                intentFilter);
-
         Log.d(LOGTAG, "onCreate");
 
         // @TODO: we do a similar "read from URL" in Updater, AbstractCommunicator, make one function for this
@@ -271,6 +265,11 @@ public final class MapActivity extends Activity {
 
         Intent i = new Intent(MainActivity.ACTION_UNPAUSE_SCANNING);
         LocalBroadcastManager.getInstance(this).sendBroadcast(i);
+
+        mReceiver = new ReporterBroadcastReceiver();
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);
+        LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver, intentFilter);
         Log.d(LOGTAG, "onStart");
     }
 


### PR DESCRIPTION
It's removed in onStop() so should be initiated in onStart().

Without this change, if the user left the map (via notification, home button press, etc) and came back, they would no longer get GPS updates.

The only obvious way to restart updates was to go back from the map activity, then re-enter it to force a re-creation.
