### PR TITLE
Add PathOverlay to the map to draw the GPS track

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="gps_track">#FF6464FF</color>
+</resources>


### PR DESCRIPTION
This is a work-in-progress, which still needs refinement and is posted to solicit feedback.

It will remember the user's location changes while the Map Activity is up and running, and draw that in the same color as the GPS dot, persisting across screen rotations, etc.

I'm planning to later change this to grab historical data from the service, or some other local store if the user enables it in the setting.

An issue is that OSMDroid is no longer recommending using PathOverlay and now says to use the OSMBonusPack Polyline, however MozStumbler does not yet include that library, and it doesn't seem to have a nice maven import available.

If the Map Activity is changed to use the Mapbox Android SDK, that SDK uses their own implementation of the PathOverlay which may be sufficient, though I'd suspect it would still be prudent to clip the paths that are passed to the overlay to only those that are within some boundry of the currently visible map as I imagine there will be performance implications with users having their entire stumbling history drawn.
