### PR TITLE
fix stop scanning button in the Notification pulldown

### DIFF
--- a/src/org/mozilla/mozstumbler/client/AboutActivity.java
+++ b/src/org/mozilla/mozstumbler/client/AboutActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.app.Activity;

--- a/src/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/src/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.content.Intent;

--- a/src/org/mozilla/mozstumbler/client/LogActivity.java
+++ b/src/org/mozilla/mozstumbler/client/LogActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.app.Activity;

--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -44,7 +44,7 @@ public final class MainActivity extends FragmentActivity {
 
     /* if service exists, start scanning, otherwise do nothing  */
     public static final String ACTION_UI_UNPAUSE_SCANNING = ACTION_BASE + "UNPAUSE_SCANNING";
-    public static final String ACTION_UI_TOGGLE_SCAN = ACTION_BASE + "TOGGLE_SCAN";
+    public static final String ACTION_UI_PAUSE_SCANNING = ACTION_BASE + "PAUSE_SCANNING";
 
 
     private static final String LEADERBOARD_URL = "https://location.services.mozilla.com/leaders";
@@ -64,7 +64,7 @@ public final class MainActivity extends FragmentActivity {
 
             CompoundButton scanningBtn = (CompoundButton) findViewById(R.id.toggle_scanning);
 
-            if (intent.getAction().equals(MainActivity.ACTION_UI_TOGGLE_SCAN) && service.isScanning()) {
+            if (intent.getAction().equals(MainActivity.ACTION_UI_PAUSE_SCANNING) && service.isScanning()) {
                 // Grab the scanning button and just click it
                 onToggleScanningClicked(scanningBtn);
             } else if (intent.getAction().equals(MainActivity.ACTION_UI_UNPAUSE_SCANNING) && !service.isScanning()) {
@@ -115,8 +115,8 @@ public final class MainActivity extends FragmentActivity {
         // Register a listener for a toggle event in the notification pulldown
         LocalBroadcastManager bManager = LocalBroadcastManager.getInstance(this);
         IntentFilter intentFilter = new IntentFilter();
-        intentFilter.addAction(MainActivity.ACTION_UI_TOGGLE_SCAN);
         intentFilter.addAction(MainActivity.ACTION_UI_UNPAUSE_SCANNING);
+        intentFilter.addAction(MainActivity.ACTION_UI_PAUSE_SCANNING);
         bManager.registerReceiver(notificationDrawerEventReceiver, intentFilter);
 
         Log.d(LOG_TAG, "onCreate");

--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.app.AlertDialog;

--- a/src/org/mozilla/mozstumbler/client/MainApp.java
+++ b/src/org/mozilla/mozstumbler/client/MainApp.java
@@ -44,7 +44,7 @@ public class MainApp extends Application {
     private MainActivity mMainActivity;
     private final long MAX_BYTES_DISK_STORAGE = 1000 * 1000 * 20; // 20MB for MozStumbler by default, is ok?
     private final int MAX_WEEKS_OLD_STORED = 4;
-    private static final String INTENT_TURN_OFF = "org.mozilla.mozstumbler.turnMeOff";
+    public static final String INTENT_TURN_OFF = "org.mozilla.mozstumbler.turnMeOff";
     private static final int    NOTIFICATION_ID = 1;
 
     public Prefs getPrefs() {
@@ -137,7 +137,7 @@ public class MainApp extends Application {
             mReceiver.unregister();
         }
         mReceiver = null;
-        Log.d(LOG_TAG, "onStop");
+        Log.d(LOG_TAG, "onTerminate");
     }
 
     private void startScanning() {
@@ -195,8 +195,8 @@ public class MainApp extends Application {
                 intentFilter.addAction(WifiScanner.ACTION_WIFIS_SCANNED);
                 intentFilter.addAction(CellScanner.ACTION_CELLS_SCANNED);
                 intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);
-                intentFilter.addAction(MainActivity.ACTION_UNPAUSE_SCANNING);
                 intentFilter.addAction(MainActivity.ACTION_UPDATE_UI);
+                intentFilter.addAction(INTENT_TURN_OFF);
                 LocalBroadcastManager.getInstance(MainApp.this).registerReceiver(this, intentFilter);
             }
         }
@@ -223,9 +223,6 @@ public class MainApp extends Application {
 
             if (action.equals(GPSScanner.ACTION_GPS_UPDATED)) {
                 receivedGpsMessage(intent);
-            } else if (action.equals(MainActivity.ACTION_UNPAUSE_SCANNING) &&
-                    null != mStumblerService) {
-                startScanning();
             }
 
             if (mMainActivity != null) {

--- a/src/org/mozilla/mozstumbler/client/MainApp.java
+++ b/src/org/mozilla/mozstumbler/client/MainApp.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/client/PackageUtils.java
+++ b/src/org/mozilla/mozstumbler/client/PackageUtils.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
+++ b/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
+++ b/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
@@ -17,18 +18,6 @@ public final class TurnOffReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.d(LOG_TAG, "onReceive!");
-
-        Intent serviceIntent = new Intent(context, ClientStumblerService.class);
-        IBinder binder = peekService(context, serviceIntent);
-        if (binder != null) {
-            // service is running, tell it to stop
-            ClientStumblerService.StumblerBinder serviceBinder = (ClientStumblerService.StumblerBinder) binder;
-            ClientStumblerService service = serviceBinder.getService();
-            service.stopScanning();
-        }
-
-        // In the case where the MainActivity is in the foreground, we need to tell it to update
-        context.sendBroadcast(new Intent(MainActivity.ACTION_UPDATE_UI));
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(MainActivity.ACTION_UI_TOGGLE_SCAN));
     }
 }

--- a/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
+++ b/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.content.BroadcastReceiver;

--- a/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
+++ b/src/org/mozilla/mozstumbler/client/TurnOffReceiver.java
@@ -22,6 +22,6 @@ public final class TurnOffReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(MainActivity.ACTION_UI_TOGGLE_SCAN));
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(MainActivity.ACTION_UI_PAUSE_SCANNING));
     }
 }

--- a/src/org/mozilla/mozstumbler/client/Updater.java
+++ b/src/org/mozilla/mozstumbler/client/Updater.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.app.Activity;

--- a/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
+++ b/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import android.app.AlertDialog;

--- a/src/org/mozilla/mozstumbler/client/WifiBlockLists.java
+++ b/src/org/mozilla/mozstumbler/client/WifiBlockLists.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client;
 
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.WifiBlockListInterface;

--- a/src/org/mozilla/mozstumbler/client/cellscanner/DefaultCellScanner.java
+++ b/src/org/mozilla/mozstumbler/client/cellscanner/DefaultCellScanner.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.cellscanner;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/CoverageOverlay.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.content.Context;

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.location.Location;
@@ -345,7 +344,7 @@ public final class MapActivity extends Activity {
     protected void onStart() {
         super.onStart();
 
-        Intent i = new Intent(MainActivity.ACTION_UNPAUSE_SCANNING);
+        Intent i = new Intent(MainActivity.ACTION_UI_UNPAUSE_SCANNING);
         LocalBroadcastManager.getInstance(this).sendBroadcast(i);
 
         mReceiver = new ReporterBroadcastReceiver();

--- a/src/org/mozilla/mozstumbler/client/mapview/MapPreferences.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapPreferences.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.TargetApi;

--- a/src/org/mozilla/mozstumbler/client/mapview/Searcher.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/Searcher.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.util.Log;

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -92,8 +92,8 @@ public class ScanManager {
         return ActiveOrPassiveStumbling.PASSIVE_STUMBLING == mStumblingMode;
     }
 
-    public void startScanning(Context context) {
-        if (mIsScanning) {
+    public synchronized void startScanning(Context context) {
+        if (this.isScanning()) {
             return;
         }
 
@@ -117,8 +117,8 @@ public class ScanManager {
         mIsScanning = true;
     }
 
-    public boolean stopScanning() {
-        if (!mIsScanning) {
+    public synchronized boolean stopScanning() {
+        if (!this.isScanning()) {
             return false;
         }
 
@@ -138,7 +138,7 @@ public class ScanManager {
         WifiScanner.setWifiBlockList(list);
     }
 
-    public boolean isScanning() {
+    public synchronized boolean isScanning() {
         return mIsScanning;
     }
 

--- a/src/org/mozilla/mozstumbler/tests/ServiceTest.java
+++ b/src/org/mozilla/mozstumbler/tests/ServiceTest.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.tests;
 
 import android.content.Intent;


### PR DESCRIPTION
Fix for issue #761 - Ignore ctags files

This patch fixes the "Stop Scanning" button in the notification pulldown.

The old code had a secondary code path to disable the scanning in TurnOffReceiver.
This patch changes the TurnOffReceiver to just send an intent to disable the scanning using a local broadcast.

The MapActivity sent an ACTION_UNPAUSE_SCANNING intent which was being accepted by the MainApp, this has been moved into the MainActivity instead..

When MainActivity::onToggleScanningClickedView() is called, we force the UI to update.  This was previously causing problems where the MapActivity would enable the scan, but the button UI was not properly refreshing.
