### PR TITLE
With no wifi, switch to low-resolution tiles.

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -11,6 +11,7 @@ public class ClientPrefs extends Prefs {
     private static final String LAT_PREF = "lat";
     private static final String LON_PREF = "lon";
     private static final String IS_FIRST_RUN = "is_first_run";
+    private static final String FORCE_LOW_BANDWIDTH_TILES = "force_low_bandwidth_tiles";
     public static final String KEEP_SCREEN_ON_PREF = "keep_screen_on";
     public static final String ENABLE_OPTION_TO_SHOW_MLS_ON_MAP = "enable_the_option_to_show_mls_on_map";
     private static final String ON_MAP_MLS_DRAW_IS_ON = "actually_draw_mls_dots_on_map";
@@ -85,4 +86,11 @@ public class ClientPrefs extends Prefs {
         setOnMapShowMLS(isEnabled);
     }
 
+    public boolean isForcedLowBandwidthTiles() {
+        return getBoolPrefWithDefault(FORCE_LOW_BANDWIDTH_TILES, false);
+    }
+
+    public void setForcedLowBandwidthTiles(boolean b) {
+        setBoolPref(FORCE_LOW_BANDWIDTH_TILES, b);
+    }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -5,16 +5,18 @@
 package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.location.Location;
 import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -24,9 +26,8 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
-import java.util.Timer;
-import java.util.TimerTask;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mozilla.mozstumbler.BuildConfig;
@@ -34,13 +35,19 @@ import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.ClientStumblerService;
 import org.mozilla.mozstumbler.client.MainApp;
-import org.mozilla.mozstumbler.service.core.http.HttpUtil;
-import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.client.ObservedLocationsReceiver;
+import org.mozilla.mozstumbler.client.mapview.tiles.AbstractMapOverlay;
+import org.mozilla.mozstumbler.client.mapview.tiles.CoverageOverlay;
+import org.mozilla.mozstumbler.client.mapview.tiles.LowResMapOverlay;
 import org.mozilla.mozstumbler.client.navdrawer.MetricsView;
 import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.core.http.HttpUtil;
+import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
+import org.osmdroid.ResourceProxy;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.tileprovider.BitmapPool;
+import org.osmdroid.tileprovider.MapTile;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
@@ -48,10 +55,14 @@ import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Overlay;
 
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
 public final class MapActivity extends android.support.v4.app.Fragment
     implements MetricsView.IMapLayerToggleListener {
 
-    public enum NoMapAvailableMessage { eHideNoMapMessage, eNoMapDueToNoSdCard, eNoMapDueToNoInternet }
+    public enum NoMapAvailableMessage { eHideNoMapMessage, eNoMapDueToNoAccessibleStorage, eNoMapDueToNoInternet }
 
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MapActivity.class.getSimpleName();
 
@@ -59,11 +70,10 @@ public final class MapActivity extends android.support.v4.app.Fragment
     private static String sCoverageUrl = null;
     private static int sGPSColor;
     private static final String ZOOM_KEY = "zoom";
-    private static final int DEFAULT_ZOOM = 8;
+    private static final int DEFAULT_ZOOM = 13;
     private static final int DEFAULT_ZOOM_AFTER_FIX = 16;
     private static final String LAT_KEY = "latitude";
     private static final String LON_KEY = "longitude";
-    private static final long MAP_TILE_AVAILABILITY_TIMER_MS = 5000;
 
     private MapView mMap;
     private AccuracyCircleOverlay mAccuracyOverlay;
@@ -73,27 +83,22 @@ public final class MapActivity extends android.support.v4.app.Fragment
     private Overlay mCoverageTilesOverlay = null;
     private ObservationPointsOverlay mObservationPointsOverlay;
     private GPSListener mGPSListener;
-
+    private LowResMapOverlay mLowResMapOverlay;
+    private ITileSource mHighResMapSource;
     private View mRootView;
 
-    private final Handler mHandler = new Handler(Looper.getMainLooper());
-    private final Runnable mCheckForMapTileAvailability = new Runnable() {
-        @Override
-        public void run() {
-            ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-            boolean hasNetwork = cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
-
-            if (getActivity().getFilesDir() == null) {
-                showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoSdCard);
-            } else if (!hasNetwork) {
-                showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoInternet);
-            } else {
-                showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
-            }
-
-            mHandler.postDelayed(mCheckForMapTileAvailability, MAP_TILE_AVAILABILITY_TIMER_MS);
+    // Used to blank the high-res tile source when adding a low-res overlay
+    private class BlankTileSource extends OnlineTileSourceBase {
+        BlankTileSource() {
+            super("fake", ResourceProxy.string.mapquest_aerial /* arbitrary value */, 13,
+                    AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP, AbstractMapOverlay.TILE_PIXEL_SIZE,
+                    "", new String[] {""});
         }
-    };
+        @Override
+        public String getTileURLString(MapTile aTile) {
+            return null;
+        }
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -134,9 +139,6 @@ public final class MapActivity extends android.support.v4.app.Fragment
         });
 
         mMap = (MapView) mRootView.findViewById(R.id.map);
-        final OnlineTileSourceBase tileSource = getTileSource();
-        showCopyright(tileSource);
-        mMap.setTileSource(tileSource);
         mMap.setBuiltInZoomControls(true);
         mMap.setMultiTouchControls(true);
 
@@ -145,7 +147,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
         sGPSColor = getResources().getColor(R.color.gps_track);
 
         mFirstLocationFix = true;
-        int zoomLevel = DEFAULT_ZOOM; // Default to seeing the world, until we get a fix
+        int zoomLevel = DEFAULT_ZOOM;
         GeoPoint lastLoc = null;
         if (savedInstanceState != null) {
             mFirstLocationFix = false;
@@ -166,6 +168,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
         final int zoom = zoomLevel;
         mMap.getController().setZoom(zoom);
         mMap.getController().setCenter(loc);
+        mMap.setMinZoomLevel(13);
 
         mMap.post(new Runnable() {
             @Override
@@ -182,37 +185,6 @@ public final class MapActivity extends android.support.v4.app.Fragment
 
         Log.d(LOG_TAG, "onCreate");
 
-        // @TODO: we do a similar "read from URL" in Updater, AbstractCommunicator, make one function for this
-        if (sCoverageUrl == null) {
-            mGetUrl.schedule(new TimerTask() {
-                @Override
-                public void run() {
-
-                    IHttpUtil httpUtil = new HttpUtil();
-
-                    java.util.Scanner scanner;
-                    try {
-                        scanner = new java.util.Scanner(httpUtil.getUrlAsStream(COVERAGE_REDIRECT_URL), "UTF-8");
-                    } catch (Exception ex) {
-                        Log.d(LOG_TAG, ex.toString());
-                        AppGlobals.guiLogInfo("Failed to get coverage url:" + ex.toString());
-                        return;
-                    }
-                    scanner.useDelimiter("\\A");
-                    String result = scanner.next();
-                    try {
-                        sCoverageUrl = new JSONObject(result).getString("tiles_url");
-                    } catch (JSONException ex) {
-                        AppGlobals.guiLogInfo("Failed to get coverage url:" + ex.toString());
-                    }
-                    scanner.close();
-                }
-            }, 0);
-        } else {
-            mCoverageTilesOverlay = new CoverageOverlay(mRootView.getContext(), sCoverageUrl, mMap);
-            mMap.getOverlays().add(mCoverageTilesOverlay);
-        }
-
         mAccuracyOverlay = new AccuracyCircleOverlay(mRootView.getContext(), sGPSColor);
         mMap.getOverlays().add(mAccuracyOverlay);
 
@@ -226,11 +198,148 @@ public final class MapActivity extends android.support.v4.app.Fragment
         initTextView(R.id.text_wifis_visible);
         initTextView(R.id.text_observation_count);
 
+        initNetworkConnectionChangedListener();
+
+        showCopyright();
+
         return mRootView;
     }
 
     MainApp getApplication() {
         return (MainApp) getActivity().getApplication();
+    }
+
+    private Runnable mCoverageUrlQuery = new Runnable() {
+        @Override
+        public void run() {
+            // @TODO: we do a similar "read from URL" in Updater, AbstractCommunicator, make one function for this
+            if (sCoverageUrl == null) {
+                mGetUrl.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+
+                        IHttpUtil httpUtil = new HttpUtil();
+
+                        java.util.Scanner scanner;
+                        try {
+                            scanner = new java.util.Scanner(httpUtil.getUrlAsStream(COVERAGE_REDIRECT_URL), "UTF-8");
+                        } catch (Exception ex) {
+                            Log.d(LOG_TAG, ex.toString());
+                            AppGlobals.guiLogInfo("Failed to get coverage url:" + ex.toString());
+                            return;
+                        }
+                        scanner.useDelimiter("\\A");
+                        String result = scanner.next();
+                        try {
+                            sCoverageUrl = new JSONObject(result).getString("tiles_url");
+                        } catch (JSONException ex) {
+                            AppGlobals.guiLogInfo("Failed to get coverage url:" + ex.toString());
+                        }
+                        scanner.close();
+                    }
+                }, 0);
+            } else if (mCoverageTilesOverlay == null) {
+                mCoverageTilesOverlay = new CoverageOverlay(mRootView.getContext(), sCoverageUrl, mMap);
+                addOverlayCoverageLayer();
+            }
+        }
+    };
+
+    private void addOverlayBaseLayer() {
+        if (mLowResMapOverlay == null) {
+            return;
+        }
+        List<Overlay> overlays = mMap.getOverlays();
+        if (overlays.indexOf(mLowResMapOverlay) == -1) {
+            overlays.add(0, mLowResMapOverlay);
+        }
+    }
+
+    private void addOverlayCoverageLayer() {
+        if (mCoverageTilesOverlay == null) {
+            return;
+        }
+        List<Overlay> overlays = mMap.getOverlays();
+        int idx = 0;
+        if (overlays.indexOf(mLowResMapOverlay) > -1) {
+           idx = 1;
+        }
+        overlays.add(idx, mCoverageTilesOverlay);
+    }
+
+    private void setHighBandwidthMap(boolean isHighBandwidth) {
+        if (ClientPrefs.getInstance().isForcedLowBandwidthTiles()) {
+            isHighBandwidth = false;
+        }
+
+        boolean isMLSTileStore = (BuildConfig.TILE_SERVER_URL != null);
+
+        if (isHighBandwidth) {
+            if (mLowResMapOverlay == null && mMap.getTileProvider().getTileSource() == mHighResMapSource) {
+                // already have set this tile source
+                return;
+            } else  {
+                mMap.getOverlays().remove(mLowResMapOverlay);
+                mLowResMapOverlay = null;
+                Toast.makeText(this.getActivity(), R.string.switch_to_high_res_tile, Toast.LENGTH_SHORT).show();
+            }
+
+            if (!isMLSTileStore) {
+                mHighResMapSource = TileSourceFactory.MAPQUESTOSM;
+            } else {
+                // TODO replace me with MapBoxTileSource
+                mHighResMapSource = new XYTileSource("MozStumbler Tile Store",
+                        null, 1, AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP,
+                        AbstractMapOverlay.TILE_PIXEL_SIZE,
+                        AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,
+                        new String[]{BuildConfig.TILE_SERVER_URL});
+            }
+            mMap.setTileSource(mHighResMapSource);
+        } else {
+            if (mLowResMapOverlay != null) {
+                // already set this
+                return;
+            }
+            mMap.setTileSource(new BlankTileSource());
+            if (mLowResMapOverlay == null) {
+                mLowResMapOverlay = new LowResMapOverlay(this.getActivity(), isMLSTileStore, mMap);
+                addOverlayBaseLayer();
+            }
+
+            Toast.makeText(this.getActivity(), R.string.switch_to_low_res_tile, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void mapNetworkConnectionChanged() {
+        if (getActivity().getFilesDir() == null) {
+            // Not the ideal spot for this check perhaps, but there is no point in checking
+            // the network when storage is not available.
+            showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoAccessibleStorage);
+            return;
+        }
+
+        mMap.post(mCoverageUrlQuery);
+
+        ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        boolean hasNetwork = cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
+
+        if (!hasNetwork) {
+            showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoInternet);
+            return;
+        }
+
+        showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
+
+        NetworkInfo info = cm.getActiveNetworkInfo();
+        setHighBandwidthMap(info.getType() == ConnectivityManager.TYPE_WIFI);
+    }
+
+    private void initNetworkConnectionChangedListener() {
+        getActivity().registerReceiver(new BroadcastReceiver() {
+            public void onReceive(Context context, Intent intent) {
+                mapNetworkConnectionChanged();
+            }
+        }, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
     }
 
     private void setStartStopMenuState(MenuItem menuItem, boolean scanning) {
@@ -271,21 +380,9 @@ public final class MapActivity extends android.support.v4.app.Fragment
         setStartStopMenuState(menuItem, !isScanning);
     }
 
-    @SuppressWarnings("ConstantConditions")
-    private static OnlineTileSourceBase getTileSource() {
-        if (BuildConfig.TILE_SERVER_URL == null) {
-            return TileSourceFactory.MAPQUESTOSM;
-        }
-        return new XYTileSource("MozStumbler Tile Store",
-                                null,
-                                1, 20, 256,
-                                ".png",
-                                new String[] { BuildConfig.TILE_SERVER_URL });
-    }
-
-    private void showCopyright(OnlineTileSourceBase tileSource) {
+    private void showCopyright() {
         TextView copyrightArea = (TextView) mRootView.findViewById(R.id.copyright_area);
-        if (TileSourceFactory.MAPQUESTOSM.equals(tileSource)) {
+        if (BuildConfig.TILE_SERVER_URL == null) {
             copyrightArea.setText("Tiles Courtesy of MapQuest\n© OpenStreetMap contributors");
         } else {
             copyrightArea.setText("© MapBox © OpenStreetMap contributors");
@@ -315,7 +412,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
         // @TODO Move this code to an appropriate place
         if (mCoverageTilesOverlay == null && sCoverageUrl != null) {
             mCoverageTilesOverlay = new CoverageOverlay(getActivity().getApplicationContext(), sCoverageUrl, mMap);
-            mMap.getOverlays().add(mMap.getOverlays().indexOf(mAccuracyOverlay), mCoverageTilesOverlay);
+            addOverlayCoverageLayer();
         }
 
         formatTextView(R.id.text_satellites_used, "%d", fixes);
@@ -362,7 +459,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
 
         dimToolbar();
 
-        mHandler.postDelayed(mCheckForMapTileAvailability, MAP_TILE_AVAILABILITY_TIMER_MS);
+        mapNetworkConnectionChanged();
     }
 
     private void saveStateToPrefs() {
@@ -379,8 +476,6 @@ public final class MapActivity extends android.support.v4.app.Fragment
         mGPSListener.removeListener();
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();
         observer.removeMapActivity();
-
-        mHandler.removeCallbacks(mCheckForMapTileAvailability);
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -90,7 +90,8 @@ public final class MapActivity extends android.support.v4.app.Fragment
     // Used to blank the high-res tile source when adding a low-res overlay
     private class BlankTileSource extends OnlineTileSourceBase {
         BlankTileSource() {
-            super("fake", ResourceProxy.string.mapquest_aerial /* arbitrary value */, 13,
+            super("fake", ResourceProxy.string.mapquest_aerial /* arbitrary value */,
+                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
                     AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP, AbstractMapOverlay.TILE_PIXEL_SIZE,
                     "", new String[] {""});
         }
@@ -168,7 +169,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
         final int zoom = zoomLevel;
         mMap.getController().setZoom(zoom);
         mMap.getController().setCenter(loc);
-        mMap.setMinZoomLevel(13);
+        mMap.setMinZoomLevel(AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP);
 
         mMap.post(new Runnable() {
             @Override
@@ -320,8 +321,10 @@ public final class MapActivity extends android.support.v4.app.Fragment
 
         mMap.post(mCoverageUrlQuery);
 
-        ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-        boolean hasNetwork = cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
+        final ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        final NetworkInfo info = cm.getActiveNetworkInfo();
+        final boolean hasNetwork = (info != null) && cm.getActiveNetworkInfo().isConnected();
+        final boolean hasWifi = (info != null) && (info.getType() == ConnectivityManager.TYPE_WIFI);
 
         if (!hasNetwork) {
             showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoInternet);
@@ -329,9 +332,7 @@ public final class MapActivity extends android.support.v4.app.Fragment
         }
 
         showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
-
-        NetworkInfo info = cm.getActiveNetworkInfo();
-        setHighBandwidthMap(info.getType() == ConnectivityManager.TYPE_WIFI);
+        setHighBandwidthMap(hasWifi);
     }
 
     private void initNetworkConnectionChangedListener() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -24,6 +24,8 @@ import java.util.Set;
 public abstract class AbstractMapOverlay extends TilesOverlay {
     // We want the map to zoom to level 20, even if tiles have less zoom available
     public static final int MAX_ZOOM_LEVEL_OF_MAP = 20;
+    public static final int MIN_ZOOM_LEVEL_OF_MAP = 13;
+
     public static final int TILE_PIXEL_SIZE = 256;
     // Use png32 which is a 32-color indexed image, the tiles are ~30% smaller
     public static String FILE_TYPE_SUFFIX_PNG = ".png32";

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.mozstumbler.client.mapview;
+package org.mozilla.mozstumbler.client.mapview.tiles;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
@@ -15,44 +14,33 @@ import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.ReusableBitmapDrawable;
-import org.osmdroid.tileprovider.tilesource.ITileSource;
-import org.osmdroid.tileprovider.tilesource.XYTileSource;
-import org.osmdroid.tileprovider.util.SimpleInvalidationHandler;
 import org.osmdroid.util.TileLooper;
-import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.TilesOverlay;
 
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * This class provides the Mozilla Coverage overlay
- */
-public class CoverageOverlay extends TilesOverlay {
-
+public abstract class AbstractMapOverlay extends TilesOverlay {
+    // We want the map to zoom to level 20, even if tiles have less zoom available
+    public static final int MAX_ZOOM_LEVEL_OF_MAP = 20;
+    public static final int TILE_PIXEL_SIZE = 256;
+    // Use png32 which is a 32-color indexed image, the tiles are ~30% smaller
+    public static String FILE_TYPE_SUFFIX_PNG = ".png32";
     private final Rect mTileRect = new Rect();
     private final Point mTilePoint = new Point();
     private final Point mTilePointMercator = new Point();
     private final Set<MapTile> mDrawnSet = new HashSet<MapTile>();
     private Projection mProjection;
 
-    public CoverageOverlay(final Context aContext, final String coverageUrl, MapView mapView) {
+    public AbstractMapOverlay(final Context aContext) {
         super(new MapTileProviderBasic(aContext), new DefaultResourceProxyImpl(aContext));
-        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
-                null,
-                1, 13, 256,
-                ".png",
-                new String[] { coverageUrl });
-        this.setLoadingBackgroundColor(Color.TRANSPARENT);
-        mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
-        mTileProvider.setTileSource(coverageTileSource);
     }
 
     // Though the tile provider can only provide up to 13, this overlay will display higher.
     @Override
     public int getMaximumZoomLevel() {
-        return 18;
+        return MAX_ZOOM_LEVEL_OF_MAP;
     }
 
     @Override
@@ -67,7 +55,7 @@ public class CoverageOverlay extends TilesOverlay {
         }
     }
 
-    private final TileLooper mCoverageTileLooper = new TileLooper() {
+    protected final TileLooper mCoverageTileLooper = new TileLooper() {
         @Override
         public void initialiseLoop(int pZoomLevel, int pTileSizePx) {
             // make sure the cache is big enough for all the tiles

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client.mapview.tiles;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.tileprovider.util.SimpleInvalidationHandler;
+import org.osmdroid.views.MapView;
+
+/**
+ * This class provides the Mozilla Coverage overlay
+ */
+public class CoverageOverlay extends AbstractMapOverlay {
+
+    public CoverageOverlay(final Context aContext, final String coverageUrl, MapView mapView) {
+        super(aContext);
+        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
+                null,
+                12, 13, AbstractMapOverlay.TILE_PIXEL_SIZE,
+                ".png",
+                new String[] { coverageUrl });
+        this.setLoadingBackgroundColor(Color.TRANSPARENT);
+        mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
+        mTileProvider.setTileSource(coverageTileSource);
+    }
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -16,12 +16,12 @@ import org.osmdroid.views.MapView;
  * This class provides the Mozilla Coverage overlay
  */
 public class CoverageOverlay extends AbstractMapOverlay {
-
     public CoverageOverlay(final Context aContext, final String coverageUrl, MapView mapView) {
         super(aContext);
         final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
                 null,
-                12, 13, AbstractMapOverlay.TILE_PIXEL_SIZE,
+                MIN_ZOOM_LEVEL_OF_MAP, MIN_ZOOM_LEVEL_OF_MAP,
+                AbstractMapOverlay.TILE_PIXEL_SIZE,
                 ".png",
                 new String[] { coverageUrl });
         this.setLoadingBackgroundColor(Color.TRANSPARENT);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -21,15 +21,17 @@ public class LowResMapOverlay extends AbstractMapOverlay {
 
         ITileSource coverageTileSource;
         if (isMLSTileStore) {
-            coverageTileSource = new XYTileSource("MozStumbler Tile Store",
-                    null,
-                    13, 13, AbstractMapOverlay.TILE_PIXEL_SIZE,
+            coverageTileSource = new XYTileSource("MozStumbler Tile Store", null,
+                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
+                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
+                    AbstractMapOverlay.TILE_PIXEL_SIZE,
                     AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,
                     new String[]{BuildConfig.TILE_SERVER_URL});
         } else {
-            coverageTileSource
-                    = new XYTileSource("MapquestOSM",
-                    ResourceProxy.string.mapquest_osm, 13, 13, AbstractMapOverlay.TILE_PIXEL_SIZE, ".jpg", new String[]{
+            coverageTileSource = new XYTileSource("MapquestOSM", ResourceProxy.string.mapquest_osm,
+                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
+                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
+                    AbstractMapOverlay.TILE_PIXEL_SIZE, ".jpg", new String[]{
                     "http://otile1.mqcdn.com/tiles/1.0.0/map/",
                     "http://otile2.mqcdn.com/tiles/1.0.0/map/",
                     "http://otile3.mqcdn.com/tiles/1.0.0/map/",

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client.mapview.tiles;
+
+import android.content.Context;
+import android.graphics.Color;
+
+import org.mozilla.mozstumbler.BuildConfig;
+import org.osmdroid.ResourceProxy;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.tileprovider.util.SimpleInvalidationHandler;
+import org.osmdroid.views.MapView;
+
+public class LowResMapOverlay extends AbstractMapOverlay {
+
+    public LowResMapOverlay(final Context aContext, boolean isMLSTileStore, MapView mapView) {
+        super(aContext);
+
+        ITileSource coverageTileSource;
+        if (isMLSTileStore) {
+            coverageTileSource = new XYTileSource("MozStumbler Tile Store",
+                    null,
+                    13, 13, AbstractMapOverlay.TILE_PIXEL_SIZE,
+                    AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,
+                    new String[]{BuildConfig.TILE_SERVER_URL});
+        } else {
+            coverageTileSource
+                    = new XYTileSource("MapquestOSM",
+                    ResourceProxy.string.mapquest_osm, 13, 13, AbstractMapOverlay.TILE_PIXEL_SIZE, ".jpg", new String[]{
+                    "http://otile1.mqcdn.com/tiles/1.0.0/map/",
+                    "http://otile2.mqcdn.com/tiles/1.0.0/map/",
+                    "http://otile3.mqcdn.com/tiles/1.0.0/map/",
+                    "http://otile4.mqcdn.com/tiles/1.0.0/map/"});
+        }
+        this.setLoadingBackgroundColor(Color.TRANSPARENT);
+        mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
+        mTileProvider.setTileSource(coverageTileSource);
+    }
+}

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -92,4 +92,6 @@
     <string name="enable_option_show_mls_on_map_summary">At the cost of a bit more memory and network usage, the map can show MLS location queries for your scans.</string>
     <string name="cell_only_observation">Cell only observation</string>
     <string name="wifi_only_observation">Wi-Fi only observation</string>
+    <string name="switch_to_low_res_tile">Using low resolution map</string>
+    <string name="switch_to_high_res_tile">Using high resolution map</string>
 </resources>


### PR DESCRIPTION
- Swap in an empty base tile layer when no wi-fi (and show a Toast), and show a low-resolution coverage map instead. 
- Instead of getting many levels of tiles for each zoom (typically I see 10 levels on disk), just get 2 levels. 
- Reduced the lowest zoom level of the map (to 30 km x 30 km approx on Nexus 5 screen) to prevent pulling in unnecessary data for areas the user isn't stumbling. 

ASIDE: Increased the max zoom to level 20, which is handy for separating the stumbling dots when walking.

TODO
- track the delta for the tile dir when not on wi-fi
- add a switch on the developer screen for tile source: default/lowres-only/high-res only
