### PR TITLE
Use MapQuest OSM tiles instead of Mapnik

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -231,7 +231,7 @@ public final class MapActivity extends Activity {
     @SuppressWarnings("ConstantConditions")
     private static OnlineTileSourceBase getTileSource() {
         if (BuildConfig.TILE_SERVER_URL == null) {
-            return TileSourceFactory.DEFAULT_TILE_SOURCE;
+            return TileSourceFactory.MAPQUESTOSM;
         }
         return new XYTileSource("MozStumbler Tile Store",
                                 null,


### PR DESCRIPTION
Members of the OSM community recommended making use of the free MapQuest tiles instead of leaning on the mapnik infrastructure.  More information available at:

http://developer.mapquest.com/web/products/open/map
