### PR TITLE
Data storage timer bugs: (1) upload timer kept being reset (2) new idle timer to flush 

### DIFF
--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -282,7 +282,7 @@ public final class MainActivity extends FragmentActivity {
             formatTextView(R.id.reports_sent, R.string.reports_sent, Integer.parseInt(value));
         }
         catch (IOException ex) {
-            Log.e(LOGTAG, "Exception in showUploadStats():" + ex.toString());
+            Log.e(LOGTAG, "Exception in showUploadStats()", ex);
         }
     }
 

--- a/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
+++ b/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
@@ -163,7 +163,7 @@ public class UploadReportsDialog extends DialogFragment
             mTotalDataSentView.setText(String.valueOf(kilobytes));
         }
         catch (IOException ex) {
-            Log.e(LOGTAG, "Exception in updateSyncedStats():" + ex.toString());
+            Log.e(LOGTAG, "Exception in updateSyncedStats()", ex);
         }
     }
 

--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -161,7 +161,7 @@ public final class StumblerService extends PersistentIntentService
                 AppGlobals.dataStorageManager.saveCurrentReportsToDisk();
             } catch (IOException ex) {
                 AppGlobals.guiLogInfo(ex.toString());
-                Log.e(LOGTAG, "Exception in onDestroy saving reports:" + ex.toString());
+                Log.e(LOGTAG, "Exception in onDestroy saving reports", ex);
             }
         }
         mReporter.shutdown();

--- a/src/org/mozilla/mozstumbler/service/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/StumblerService.java
@@ -23,7 +23,7 @@ import org.mozilla.mozstumbler.service.utils.PersistentIntentService;
 import java.io.IOException;
 
 public final class StumblerService extends PersistentIntentService
-        implements DataStorageManager.DatabaseIsEmptyTracker {
+        implements DataStorageManager.StorageIsEmptyTracker {
     private static final String LOGTAG          = StumblerService.class.getName();
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE;
     public static final String ACTION_START_PASSIVE = ACTION_BASE + ".START_PASSIVE";
@@ -221,12 +221,11 @@ public final class StumblerService extends PersistentIntentService
         if (AppGlobals.isDebug)Log.d(LOGTAG,"onRebind");
     }
 
-    public void databaseIsEmpty(boolean isEmpty) {
+    public void storageIsEmpty(boolean isEmpty) {
         if (isEmpty) {
             UploadAlarmReceiver.cancelAlarm(this);
         } else {
             UploadAlarmReceiver.scheduleAlarm(this);
         }
     }
-
 }

--- a/src/org/mozilla/mozstumbler/service/datahandling/DataStorageManager.java
+++ b/src/org/mozilla/mozstumbler/service/datahandling/DataStorageManager.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.ResourceBundle;
 
 /** Stores reports in memory (mCurrentReports) until MAX_REPORTS_IN_MEMORY,
  * then writes them to disk as a .gz file. The name of the file has
@@ -230,7 +229,7 @@ public class DataStorageManager {
             try {
                 writeSyncStats(last_upload_time, 0, observations_sent, wifis_sent, cells_sent);
             } catch (IOException ex) {
-                Log.e(LOG_TAG, "Exception in DataStorageManager upgrading db:" + ex.toString());
+                Log.e(LOG_TAG, "Exception in DataStorageManager upgrading db:", ex);
             }
         }
     }
@@ -456,12 +455,12 @@ public class DataStorageManager {
         try {
             out = new FileOutputStream(mStatsFile);
             Properties props = new Properties();
-            props.setProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "" + time);
-            props.setProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "" + bytesSent);
-            props.setProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "" + totalObs);
-            props.setProperty(DataStorageContract.Stats.KEY_CELLS_SENT, "" + totalCells);
-            props.setProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "" + totalWifis);
-            props.setProperty(DataStorageContract.Stats.KEY_VERSION, "" + DataStorageContract.Stats.VERSION_CODE);
+            props.setProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, String.valueOf(time));
+            props.setProperty(DataStorageContract.Stats.KEY_BYTES_SENT, String.valueOf(bytesSent));
+            props.setProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, String.valueOf(totalObs));
+            props.setProperty(DataStorageContract.Stats.KEY_CELLS_SENT, String.valueOf(totalCells));
+            props.setProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, String.valueOf(totalWifis));
+            props.setProperty(DataStorageContract.Stats.KEY_VERSION, String.valueOf(DataStorageContract.Stats.VERSION_CODE));
             props.store(out, null);
         } finally {
             if (out != null)

--- a/src/org/mozilla/mozstumbler/service/scanners/WifiScanner.java
+++ b/src/org/mozilla/mozstumbler/service/scanners/WifiScanner.java
@@ -155,7 +155,7 @@ public class WifiScanner extends BroadcastReceiver {
                     stop(); // set mWifiScanTimer to null
                     return;
                 }
-                if (AppGlobals.isDebug) Log.d(LOGTAG, "WiFi Scanning Timer fired");
+                if (AppGlobals.isDebug) Log.v(LOGTAG, "WiFi Scanning Timer fired");
                 getWifiManager().startScan();
             }
         }, 0, WIFI_MIN_UPDATE_TIME);
@@ -197,7 +197,7 @@ public class WifiScanner extends BroadcastReceiver {
         if (scanResults.isEmpty())
             return;
 
-        if (AppGlobals.isDebug) Log.d(LOGTAG, scanResults.toString());
+        if (AppGlobals.isDebug) Log.v(LOGTAG, scanResults.toString());
 
         Intent i = new Intent(ACTION_WIFIS_SCANNED);
         i.putParcelableArrayListExtra(ACTION_WIFIS_SCANNED_ARG_RESULTS, scanResults);


### PR DESCRIPTION
Some trivial fixes for 2 edge cases, one is where collections keep happening and the upload timer keeps getting pushed back by rescheduling, the other where there are collections in memory that aren't being flushed to disk because stumbler is idle and there is no wifi.

Also, bundled in a few cleanup items with this PR.
