### PR TITLE
Place the marker for the current point over top of the previous points

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -183,11 +183,11 @@ public final class MapActivity extends Activity {
             mMap.getOverlays().add(mCoverageTilesOverlay);
         }
 
-        mAccuracyOverlay = new AccuracyCircleOverlay(this.getApplicationContext(), sGPSColor);
-        mMap.getOverlays().add(mAccuracyOverlay);
-
         mObservationPointsOverlay = new ObservationPointsOverlay(this, mMap);
         mMap.getOverlays().add(mObservationPointsOverlay);
+
+        mAccuracyOverlay = new AccuracyCircleOverlay(this.getApplicationContext(), sGPSColor);
+        mMap.getOverlays().add(mAccuracyOverlay);
 
         ObservedLocationsReceiver r = ObservedLocationsReceiver.getInstance(this);
         for (ObservationPoint p : r.getPoints()) {


### PR DESCRIPTION
Without this, the current position can get swamped by the previous points
when zoomed out.
