### PR TITLE
Fix lifespan with "Don't keep activities" on

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -30,8 +30,6 @@
         <activity
             android:name=".client.navdrawer.MainDrawerActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
-            android:configChanges="orientation|screenSize|keyboard"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".client.navdrawer.MainDrawerActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -16,5 +16,6 @@ public interface IMainActivity {
     public void updateUiOnMainThread();
     public void displayObservationCount(int count);
     public void setUploadState(boolean isUploadingObservations);
+    public void recreatePausedActivity();
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -16,6 +16,6 @@ public interface IMainActivity {
     public void updateUiOnMainThread();
     public void displayObservationCount(int count);
     public void setUploadState(boolean isUploadingObservations);
-    public void recreatePausedActivity();
+    public void keepScreenOnChanged(boolean isEnabled);
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -368,4 +368,10 @@ public class MainApp extends Application
             mMainActivity.get().setUploadState(isUploading);
         }
     }
+
+    public void keepScreenOnPrefChanged() {
+        if (mMainActivity.get() != null) {
+            mMainActivity.get().recreatePausedActivity();
+        }
+    }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -369,9 +369,9 @@ public class MainApp extends Application
         }
     }
 
-    public void keepScreenOnPrefChanged() {
+    public void keepScreenOnPrefChanged(boolean isEnabled) {
         if (mMainActivity.get() != null) {
-            mMainActivity.get().recreatePausedActivity();
+            mMainActivity.get().keepScreenOnChanged(isEnabled);
         }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -9,6 +9,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActionBarDrawerToggle;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.MenuItemCompat;
@@ -86,11 +87,15 @@ public class MainDrawerActivity
         getSupportActionBar().setHomeButtonEnabled(true);
 
         FragmentManager fragmentManager = getSupportFragmentManager();
-        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-
-        mMapActivity = new MapActivity();
-        fragmentTransaction.add(R.id.content_frame, mMapActivity);
-        fragmentTransaction.commit();
+        Fragment fragment = fragmentManager.findFragmentById(R.id.content_frame);
+        if (fragment == null) {
+            mMapActivity = new MapActivity();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.add(R.id.content_frame, mMapActivity);
+            fragmentTransaction.commit();
+        } else {
+            mMapActivity = (MapActivity) fragment;
+        }
 
         getApp().setMainActivity(this);
 
@@ -164,11 +169,13 @@ public class MainDrawerActivity
     public void onStart() {
         super.onStart();
         mMetricsView.setMapLayerToggleListener(mMapActivity);
+        mMetricsView.update();
 
         if (ClientPrefs.getInstance().isFirstRun()) {
             FragmentManager fm = getSupportFragmentManager();
             FirstRunFragment.showInstance(fm);
         }
+
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -56,9 +56,7 @@ public class MainDrawerActivity
                     WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
         }
 
-        if (ClientPrefs.getInstance().getKeepScreenOn()) {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
+        keepScreenOnChanged(ClientPrefs.getInstance().getKeepScreenOn());
 
         getSupportActionBar().setTitle(getString(R.string.app_name));
 
@@ -248,16 +246,12 @@ public class MainDrawerActivity
         mMetricsView.setUploadState(isUploadingObservations);
     }
 
-    public void recreatePausedActivity() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-            Intent i = getApplicationContext().getPackageManager()
-                    .getLaunchIntentForPackage(getApplicationContext().getPackageName());
-            i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK );
-            startActivity(i);
-            PreferencesScreen.setPrefs(getApp().getPrefs());
-            startActivity(new Intent(getApplication(), PreferencesScreen.class));
+    public void keepScreenOnChanged(boolean isEnabled) {
+        int flag = android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+        if (isEnabled) {
+            getWindow().addFlags(flag);
         } else {
-            recreate();
+            getWindow().clearFlags(flag);
         }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -247,4 +247,17 @@ public class MainDrawerActivity
     public void setUploadState(boolean isUploadingObservations) {
         mMetricsView.setUploadState(isUploadingObservations);
     }
+
+    public void recreatePausedActivity() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            Intent i = getApplicationContext().getPackageManager()
+                    .getLaunchIntentForPackage(getApplicationContext().getPackageName());
+            i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK );
+            startActivity(i);
+            PreferencesScreen.setPrefs(getApp().getPrefs());
+            startActivity(new Intent(getApplication(), PreferencesScreen.class));
+        } else {
+            recreate();
+        }
+    }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LeaderboardActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LeaderboardActivity.java
@@ -28,6 +28,11 @@ public class LeaderboardActivity extends ActionBarActivity {
         mWebView = (WebView) findViewById(R.id.webview);
         mWebView.setVisibility(View.INVISIBLE);
         mWebView.getSettings().setJavaScriptEnabled(true);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
         setSupportProgressBarVisibility(true);
         final Activity activity = this;
         mWebView.setWebChromeClient(new WebChromeClient() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -133,6 +133,7 @@ public class PreferencesScreen extends PreferenceActivity {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 sPrefs.setKeepScreenOn(newValue.equals(true));
+                ((MainApp) getApplication()).keepScreenOnPrefChanged();
                 return true;
             }
         });

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -133,7 +133,7 @@ public class PreferencesScreen extends PreferenceActivity {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 sPrefs.setKeepScreenOn(newValue.equals(true));
-                ((MainApp) getApplication()).keepScreenOnPrefChanged();
+                ((MainApp) getApplication()).keepScreenOnPrefChanged(newValue.equals(true));
                 return true;
             }
         });


### PR DESCRIPTION
- This option simulates low memory states where non-visible activities are destroyed rather than backgrounded. Well-behaved apps should pass this test without issues.
- Required changing fragment creation, and properly handling onDestroy to
  avoid tons of warning messages in the logs
- _May_ be a serious issue on old devices, which actually do destroy activities more aggressively.
- Previously, because we didn't have proper lifecycle management, the main activity was set in the manifest to not re-create on orientation changed. Removed this requirement.
