### PR TITLE
Fix #510 - Only collect StumblerBundle instances if we've got valid NMEA data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build
 gradle.properties
 *.keystore
 local.properties
+
+# ignore vim swap files
+*.sw?

--- a/src/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client;
+
+/**
+ * This is the public threadsafe interface for the MainActivity.
+ *
+ * This is useful as the MainActivity needs to operate on the UI
+ * thread, but events may come from bound services, or by Intent
+ * listeners.
+ */
+
+public interface IMainActivity {
+    public void updateUiOnMainThread();
+    public void setGpsFixes(int fixes);
+    public void setGpsSats(int sats);
+}
+

--- a/src/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -14,6 +14,7 @@ package org.mozilla.mozstumbler.client;
 
 public interface IMainActivity {
     public void updateUiOnMainThread();
+
     public void setGpsFixes(int fixes);
     public void setGpsSats(int sats);
 }

--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -56,21 +56,20 @@ public final class MainActivity extends FragmentActivity
 
 
     public synchronized void setGpsFixes(int fixes) {
-        this.mGpsFixes = fixes;
+        mGpsFixes = fixes;
     }
 
     public synchronized void setGpsSats(int sats) {
-        this.mGpsSats = sats;
+        mGpsSats = sats;
     }
 
     public synchronized int getGpsFixes() {
-        return this.mGpsFixes;
+        return mGpsFixes;
     }
 
     public synchronized int getGpsSats() {
-        return this.mGpsSats;
+        return mGpsSats;
     }
-
 
     private BroadcastReceiver notificationDrawerEventReceiver = new BroadcastReceiver() {
         @Override

--- a/src/org/mozilla/mozstumbler/client/MainActivity.java
+++ b/src/org/mozilla/mozstumbler/client/MainActivity.java
@@ -36,13 +36,14 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
 import java.io.IOException;
 import java.util.Properties;
 
-public final class MainActivity extends FragmentActivity {
+public final class MainActivity extends FragmentActivity
+                                implements IMainActivity {
+
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MainActivity.class.getSimpleName();
 
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".MainActivity.";
     public static final String ACTION_UPDATE_UI = ACTION_BASE + "UPDATE_UI";
 
-    /* if service exists, start scanning, otherwise do nothing  */
     public static final String ACTION_UI_UNPAUSE_SCANNING = ACTION_BASE + "UNPAUSE_SCANNING";
     public static final String ACTION_UI_PAUSE_SCANNING = ACTION_BASE + "PAUSE_SCANNING";
 
@@ -52,6 +53,23 @@ public final class MainActivity extends FragmentActivity {
     int                      mGpsFixes;
     int                      mGpsSats;
     private boolean          mGeofenceHere = false;
+
+
+    public synchronized void setGpsFixes(int fixes) {
+        this.mGpsFixes = fixes;
+    }
+
+    public synchronized void setGpsSats(int sats) {
+        this.mGpsSats = sats;
+    }
+
+    public synchronized int getGpsFixes() {
+        return this.mGpsFixes;
+    }
+
+    public synchronized int getGpsSats() {
+        return this.mGpsSats;
+    }
 
 
     private BroadcastReceiver notificationDrawerEventReceiver = new BroadcastReceiver() {
@@ -146,7 +164,7 @@ public final class MainActivity extends FragmentActivity {
         }
     }
 
-    protected void updateUiOnMainThread() {
+    public void updateUiOnMainThread() {
         this.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -187,10 +205,10 @@ public final class MainActivity extends FragmentActivity {
         currentCellInfo = service.getCurrentCellInfoCount();
         isGeofenced = service.isGeofenced();
 
-        String lastLocationString = (mGpsFixes > 0 && locationsScanned > 0)?
+        String lastLocationString = (this.getGpsFixes() > 0 && locationsScanned > 0)?
                                     formatLocation(latitude, longitude) : "-";
 
-        formatTextView(R.id.gps_satellites, R.string.gps_satellites, mGpsFixes, mGpsSats);
+        formatTextView(R.id.gps_satellites, R.string.gps_satellites, this.getGpsFixes(), this.getGpsSats());
         formatTextView(R.id.last_location, R.string.last_location, lastLocationString);
         formatTextView(R.id.wifi_access_points, R.string.wifi_access_points, APs);
         setVisibleAccessPoints(scanning, wifiStatus, visibleAPs);
@@ -199,7 +217,7 @@ public final class MainActivity extends FragmentActivity {
         formatTextView(R.id.locations_scanned, R.string.locations_scanned, locationsScanned);
         service.checkPrefs();
         if (mGeofenceHere) {
-            if (mGpsFixes > 0 && locationsScanned > 0) {
+            if (this.getGpsFixes() > 0 && locationsScanned > 0) {
                 Location coord = new Location(AppGlobals.LOCATION_ORIGIN_INTERNAL);
                 coord.setLatitude(latitude);
                 coord.setLongitude(longitude);

--- a/src/org/mozilla/mozstumbler/client/MainApp.java
+++ b/src/org/mozilla/mozstumbler/client/MainApp.java
@@ -44,7 +44,7 @@ public class MainApp extends Application {
     private ClientStumblerService mStumblerService;
     private ServiceConnection mConnection;
     private ServiceBroadcastReceiver mReceiver;
-    private MainActivity mMainActivity;
+    private IMainActivity mMainActivity;
     private final long MAX_BYTES_DISK_STORAGE = 1000 * 1000 * 20; // 20MB for MozStumbler by default, is ok?
     private final int MAX_WEEKS_OLD_STORED = 4;
     public static final String INTENT_TURN_OFF = "org.mozilla.mozstumbler.turnMeOff";
@@ -58,7 +58,7 @@ public class MainApp extends Application {
         return mStumblerService;
     }
 
-    public void setMainActivity(MainActivity mainActivity) {
+    public void setMainActivity(IMainActivity mainActivity) {
         mMainActivity = mainActivity;
     }
 
@@ -215,8 +215,8 @@ public class MainApp extends Application {
         private void receivedGpsMessage(Intent intent) {
             String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
             if (subject.equals(GPSScanner.SUBJECT_NEW_STATUS) && mMainActivity != null) {
-                mMainActivity.mGpsFixes = intent.getIntExtra(GPSScanner.NEW_STATUS_ARG_FIXES ,0);
-                mMainActivity.mGpsSats = intent.getIntExtra(GPSScanner.NEW_STATUS_ARG_SATS, 0);
+                mMainActivity.setGpsFixes(intent.getIntExtra(GPSScanner.NEW_STATUS_ARG_FIXES ,0));
+                mMainActivity.setGpsSats(intent.getIntExtra(GPSScanner.NEW_STATUS_ARG_SATS, 0));
             }
         }
 

--- a/src/org/mozilla/mozstumbler/client/MainApp.java
+++ b/src/org/mozilla/mozstumbler/client/MainApp.java
@@ -199,6 +199,7 @@ public class MainApp extends Application {
                 intentFilter.addAction(WifiScanner.ACTION_WIFIS_SCANNED);
                 intentFilter.addAction(CellScanner.ACTION_CELLS_SCANNED);
                 intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);
+                intentFilter.addAction(GPSScanner.ACTION_NMEA_RECEIVED);
                 intentFilter.addAction(MainActivity.ACTION_UPDATE_UI);
                 intentFilter.addAction(INTENT_TURN_OFF);
                 LocalBroadcastManager.getInstance(MainApp.this).registerReceiver(this, intentFilter);
@@ -220,6 +221,17 @@ public class MainApp extends Application {
             }
         }
 
+        private void receivedNmeaMessage(Intent intent) {
+            String nmea_data = intent.getStringExtra(GPSScanner.NMEA_DATA);
+
+
+            if (nmea_data != null) {
+                // TODO: we should probably have some kind of visual
+                // indicator to note that GPS NMEA data is being
+                // actively received.
+            }
+        }
+
         @Override
         public void onReceive(Context context, Intent intent) {
 
@@ -227,6 +239,10 @@ public class MainApp extends Application {
 
             if (action.equals(GPSScanner.ACTION_GPS_UPDATED)) {
                 receivedGpsMessage(intent);
+            }
+
+            if (action.equals(GPSScanner.ACTION_NMEA_RECEIVED)) {
+                receivedNmeaMessage(intent);
             }
 
             if (mMainActivity != null) {

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread;
+
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * This is the public interface for the Reporter class.  
+ * All methods here are properly synchronized as the reporter
+ * must manage a consistent StumblerBundle instance.
+ */
+public interface IReporter {
+    /*
+     * There are 2 threads of control that can access the
+     * reporter.  
+     *
+     * The StumberService (or ClientStumblerService)
+     * has a reference called mReporter which is an instance of
+     * the Reporter object.  It invokes the flush() method when
+     * StumblerService::stopScanning() is called - usually from UI
+     * events from an Activity.
+     *
+     * The other thread of control is the Android intents pump,
+     * which calls into the Reporter class through onReceive via
+     * an Intent.
+     * 
+     */
+
+    public void startup(Context context);
+    public void shutdown();
+    public void flush();
+    public void onReceive(Context context, Intent intent);
+
+}

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
@@ -32,6 +32,5 @@ public interface IReporter {
     public void startup(Context context);
     public void shutdown();
     public void flush();
-    public void onReceive(Context context, Intent intent);
 
 }

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -103,7 +103,10 @@ public final class Reporter extends BroadcastReceiver {
         if (subject.equals(GPSScanner.SUBJECT_NEW_LOCATION)) {
             reportCollectedLocation();
             Location newPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
-            mBundle = (newPosition != null) ? new StumblerBundle(newPosition, mPhoneType) : mBundle;
+
+            if (newPosition != null) {
+                mBundle = new StumblerBundle(newPosition, mPhoneType);
+            }
         }
     }
 

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -29,7 +29,7 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellS
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
 
-public final class Reporter extends BroadcastReceiver {
+public final class Reporter extends BroadcastReceiver implements IReporter {
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Reporter.class.getSimpleName();
     public static final String ACTION_FLUSH_TO_BUNDLE = AppGlobals.ACTION_NAMESPACE + ".FLUSH";
     private boolean mIsStarted;
@@ -47,8 +47,7 @@ public final class Reporter extends BroadcastReceiver {
 
     Reporter() {}
 
-
-    void startup(Context context) {
+    public synchronized void startup(Context context) {
         if (mIsStarted) {
             return;
         }
@@ -69,7 +68,7 @@ public final class Reporter extends BroadcastReceiver {
                 intentFilter);
     }
 
-    void shutdown() {
+    public synchronized void shutdown() {
         if (mContext == null) {
             return;
         }
@@ -105,7 +104,7 @@ public final class Reporter extends BroadcastReceiver {
     }
 
     @Override
-    public void onReceive(Context context, Intent intent) {
+    public synchronized void onReceive(Context context, Intent intent) {
         String action = intent.getAction();
 
         if (action.equals(ACTION_FLUSH_TO_BUNDLE)) {

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -47,9 +47,6 @@ public final class Reporter extends BroadcastReceiver {
 
     Reporter() {}
 
-    private void resetData() {
-        mBundle = null;
-    }
 
     public void flush() {
         reportCollectedLocation();
@@ -66,7 +63,7 @@ public final class Reporter extends BroadcastReceiver {
 
         mIsStarted = true;
 
-        resetData();
+        mBundle = null;
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(WifiScanner.ACTION_WIFIS_SCANNED);
         intentFilter.addAction(CellScanner.ACTION_CELLS_SCANNED);

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -98,6 +98,7 @@ public final class Reporter extends BroadcastReceiver {
             Location newPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
 
             if (newPosition != null) {
+                flush();
                 mBundle = new StumblerBundle(newPosition, mPhoneType);
             }
         }

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -35,7 +35,7 @@ public class StumblerService extends PersistentIntentService
     public static final String ACTION_NOT_FROM_HOST_APP = ACTION_BASE + ".NOT_FROM_HOST";
     public static final AtomicBoolean sFirefoxStumblingEnabled = new AtomicBoolean();
     protected final ScanManager mScanManager = new ScanManager();
-    protected final Reporter mReporter = new Reporter();
+    protected final IReporter mReporter = new Reporter();
 
     // This is a delay before the single-shot upload is attempted. The number is arbitrary
     // and used to avoid startup tasks bunching up.

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -55,19 +55,6 @@ public final class StumblerBundle implements Parcelable {
         out.writeInt(mPhoneType);
     }
 
-    public static final Parcelable.Creator<StumblerBundle> CREATOR
-        = new Parcelable.Creator<StumblerBundle>() {
-        @Override
-        public StumblerBundle createFromParcel(Parcel in) {
-            return new StumblerBundle(in);
-        }
-
-        @Override
-        public StumblerBundle[] newArray(int size) {
-            return new StumblerBundle[size];
-        }
-    };
-
     private StumblerBundle(Parcel in) {
         mWifiData = new HashMap<String, ScanResult>();
         mCellData = new HashMap<String, CellInfo>();

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -18,6 +18,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
 
+/**
+ * A StumblerBundle contains stumbling data related to a single GPS lat/long fix.
+ */
 public final class StumblerBundle implements Parcelable {
     private final int mPhoneType;
     private final Location mGpsPosition;

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -135,6 +135,7 @@ public class GPSScanner implements LocationListener {
         };
 
         lm.addGpsStatusListener(mGPSListener);
+        lm.addNmeaListener(mNMEAListener);
     }
 
     public void stop() {

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -34,6 +34,10 @@ public class GPSScanner implements LocationListener {
     public static final String NEW_STATUS_ARG_SATS = "sats";
     public static final String NEW_LOCATION_ARG_LOCATION = "location";
 
+    public static final String ACTION_NMEA_RECEIVED = ACTION_BASE + "NMEA_RECEIVED";
+    public static final String NMEA_DATA = "nmea_data";
+    public static final String NMEA_TIMESTAMP = "nmea_ts";
+
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + GPSScanner.class.getSimpleName();
     private static final int MIN_SAT_USED_IN_FIX = 3;
     private static final long ACTIVE_MODE_GPS_MIN_UPDATE_TIME_MS = 1000;
@@ -44,6 +48,7 @@ public class GPSScanner implements LocationListener {
     private final LocationBlockList mBlockList = new LocationBlockList();
     private final Context mContext;
     private GpsStatus.Listener mGPSListener;
+    private GpsStatus.NmeaListener mNMEAListener;
     private int mLocationCount;
     private Location mLocation = new Location("internal");
     private boolean mAutoGeofencing;
@@ -80,6 +85,17 @@ public class GPSScanner implements LocationListener {
                                   this);
 
         reportLocationLost();
+
+        mNMEAListener = new GpsStatus.NmeaListener() {
+            public void onNmeaReceived(long timestamp, String nmea) {
+                // Send an intent with a copy of the NMEA data
+                Intent intent = new Intent(ACTION_NMEA_RECEIVED);
+                intent.putExtra(NMEA_TIMESTAMP, timestamp);
+                intent.putExtra(NMEA_DATA, nmea);
+                LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(intent);
+            }
+        };
+
         mGPSListener = new GpsStatus.Listener() {
                 public void onGpsStatusChanged(int event) {
                 if (event == GpsStatus.GPS_EVENT_SATELLITE_STATUS) {
@@ -106,6 +122,15 @@ public class GPSScanner implements LocationListener {
                 } else if (event == GpsStatus.GPS_EVENT_STOPPED) {
                     reportLocationLost();
                 }
+            }
+
+            private void reportNewGpsStatus(int fixes, int sats) {
+                Intent i = new Intent(ACTION_GPS_UPDATED);
+                i.putExtra(Intent.EXTRA_SUBJECT, SUBJECT_NEW_STATUS);
+                i.putExtra(NEW_STATUS_ARG_FIXES, fixes);
+                i.putExtra(NEW_STATUS_ARG_SATS, sats);
+                i.putExtra(ACTION_ARG_TIME, System.currentTimeMillis());
+                LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
             }
         };
 
@@ -249,12 +274,4 @@ public class GPSScanner implements LocationListener {
         LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
     }
 
-    private void reportNewGpsStatus(int fixes, int sats) {
-        Intent i = new Intent(ACTION_GPS_UPDATED);
-        i.putExtra(Intent.EXTRA_SUBJECT, SUBJECT_NEW_STATUS);
-        i.putExtra(NEW_STATUS_ARG_FIXES, fixes);
-        i.putExtra(NEW_STATUS_ARG_SATS, sats);
-        i.putExtra(ACTION_ARG_TIME, System.currentTimeMillis());
-        LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
-    }
 }

--- a/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
+++ b/src/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
@@ -33,17 +33,6 @@ public class CellInfo implements Parcelable {
     public static final int UNKNOWN_CID = -1;
     public static final int UNKNOWN_SIGNAL = -1000;
 
-    public static final Parcelable.Creator<CellInfo> CREATOR
-            = new Parcelable.Creator<CellInfo>() {
-        public CellInfo createFromParcel(Parcel in) {
-            return new CellInfo(in);
-        }
-
-        public CellInfo[] newArray(int size) {
-            return new CellInfo[size];
-        }
-    };
-
     private String mRadio;
     private String mCellRadio;
 


### PR DESCRIPTION
This should fix #510 

This adds an NMEA listener to the MainActivity and the Reporter.

An incoming NMEA data stream is a pretty good indicator that we're using a real GPS.

The MainActivity has stubs so that we can add visual feedback that NMEA data is being read.

The Reporter checks that we've received GGA and GSV sentences within the last 60 seconds or else StumblerBundle instances are not created.

I also did some minor code cleanup along the way.
