### PR TITLE
Fix auto-follow

### DIFF
--- a/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/src/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -91,6 +91,7 @@ public final class MapActivity extends Activity {
                 if (mAccuracyOverlay == null || mAccuracyOverlay.getLocation() == null)
                     return;
                 mMap.getController().animateTo((mAccuracyOverlay.getLocation()));
+                mUserPanning = false;
             }
         });
 
@@ -242,6 +243,8 @@ public final class MapActivity extends Activity {
             mFirstLocationFix = false;
             mMap.getController().setCenter(new GeoPoint(location));
             mUserPanning = false;
+        } else if (!mUserPanning) {
+            mMap.getController().animateTo((mAccuracyOverlay.getLocation()));
         }
 
         formatTextView(R.id.latitude_text, "%1$.4f", location.getLatitude());


### PR DESCRIPTION
The map no longer re-centers on the current location, making the user constantly press the centerMe button as they move.  After this change, pressing the centerMe button will keep centering until the user manually pans at which point it will stop following until they press the centerMe button again.
