### PR TITLE
Pan mode

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -202,7 +202,6 @@ public final class MapActivity extends Activity {
         } else {
             mAccuracyOverlay.setLocation(location);
         }
-        mMap.invalidate();
     }
 
     private void positionMapAt(Location location) {
@@ -215,7 +214,6 @@ public final class MapActivity extends Activity {
         } else {
             mMap.getController().animateTo(point);
         }
-        mMap.invalidate();
     }
 
     private static class AccuracyCircleOverlay extends Overlay {

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -187,7 +187,7 @@ public final class MapActivity extends Activity {
         return coverageTileOverlay;
     }
 
-    private void positionMapAt(Location location) {
+    private void setUserPositionAt(Location location) {
         if  (mCoverageTilesOverlay == null && sCoverageUrl != null) {
             mCoverageTilesOverlay = CoverageTilesOverlay(this);
             mMap.getOverlays().add(mCoverageTilesOverlay);
@@ -199,7 +199,10 @@ public final class MapActivity extends Activity {
         } else {
             mAccuracyOverlay.setLocation(location);
         }
+        mMap.invalidate();
+    }
 
+    private void positionMapAt(Location location) {
         final GeoPoint point = new GeoPoint(location.getLatitude(), location.getLongitude());
         if (mFirstLocationFix) {
             mMap.getController().setZoom(13);
@@ -317,6 +320,7 @@ public final class MapActivity extends Activity {
 
         @Override
         protected void onPostExecute(Location result) {
+            setUserPositionAt(result);
             positionMapAt(result);
         }
     }


### PR DESCRIPTION
This allows the user to move around the map without being pulled back to the center every time a new GPS fix comes in.  They can turn this off by touching the "Refresh" menu item.  Will move this later to a visible button similar to Google Maps. 

It's a bit convoluted, as the only reliable way I could find for OSMDroid to report that a user-initiated swipe has happened was to use an Overlay and listen for touch events.  When one happens, call back to the creator to store that it was a user initiated move.
