### PR TITLE
Limit the gps location dot update to 1 Hz max

### DIFF
--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -178,8 +178,9 @@ public final class MainActivity extends FragmentActivity {
         boolean isGeofenced = false;
 
         locationsScanned = service.getLocationCount();
-        latitude = service.getLatitude();
-        longitude = service.getLongitude();
+        Location location = service.getLocation();
+        latitude = location.getLatitude();
+        longitude = location.getLongitude();
         wifiStatus = service.getWifiStatus();
         APs = service.getAPCount();
         visibleAPs = service.getVisibleAPCount();

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -81,14 +81,6 @@ public class StumblerService extends PersistentIntentService
         return mScanManager.getLocationCount();
     }
 
-    public double getLatitude() {
-        return mScanManager.getLatitude();
-    }
-
-    public double getLongitude() {
-        return mScanManager.getLongitude();
-    }
-
     public Location getLocation() {
         return mScanManager.getLocation();
     }


### PR DESCRIPTION
1 Hz is the typical max rate of a GPS, I can see it update more frequently than this, which only conflicts with pan and zoom gestures if done too often.
