### PR TITLE
Features/osmdroid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ local.properties
 
 # ignore vim swap files
 *.sw?
+
+# JAR releases
+libs/*.jar

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MozStumbler
 [![Build Status](https://travis-ci.org/mozilla/MozStumbler.png)](https://travis-ci.org/mozilla/MozStumbler.png)
 
-# Building #
+# Building # 
 
 ```
 ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.+'
+
+        // Gradle download task is from: https://github.com/michel-kraemer/gradle-download-task
+        classpath 'de.undercouch:gradle-download-task:1.0'
     }
 }
 
@@ -15,12 +18,24 @@ repositories {
     mavenCentral()
 }
 
+
+import de.undercouch.gradle.tasks.download.Download
+
+def libDir = "libs"
+
+task updateJars(type: Download) {
+    src([
+        'https://github.com/mozilla/osmdroid/releases/download/4.3pre0/osmdroid-android-4.3-SNAPSHOT.jar'
+    ])
+    dest libDir
+}
+
 android {
     compileSdkVersion 19
     buildToolsVersion '19.1.0'
 
     dependencies {
-        compile "org.osmdroid:osmdroid-android:4.2"
+        compile files('libs/osmdroid-android-4.3-SNAPSHOT.jar')
         compile 'org.slf4j:slf4j-android:1.7.7'
         compile "com.android.support:support-v4:19.1.+"
     }
@@ -62,6 +77,12 @@ android {
         abortOnError true
         disable 'MissingTranslation'
     }
+}
+
+// Declare dependency between building the android app and grabbing the
+// JAR files.  I hate you gradle and your crappy DSL.
+project.afterEvaluate{
+    prepareDebugDependencies.dependsOn("updateJars")
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ repositories {
 
 import de.undercouch.gradle.tasks.download.Download
 
-def libDir = "libs"
+def libDir = new File("libs")
+libDir.mkdirs()
 
 task updateJars(type: Download) {
     src([


### PR DESCRIPTION
Fixes #808 

We now use our own fork of osmdroid - you'll have to run libs/update.sh to grab the latest JAR file for osmdroid
