### PR TITLE
Post the zoom and center on the map directly

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -140,7 +140,7 @@ public final class MapActivity extends Activity {
         mMap.getController().setZoom(zoom);
         mMap.getController().setCenter(loc);
 
-        new Handler().postDelayed(new Runnable() {
+        mMap.post(new Runnable() {
             @Override
             public void run() {
                 // https://github.com/osmdroid/osmdroid/issues/22
@@ -151,7 +151,7 @@ public final class MapActivity extends Activity {
                 mMap.getController().setZoom(zoom);
                 mMap.getController().setCenter(loc);
             }
-        }, 300);
+        });
 
         Log.d(LOG_TAG, "onCreate");
 


### PR DESCRIPTION
Rather than create a new Handler with a delay, post onto the mMap directly the
zoom & center with no delay.

This worked similarly for me as the postDelayed with an independent Handler().
