### PR TITLE
Use the last map center (not necessarily the last user location), instead of (0,0)

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapPreferences.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapPreferences.java
@@ -1,0 +1,54 @@
+package org.mozilla.mozstumbler.client.mapview;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.util.GeoPoint;
+
+/**
+ * Storage of preferences specific to the map view
+ */
+public final class MapPreferences {
+    private static final String LOGTAG = MapPreferences.class.getName();
+    private static final String PREFS_FILE = MapPreferences.class.getName();
+
+    private static final String LAT_PREF = "lat";
+    private static final String LON_PREF = "lon";
+
+    private final SharedPreferences mSharedPrefs;
+
+    public MapPreferences(Context context) {
+        mSharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+    }
+
+    /// Setters
+
+    public void setLastMapCenter(IGeoPoint center) {
+        SharedPreferences.Editor editor = mSharedPrefs.edit();
+        editor.putFloat(LAT_PREF, (float) center.getLatitude());
+        editor.putFloat(LON_PREF, (float) center.getLongitude());
+        apply(editor);
+    }
+
+    /// Getters
+
+    public GeoPoint getLastMapCenter() {
+        final float lat = mSharedPrefs.getFloat(LAT_PREF, 0);
+        final float lon = mSharedPrefs.getFloat(LON_PREF, 0);
+        return new GeoPoint(lat, lon);
+    }
+
+    /// Helpers
+    @TargetApi(9)
+    private static void apply(SharedPreferences.Editor editor) {
+        if (Build.VERSION.SDK_INT >= 9) {
+            editor.apply();
+        } else if (!editor.commit()) {
+            Log.e(LOGTAG, "", new IllegalStateException("commit() failed"));
+        }
+    }
+}


### PR DESCRIPTION
Rather than having the user see (0,0) every time they start, persist the last map center, and use that if the stumbler service doesn't yet have a real location.

Persisting some preferences for the Map separate from the the rest of the app/service seemed to make sense in this context.  Can move that if desired. 
