### PR TITLE
Reporter/HttpUtil cleanup items for easier testing/debugging

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
@@ -34,6 +34,7 @@ public class MLSLocationGetter extends AsyncTask<String, Void, Location> {
 
     public interface MLSLocationGetterCallback {
         void setMLSResponseLocation(Location loc);
+        void errorMLSResponse();
     }
 
     public MLSLocationGetter(MLSLocationGetterCallback callback, JSONObject mlsQueryObj) {
@@ -54,7 +55,7 @@ public class MLSLocationGetter extends AsyncTask<String, Void, Location> {
 
         IResponse resp = mls.search(mQueryMLSBytes, null, false);
         if (resp == null) {
-            Log.e(LOG_TAG, "Error processing search request", new RuntimeException("Error processing search"));
+            Log.i(LOG_TAG, "Error processing search request");
             return null;
         }
         int bytesSent = resp.bytesSent();
@@ -86,8 +87,9 @@ public class MLSLocationGetter extends AsyncTask<String, Void, Location> {
     protected void onPostExecute(Location location) {
         sRequestCounter.decrementAndGet();
         if (location == null) {
-            return;
+            mCallback.errorMLSResponse();
+        } else {
+            mCallback.setMLSResponseLocation(location);
         }
-        mCallback.setMLSResponseLocation(location);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -12,6 +12,7 @@ import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageContract;
 import org.osmdroid.util.GeoPoint;
+import org.mozilla.mozstumbler.service.core.logging.Log;
 
 public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCallback {
     public GeoPoint pointGPS;
@@ -57,5 +58,9 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
             mMLSLocationGetter = null;
             pointMLS = new GeoPoint(location);
         }
+    }
+    public void errorMLSResponse() {
+        Log.i(ObservationPoint.class.getSimpleName(), "Error:" + mMLSQuery.toString());
+        mMLSLocationGetter = null;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
@@ -194,11 +194,9 @@ public class HttpUtil implements IHttpUtil {
                     getContentBody(httpURLConnection),
                     wire_data.length);
         } catch (IOException e) {
-            Log.e(LOG_TAG, "", e);
+            Log.i(LOG_TAG, "post error:" + e.toString() + " Data:" + data.toString());
         } finally {
-            if (httpURLConnection != null) {
-                httpURLConnection.disconnect();
-            }
+            httpURLConnection.disconnect();
         }
         return null;
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -105,13 +105,10 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
         if (subject.equals(GPSScanner.SUBJECT_NEW_LOCATION)) {
             Location newPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
-            if (newPosition != null) {
+            // Only create StumblerBundle instances if the NMEA data looks marginally ok
+            if (newPosition != null && this.hasNMEAData()) {
                 flush();
-                // Only create StumblerBundle instances if the NMEA
-                // data looks marginally ok
-                if (this.hasNMEAData()) {
-                    mBundle = new StumblerBundle(newPosition, mPhoneType);
-                }
+                mBundle = new StumblerBundle(newPosition, mPhoneType);
             }
         }
     }
@@ -250,6 +247,9 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             Log.d(LOG_TAG, "Received bundle: " + mlsObj.toString());
         }
 
+        if (wifiCount + cellCount < 1)
+            return;
+
         mPreviousBundleJSON = mlsObj;
 
         AppGlobals.guiLogInfo(mlsObj.toString());
@@ -259,7 +259,5 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }
-
-        mBundle.wasSent();
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -247,8 +247,9 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             Log.d(LOG_TAG, "Received bundle: " + mlsObj.toString());
         }
 
-        if (wifiCount + cellCount < 1)
+        if (wifiCount + cellCount < 1) {
             return;
+        }
 
         mPreviousBundleJSON = mlsObj;
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -27,12 +27,6 @@ public final class StumblerBundle implements Parcelable {
     private final Map<String, ScanResult> mWifiData;
     private final Map<String, CellInfo> mCellData;
 
-    public void wasSent() {
-        mGpsPosition.setTime(System.currentTimeMillis());
-        mWifiData.clear();
-        mCellData.clear();
-    }
-
     @Override
     public int describeContents() {
         return 0;


### PR DESCRIPTION
Reporter/HttpUtil cleanup
While debugging MLSLocationGetter I ran into a few cleanup issues
- wasSent() doesn't seem to serve a purpose, removed
- changed some Log.e(...) to be more concise as the code I was debugging
  was spamming the log when throwing exceptions
- added errorMLSResponse on MLSLocationGetter to clear the state after
  an error
- In Reporter.java, I added a check for zero wifi and cell count, it is
  hard to repro, it happens when I modify the code for load testing (as I
  typically do), but it helps prevent false errors when testing at the
  very least.
