### PR TITLE
queued MLS locations were being removed too early

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -83,9 +83,8 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
                         if (getMapActivity() != null) {
                             getMapActivity().newMLSPoint(obs);
                         }
+                        li.remove();
                     }
-                    li.remove();
-
                 }
             }
         }


### PR DESCRIPTION
I think i moved a line during a rebase, the queued MLS locations were being removed from the queue too early. (one line was out of place, fixed).
