### PR TITLE
Added tile storage dir override for osmdroid. 

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -37,6 +37,7 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellS
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploadParam;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
+import org.osmdroid.tileprovider.constants.TileFilePath;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,9 +73,26 @@ public class MainApp extends Application implements ObservedLocationsReceiver.IC
         mMainActivity = new WeakReference<IMainActivity>(mainActivity);
     }
 
+    private File getStorageDir(Context c) {
+        File dir = c.getExternalFilesDir(null);
+
+        if (dir == null) {
+            dir = c.getFilesDir();
+        }
+
+        if (dir == null) {
+            Log.i(LOG_TAG, "No tile storage available");
+            return null;
+        }
+
+        return new File(dir, "osmdroid");
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
+
+        TileFilePath.directoryOverride = getStorageDir(getApplicationContext());
 
         AppGlobals.isDebug = BuildConfig.DEBUG;
         AppGlobals.isRobolectric = BuildConfig.ROBOLECTRIC;


### PR DESCRIPTION
Solves the problem of no SD card by optionally storing the tile in internal storage.

Addresses the issues:
issue #918 and issue #892.
