### PR TITLE
Cleanup Metrics upload monitoring: Change main app to be the upload listener.

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -14,7 +14,7 @@ package org.mozilla.mozstumbler.client;
 
 public interface IMainActivity {
     public void updateUiOnMainThread();
-
     public void displayObservationCount(int count);
+    public void setUploadState(boolean isUploadingObservations);
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -38,6 +38,7 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellScanner;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploadParam;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
+import org.mozilla.mozstumbler.service.uploadthread.AsyncUploaderListener;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.osmdroid.tileprovider.constants.TileFilePath;
 
@@ -48,7 +49,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MainApp extends Application implements ObservedLocationsReceiver.ICountObserver {
+public class MainApp extends Application
+        implements ObservedLocationsReceiver.ICountObserver,
+        AsyncUploaderListener {
     public static final AtomicBoolean isUploading = new AtomicBoolean();
     private final String LOG_TAG = AppGlobals.LOG_PREFIX + MainApp.class.getSimpleName();
     private ClientStumblerService mStumblerService;
@@ -351,9 +354,16 @@ public class MainApp extends Application implements ObservedLocationsReceiver.IC
 
     public void showKmlDialog(Activity activity) {
        if (getService().isScanning()) {
-          stopScanning();
+           stopScanning();
            mMainActivity.get().updateUiOnMainThread();
        }
        activity.startActivity(new Intent(activity, KMLActivity.class));
+    }
+
+    @Override
+    public void onUploadProgress(boolean isUploading) {
+        if (mMainActivity.get() != null) {
+            mMainActivity.get().setUploadState(isUploading);
+        }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -234,4 +234,8 @@ public class MainDrawerActivity
         });
     }
 
+    @Override
+    public void setUploadState(boolean isUploadingObservations) {
+        mMetricsView.setUploadState(isUploadingObservations);
+    }
 }


### PR DESCRIPTION
As part of the quickie hookup for metrics upload, the metrics was the
upload listener, and because of the transient state of the metrics, it
also had a timer to check if uploading. This is ugly. Make it listener-based only (no Timer), and set the MainApp to be the listener of the uploads (which will pass on the info to metrics view if it is alive).
