### PR TITLE
Coverage overlay zoom

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
@@ -1,0 +1,27 @@
+package org.mozilla.mozstumbler.client.mapview;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import org.osmdroid.DefaultResourceProxyImpl;
+import org.osmdroid.tileprovider.MapTileProviderBasic;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.views.overlay.TilesOverlay;
+
+/**
+ * This class provides the Mozilla Coverage overlay
+ */
+public class CoverageOverlay extends TilesOverlay {
+
+    public CoverageOverlay(final Context aContext, final String coverageUrl) {
+        super(new MapTileProviderBasic(aContext), new DefaultResourceProxyImpl(aContext));
+        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
+                null,
+                1, 13, 256,
+                ".png",
+                new String[] { coverageUrl });
+        this.setLoadingBackgroundColor(Color.TRANSPARENT);
+        mTileProvider.setTileSource(coverageTileSource);
+    }
+}

--- a/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
@@ -17,6 +17,9 @@ import org.osmdroid.util.TileLooper;
 import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.TilesOverlay;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * This class provides the Mozilla Coverage overlay
  */
@@ -25,6 +28,7 @@ public class CoverageOverlay extends TilesOverlay {
     private final Rect mTileRect = new Rect();
     private final Point mTilePoint = new Point();
     private final Point mTilePointMercator = new Point();
+    private final Set<MapTile> mDrawnSet = new HashSet<MapTile>();
     private Projection mProjection;
 
     public CoverageOverlay(final Context aContext, final String coverageUrl) {
@@ -51,6 +55,7 @@ public class CoverageOverlay extends TilesOverlay {
             super.drawTiles(c, projection, zoomLevel, tileSizePx, viewPort);
         } else {
             mProjection = projection;
+            mDrawnSet.clear();
             mCoverageTileLooper.loop(c, zoomLevel, tileSizePx, viewPort);
         }
     }
@@ -72,16 +77,15 @@ public class CoverageOverlay extends TilesOverlay {
             final int zoomDifference = pTile.getZoomLevel() - zoomLevel;
             final int scaleDiff = 1 << zoomDifference;
 
-            // Only draw each large tile once
-            if (pX % scaleDiff != 0 || pY % scaleDiff != 0) {
-                return;
-            }
-
             pTileSizePx *= scaleDiff;
             pX /= scaleDiff;
             pY /= scaleDiff;
 
             final MapTile tile = new MapTile(zoomLevel, pTile.getX() >> zoomDifference, pTile.getY() >> zoomDifference);
+            if (mDrawnSet.contains(tile)) {
+                return;
+            }
+            mDrawnSet.add(tile);
 
             Drawable currentMapTile = mTileProvider.getMapTile(tile);
 

--- a/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
@@ -1,18 +1,31 @@
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.content.Context;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 
 import org.osmdroid.DefaultResourceProxyImpl;
+import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
+import org.osmdroid.tileprovider.ReusableBitmapDrawable;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.util.TileLooper;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.TilesOverlay;
 
 /**
  * This class provides the Mozilla Coverage overlay
  */
 public class CoverageOverlay extends TilesOverlay {
+
+    private final Rect mTileRect = new Rect();
+    private final Point mTilePoint = new Point();
+    private final Point mTilePointMercator = new Point();
+    private Projection mProjection;
 
     public CoverageOverlay(final Context aContext, final String coverageUrl) {
         super(new MapTileProviderBasic(aContext), new DefaultResourceProxyImpl(aContext));
@@ -23,5 +36,81 @@ public class CoverageOverlay extends TilesOverlay {
                 new String[] { coverageUrl });
         this.setLoadingBackgroundColor(Color.TRANSPARENT);
         mTileProvider.setTileSource(coverageTileSource);
+    }
+
+    // Though the tile provider can only provide up to 13, this overlay will display higher.
+    @Override
+    public int getMaximumZoomLevel() {
+        return 18;
+    }
+
+    @Override
+    public void drawTiles(final Canvas c, final Projection projection, final int zoomLevel,
+                          final int tileSizePx, final Rect viewPort) {
+        if (zoomLevel <= mTileProvider.getMaximumZoomLevel()) {
+            super.drawTiles(c, projection, zoomLevel, tileSizePx, viewPort);
+        } else {
+            mProjection = projection;
+            mCoverageTileLooper.loop(c, zoomLevel, tileSizePx, viewPort);
+        }
+    }
+
+    private final TileLooper mCoverageTileLooper = new TileLooper() {
+        @Override
+        public void initialiseLoop(int pZoomLevel, int pTileSizePx) {
+            // make sure the cache is big enough for all the tiles
+            final int numNeeded = (mLowerRight.y - mUpperLeft.y + 1) * (mLowerRight.x - mUpperLeft.x + 1);
+            mTileProvider.ensureCapacity(numNeeded + getOvershootTileCache());
+        }
+
+        @Override
+        public void finaliseLoop() {}
+
+        @Override
+        public void handleTile(Canvas pCanvas, int pTileSizePx, MapTile pTile, int pX, int pY) {
+            int zoomLevel = Math.min(pTile.getZoomLevel(), mTileProvider.getMaximumZoomLevel());
+            final int zoomDifference = pTile.getZoomLevel() - zoomLevel;
+            final int scaleDiff = 1 << zoomDifference;
+
+            // Only draw each large tile once
+            if (pX % scaleDiff != 0 || pY % scaleDiff != 0) {
+                return;
+            }
+
+            pTileSizePx *= scaleDiff;
+            pX /= scaleDiff;
+            pY /= scaleDiff;
+
+            final MapTile tile = new MapTile(zoomLevel, pTile.getX() >> zoomDifference, pTile.getY() >> zoomDifference);
+
+            Drawable currentMapTile = mTileProvider.getMapTile(tile);
+
+            boolean isReusable = currentMapTile instanceof ReusableBitmapDrawable;
+            final ReusableBitmapDrawable reusableBitmapDrawable =
+                    isReusable ? (ReusableBitmapDrawable) currentMapTile : null;
+
+            if (currentMapTile != null) {
+                mTilePoint.set(pX * pTileSizePx, pY * pTileSizePx);
+                mTileRect.set(mTilePoint.x, mTilePoint.y, mTilePoint.x + pTileSizePx, mTilePoint.y
+                        + pTileSizePx);
+                if (isReusable) {
+                    reusableBitmapDrawable.beginUsingDrawable();
+                }
+                try {
+                    onTileReadyToDraw2(pCanvas, currentMapTile, mTileRect);
+                } finally {
+                    if (isReusable)
+                        reusableBitmapDrawable.finishUsingDrawable();
+                }
+            }
+        }
+    };
+
+    private void onTileReadyToDraw2(final Canvas c, final Drawable currentMapTile,
+                                     final Rect tileRect) {
+        mProjection.toPixelsFromMercator(tileRect.left, tileRect.top, mTilePointMercator);
+        tileRect.offsetTo(mTilePointMercator.x, mTilePointMercator.y);
+        currentMapTile.setBounds(tileRect);
+        currentMapTile.draw(c);
     }
 }

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -39,8 +39,6 @@ import org.mozilla.mozstumbler.client.MainActivity;
 import org.mozilla.mozstumbler.service.scanners.GPSScanner;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.tileprovider.BitmapPool;
-import org.osmdroid.tileprovider.MapTileProviderBasic;
-import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
@@ -49,7 +47,6 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.PathOverlay;
-import org.osmdroid.views.overlay.TilesOverlay;
 
 public final class MapActivity extends Activity {
     private static final String LOGTAG = MapActivity.class.getName();
@@ -73,7 +70,7 @@ public final class MapActivity extends Activity {
     private boolean mUserPanning = false;
     private ReporterBroadcastReceiver mReceiver;
     Timer mGetUrl = new Timer();
-    TilesOverlay mCoverageTilesOverlay = null;
+    Overlay mCoverageTilesOverlay = null;
 
     static GpsTrackLocationReceiver sGpsTrackLocationReceiver;
 
@@ -240,22 +237,9 @@ public final class MapActivity extends Activity {
                                 new String[] { BuildConfig.TILE_SERVER_URL });
     }
 
-    private static TilesOverlay CoverageTilesOverlay(Context context) {
-        final MapTileProviderBasic coverageTileProvider = new MapTileProviderBasic(context);
-        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
-                null,
-                1, 13, 256,
-                ".png",
-                new String[] { sCoverageUrl });
-        coverageTileProvider.setTileSource(coverageTileSource);
-        final TilesOverlay coverageTileOverlay = new TilesOverlay(coverageTileProvider,context);
-        coverageTileOverlay.setLoadingBackgroundColor(Color.TRANSPARENT);
-        return coverageTileOverlay;
-    }
-
     private void setUserPositionAt(Location location) {
         if  (mCoverageTilesOverlay == null && sCoverageUrl != null) {
-            mCoverageTilesOverlay = CoverageTilesOverlay(this);
+            mCoverageTilesOverlay = new CoverageOverlay(this, sCoverageUrl);
             mMap.getOverlays().add(mCoverageTilesOverlay);
         }
 


### PR DESCRIPTION
This moves the coverage overlay into its own class which, for the moment, extends the TilesOverlay.  Once it is changed to be purely vector based, it no longer need do so, but there should not be changes necessary to the MapActivity at that point as it sees the coverage map as a simple Overlay.

When asked to draw zoom levels greater than those provided by the coverage map (currently level 13), this will now determine a scaling factor, grab the lower zoom level image, and do a simple scale to draw the overlay.

Once the vectorization is at a happy point, it should be able to be swapped into the mCoverageTileLooper with minimal fuss.
