### PR TITLE
Basic integration of Galaxy leaderboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ android {
         compile "org.osmdroid:osmdroid-android:4.2"
         compile 'org.slf4j:slf4j-android:1.7.7'
         compile "com.android.support:support-v4:19.1.+"
+        compile "com.loopj.android:android-async-http:1.4.5"
     }
 
     sourceSets {

--- a/src/org/mozilla/mozstumbler/client/leaderboard/GalaxyManager.java
+++ b/src/org/mozilla/mozstumbler/client/leaderboard/GalaxyManager.java
@@ -1,0 +1,345 @@
+package org.mozilla.mozstumbler.client.leaderboard;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.loopj.android.http.JsonHttpResponseHandler;
+import com.loopj.android.http.RequestParams;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.StringEntity;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Created by JeremyChiang on 2014-08-28.
+ */
+public class GalaxyManager {
+
+    private static final String TAG = GalaxyManager.class.getName();
+    private GalaxyManagerListener galaxyManagerListener;
+
+    public interface GalaxyManagerListener {
+        public void gameFound(JSONObject game);
+        public void leaderboardFound(JSONObject leaderboard);
+        public void scoresFound(JSONArray scores);
+    }
+
+    public GalaxyManager(GalaxyManagerListener galaxyManagerListener) {
+        this.galaxyManagerListener = galaxyManagerListener;
+    }
+
+    public void getGame(final String gameSlug) {
+        RequestParams requestParams = null;
+
+        GalaxyRestClient.get(
+                GalaxyRestClient.GAME_DIRECTORY + "/" + gameSlug,
+                requestParams,
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                        // If the response is JSONObject instead of a JSONArray.
+                        Log.d(TAG, "Game, " + gameSlug + ", retrieved with status code: " + statusCode);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.gameFound(response);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error retrieving game, " + gameSlug + ", reason: " + responseString);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.gameFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.gameFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.gameFound(null);
+                        }
+                    }
+                });
+    }
+
+    public void createGame(Context context, final String nameOfSlug, String nameOfGame, String description, String appUrl) {
+        JSONObject game = new JSONObject();
+        Header[] headers = null;
+
+        try {
+            game.put(GalaxyRestClient.KEY_GAME_SLUG, nameOfSlug);
+            game.put(GalaxyRestClient.KEY_GAME_NAME, nameOfGame);
+            game.put(GalaxyRestClient.KEY_GAME_DESCRIPTION, description);
+            game.put(GalaxyRestClient.KEY_GAME_URL, appUrl);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        HttpEntity gameEntity = null;
+
+        try {
+            gameEntity = new StringEntity(game.toString());
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        GalaxyRestClient.post(
+                context,
+                GalaxyRestClient.GAME_DIRECTORY + "/",
+                headers,
+                gameEntity,
+                "application/json",
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                        // If the response is JSONObject instead of a JSONArray.
+                        Log.d(TAG, "Game, " + nameOfSlug + ", created with status code: " + statusCode);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error creating game, " + nameOfSlug + ", reason: " + responseString);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating game, " + nameOfSlug + ", reason: " + errorResponse.toString());
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating game, " + nameOfSlug + ", reason: " + errorResponse.toString());
+                    }
+                });
+    }
+
+    public void getLeaderboard(final String gameSlug, final String leaderboardSlug) {
+        RequestParams requestParams = null;
+
+        GalaxyRestClient.get(
+                GalaxyRestClient.GAME_DIRECTORY + "/" + gameSlug + "/" +
+                GalaxyRestClient.LEADERBOARD_DIRECTORY + "/" + leaderboardSlug,
+                requestParams,
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                        // If the response is JSONObject instead of a JSONArray.
+                        Log.d(TAG, "Leaderboard, " + leaderboardSlug + ", retrieved with status code: " + statusCode);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.leaderboardFound(response);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error retrieving leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + responseString);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.leaderboardFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.leaderboardFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.leaderboardFound(null);
+                        }
+                    }
+                });
+    }
+
+    public void createLeaderboard(Context context, final String gameSlug, final String leaderboardSlug, final String leaderboardName) {
+        JSONObject leaderboard = new JSONObject();
+        Header[] headers = null;
+
+        try {
+            leaderboard.put(GalaxyRestClient.KEY_LEADERBOARD_SLUG, leaderboardSlug);
+            leaderboard.put(GalaxyRestClient.KEY_LEADERBOARD_NAME, leaderboardName);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        HttpEntity leaderboardEntity = null;
+
+        try {
+            leaderboardEntity = new StringEntity(leaderboard.toString());
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        GalaxyRestClient.post(
+                context,
+                GalaxyRestClient.GAME_DIRECTORY + "/" + gameSlug + "/" + GalaxyRestClient.LEADERBOARD_DIRECTORY,
+                headers,
+                leaderboardEntity,
+                "application/json",
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                        // If the response is JSONObject instead of a JSONArray.
+                        Log.d(TAG, "Leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", created with status code: " + statusCode);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error creating leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + responseString);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+                    }
+                });
+    }
+
+    public void getScores(final String gameSlug, final String leaderboardSlug) {
+        RequestParams requestParams = null;
+
+        GalaxyRestClient.get(
+                GalaxyRestClient.GAME_DIRECTORY + "/" + gameSlug +
+                        "/" + GalaxyRestClient.LEADERBOARD_DIRECTORY + "/" + leaderboardSlug +
+                        "/" + GalaxyRestClient.SCORES_DIRECTORY,
+                requestParams,
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONArray response) {
+                        super.onSuccess(statusCode, headers, response);
+                        Log.d(TAG, "Scores for leaderboard, " + leaderboardSlug + ", retrieved with status code: " + statusCode);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.scoresFound(response);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error retrieving scores for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + responseString);
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.scoresFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving scores for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.scoresFound(null);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error retrieving scores for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+
+                        if (galaxyManagerListener != null) {
+                            galaxyManagerListener.scoresFound(null);
+                        }
+                    }
+                });
+    }
+
+    public void setScore(Context context, final String gameSlug, final String leaderboardSlug, final String userName, final int newScore) {
+        JSONObject score = new JSONObject();
+        Header[] headers = null;
+
+        try {
+            score.put(GalaxyRestClient.KEY_SCORE_USER, userName);
+            score.put(GalaxyRestClient.KEY_SCORE_SCORE, newScore);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        HttpEntity scoreEntity = null;
+
+        try {
+            scoreEntity = new StringEntity(score.toString());
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        GalaxyRestClient.post(
+                context,
+                GalaxyRestClient.GAME_DIRECTORY + "/" + gameSlug +
+                        "/" + GalaxyRestClient.LEADERBOARD_DIRECTORY + "/" + leaderboardSlug +
+                        "/" + GalaxyRestClient.SCORES_DIRECTORY,
+                headers,
+                scoreEntity,
+                "application/json",
+                new JsonHttpResponseHandler() {
+                    @Override
+                    public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                        // If the response is JSONObject instead of a JSONArray.
+                        Log.d(TAG, "Score for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", created with status code: " + statusCode);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
+                        super.onFailure(statusCode, headers, responseString, throwable);
+                        Log.d(TAG, "Error creating score for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + responseString);
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating score for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+                    }
+
+                    @Override
+                    public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONArray errorResponse) {
+                        super.onFailure(statusCode, headers, throwable, errorResponse);
+                        Log.d(TAG, "Error creating score for leaderboard, " + leaderboardSlug + ", for game, " + gameSlug + ", reason: " + errorResponse.toString());
+                    }
+                });
+    }
+}

--- a/src/org/mozilla/mozstumbler/client/leaderboard/GalaxyRestClient.java
+++ b/src/org/mozilla/mozstumbler/client/leaderboard/GalaxyRestClient.java
@@ -1,0 +1,53 @@
+package org.mozilla.mozstumbler.client.leaderboard;
+
+import android.content.Context;
+
+import com.loopj.android.http.AsyncHttpClient;
+import com.loopj.android.http.AsyncHttpResponseHandler;
+import com.loopj.android.http.RequestParams;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+
+/**
+ * Created by JeremyChiang on 2014-08-28.
+ */
+public class GalaxyRestClient {
+
+    private static final String BASE_URL = "https://api-galaxy.dev.mozaws.net/";
+    private static AsyncHttpClient client = new AsyncHttpClient();
+
+    public static final String GAME_SLUG = "mozstumbler";
+    public static final String GAME_NAME = "MozStumbler";
+    public static final String GAME_DESC = "A game based on stumbling WiFi access points.";
+    public static final String GAME_URL = "https://github.com/mozilla/MozStumbler";
+    public static final String GAME_DIRECTORY = "games";
+
+    public static final String LEADERBOARD_SLUG = "points-collected";
+    public static final String LEADERBOARD_NAME = "Points Collected Leaderboard";
+    public static final String LEADERBOARD_DIRECTORY = "leaderboards";
+    public static final String SCORES_DIRECTORY = "scores";
+
+    public static final String KEY_GAME_SLUG = "slug";
+    public static final String KEY_GAME_NAME = "name";
+    public static final String KEY_GAME_DESCRIPTION = "description";
+    public static final String KEY_GAME_URL = "app_url";
+
+    public static final String KEY_LEADERBOARD_SLUG = "slug";
+    public static final String KEY_LEADERBOARD_NAME = "name";
+
+    public static final String KEY_SCORE_USER = "user";
+    public static final String KEY_SCORE_SCORE = "score";
+
+    public static void get(String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
+        client.get(getAbsoluteUrl(url), params, responseHandler);
+    }
+
+    public static void post(Context context, String url, Header[] headers, HttpEntity entity, String contentType, AsyncHttpResponseHandler responseHandler) {
+        client.post(context, getAbsoluteUrl(url), headers, entity, contentType, responseHandler);
+    }
+
+    private static String getAbsoluteUrl(String relativeUrl) {
+        return BASE_URL + relativeUrl;
+    }
+}


### PR DESCRIPTION
- Uses http://loopj.com/android-async-http/
- Access and modify constants in GalaxyRestClient
- Instantiate an instance of GalaxyManager to get & post data
- When instantiating a GalaxyManager, pass a listener, or null if not interested in callbacks
