### PR TITLE
#932 - Removes the XYTileSource and enables the MapBoxTileSource

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,30 @@ android {
         unittest {
             buildConfigField "boolean", "ROBOLECTRIC", "true"
         }
+
+        applicationVariants.all { variant ->
+            variant.processManifest.doLast {
+                println("configuring AndroidManifest.xml");
+                copy {
+                    from("${buildDir}/intermediates/manifests") {
+                        include "${variant.dirName}/AndroidManifest.xml"
+                    }
+                    into("${buildDir}/intermediates/filtered_manifests")
+                }
+
+                def manifestFile = new File("${buildDir}/intermediates/filtered_manifests/${variant.dirName}/AndroidManifest.xml")
+                    def content = manifestFile.getText()
+                    def updatedContent = content.replaceAll("FAKE_MAPBOX_MAPID", getMapboxAPIKey())
+                    manifestFile.write(updatedContent)
+            }
+
+            // This is a bit confusing, we want to swap in the
+            // filtered AndroidManifest.xml file so that we don't
+            // modify the original AndroidManifest.xml. This prevents
+            // accidental commit of the mapbox key into source
+            // control.
+            variant.processResources.manifestFile = new File("${buildDir}/intermediates/filtered_manifests/${variant.dirName}/AndroidManifest.xml")
+        }
     }
 
     sourceSets {
@@ -268,6 +292,20 @@ String getMozillaApiKey() {
     }
     println "No private.properties for Mozilla API Key configuration.."
     return "null";
+}
+
+String getMapboxAPIKey() {
+    // Yeah, this is lame, opening the file again.  Sosume.
+    File signFile = rootProject.file('private.properties')
+    if (signFile.exists()) {
+        Properties p = new Properties()
+        p.load(new FileInputStream(signFile))
+
+        if (p['MapAPIKey'] != null) {
+            return p['MapAPIKey'];
+        }
+    }
+    return '';
 }
 
 String getTileServerUrl() {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -123,6 +123,7 @@
             </intent-filter>
         </receiver
         -->
+        <meta-data android:name="MAPBOX_MAPID" android:value="FAKE_MAPBOX_MAPID" />
     </application>
 
 </manifest>

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapActivity.java
@@ -48,9 +48,9 @@ import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.tileprovider.BitmapPool;
 import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.MapBoxTileSource;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
-import org.osmdroid.tileprovider.tilesource.XYTileSource;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Overlay;
@@ -303,12 +303,14 @@ public final class MapActivity extends android.support.v4.app.Fragment
             if (!isMLSTileStore) {
                 mHighResMapSource = TileSourceFactory.MAPQUESTOSM;
             } else {
-                // TODO replace me with MapBoxTileSource
-                mHighResMapSource = new XYTileSource("MozStumbler Tile Store",
+                // This has to be called prior to instantiating the
+                // MapBoxTileSouce to set the Mapbox API Key
+                MapBoxTileSource.retrieveMapBoxMapId(getApplication().getApplicationContext());
+
+                mHighResMapSource = new MapBoxTileSource("MozStumbler Tile Store",
                         null, 1, AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP,
                         AbstractMapOverlay.TILE_PIXEL_SIZE,
-                        AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,
-                        new String[]{BuildConfig.TILE_SERVER_URL});
+                        AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG);
             }
             mMap.setTileSource(mHighResMapSource);
         } else {


### PR DESCRIPTION
This fixes #932.

The MapBoxTileSource randomly pulls from one of four different tile servers which should be more responsive.

The gradle build has been modified in a strange way, but it's been commented.
