### PR TITLE
Hardware acceleration option in prefs, on by default

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -95,5 +95,6 @@
     <string name="scroll_to_start">Scroll to Top</string>
     <string name="scroll_to_end">Scroll to End</string>
     <string name="upload_observations_data_size">Size (KB):</string>
+    <string name="hardware_acceleration_title">Enable hardware acceleration</string>
 
 </resources>

--- a/res/xml/stumbler_preferences.xml
+++ b/res/xml/stumbler_preferences.xml
@@ -29,4 +29,8 @@
         android:summary="@string/wifi_scan_always_summary"
         android:defaultValue="false" />
 
+    <CheckBoxPreference
+        android:key="hardware_acceleration"
+        android:title="@string/hardware_acceleration_title"
+        android:defaultValue="true" />
 </PreferenceScreen>

--- a/src/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/src/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -10,6 +10,7 @@ public class ClientPrefs extends Prefs {
     private static final String LOG_TAG = ClientPrefs.class.getName();
     private static final String LAT_PREF = "lat";
     private static final String LON_PREF = "lon";
+    private static final String HARDWARE_ACCEL_PREF = "hardware_acceleration";
 
     protected ClientPrefs(Context context) {
         super(context);
@@ -34,14 +35,22 @@ public class ClientPrefs extends Prefs {
     }
 
     public synchronized void setLastMapCenter(IGeoPoint center) {
-        SharedPreferences.Editor editor = getPrefs().edit();
         editor.putFloat(LAT_PREF, (float) center.getLatitude());
         editor.putFloat(LON_PREF, (float) center.getLongitude());
         apply(editor);
     }
+
     public synchronized GeoPoint getLastMapCenter() {
         final float lat = getPrefs().getFloat(LAT_PREF, 0);
         final float lon = getPrefs().getFloat(LON_PREF, 0);
         return new GeoPoint(lat, lon);
+    }
+
+    public boolean getIsHardwareAccelerated() {
+        return getBoolPrefWithDefault(HARDWARE_ACCEL_PREF, true);
+    }
+
+    public void setIsHardwareAccelerated(boolean on) {
+        setBoolPref(HARDWARE_ACCEL_PREF, on);
     }
 }

--- a/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
+++ b/src/org/mozilla/mozstumbler/client/PreferencesScreen.java
@@ -19,7 +19,6 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.text.TextUtils;
 import org.mozilla.mozstumbler.R;
-import org.mozilla.mozstumbler.service.Prefs;
 
 public class PreferencesScreen extends PreferenceActivity {
     private static final int REQUEST_CODE_WIFI_SCAN_ALWAYS = 1;
@@ -29,11 +28,12 @@ public class PreferencesScreen extends PreferenceActivity {
     private Preference mGeofenceHere;
     private CheckBoxPreference mWifiScanAlwaysSwitch;
     private CheckBoxPreference mWifiPreference;
+    private CheckBoxPreference mIsHardwareAccelerated;
 
-    private static Prefs sPrefs;
+    private static ClientPrefs sPrefs;
 
     /* Precondition to using this class, call this method to set Prefs */
-    public static void setPrefs(Prefs p) {
+    public static void setPrefs(ClientPrefs p) {
         sPrefs = p;
     }
 
@@ -51,6 +51,7 @@ public class PreferencesScreen extends PreferenceActivity {
         mGeofenceSwitch = (CheckBoxPreference) getPreferenceManager().findPreference("geofence_switch");
         mGeofenceHere = getPreferenceManager().findPreference("geofence_here");
         mWifiScanAlwaysSwitch = (CheckBoxPreference) getPreferenceManager().findPreference("wifi_scan_always");
+        mIsHardwareAccelerated = (CheckBoxPreference) getPreferenceManager().findPreference("hardware_acceleration");
 
         setNicknamePreferenceTitle(sPrefs.getNickname());
         mWifiPreference.setChecked(sPrefs.getUseWifiOnly());
@@ -112,6 +113,14 @@ public class PreferencesScreen extends PreferenceActivity {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 sPrefs.setUseWifiOnly(newValue.equals(true));
+                return true;
+            }
+        });
+
+        mIsHardwareAccelerated.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                sPrefs.setIsHardwareAccelerated(newValue.equals(true));
                 return true;
             }
         });

--- a/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
+++ b/src/org/mozilla/mozstumbler/client/UploadReportsDialog.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 
 import org.mozilla.mozstumbler.service.utils.AbstractCommunicator;
 import org.mozilla.mozstumbler.service.AppGlobals;
-import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageContract;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
@@ -92,9 +91,10 @@ public class UploadReportsDialog extends DialogFragment
             @Override
             public void onClick(View v) {
                 AsyncUploader.UploadSettings settings =
-                        new AsyncUploader.UploadSettings(Prefs.getInstance().getWifiScanAlways(), Prefs.getInstance().getUseWifiOnly());
+                        new AsyncUploader.UploadSettings(ClientPrefs.getInstance().getWifiScanAlways(),
+                                ClientPrefs.getInstance().getUseWifiOnly());
                 mUploader = new AsyncUploader(settings, UploadReportsDialog.this);
-                mUploader.setNickname(Prefs.getInstance().getNickname());
+                mUploader.setNickname(ClientPrefs.getInstance().getNickname());
                 mUploader.execute();
                 updateProgressbarStatus();
             }

--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -23,6 +23,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -32,7 +33,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.ClientStumblerService;
 import org.mozilla.mozstumbler.client.MainApp;
 import org.mozilla.mozstumbler.service.AppGlobals;
@@ -132,6 +132,14 @@ public final class MapActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (((MainApp) getApplication()).getPrefs().getIsHardwareAccelerated() &&
+            Build.VERSION.SDK_INT > 10) {
+                getWindow().setFlags(
+                        WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+                        WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
+        }
+
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         setContentView(R.layout.activity_map);
 

--- a/src/org/mozilla/mozstumbler/client/mapview/Searcher.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/Searcher.java
@@ -13,7 +13,7 @@ import java.io.InputStreamReader;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.mozilla.mozstumbler.service.Prefs;
+import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.utils.AbstractCommunicator;
 import org.mozilla.mozstumbler.service.AppGlobals;
 
@@ -27,7 +27,7 @@ public class Searcher extends AbstractCommunicator {
     private JSONObject mResponse;
 
     public Searcher() {
-        super(Prefs.getInstance().getUserAgent());
+        super(ClientPrefs.getInstance().getUserAgent());
     }
 
     @Override


### PR DESCRIPTION
Ideally we can make a conclusion as to whether this preference is needed, and whether hardware acceleration should be on or off. I vote for on, the user experience is much better (on the devices I have tested), and the RAM usage looks comparable to similar apps.
