### PR TITLE
980 - fix the listener for the on/off switch

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -19,6 +19,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.CompoundButton;
 import android.widget.Switch;
 
 import org.mozilla.mozstumbler.BuildConfig;
@@ -114,9 +115,9 @@ public class MainDrawerActivity
         if (Build.VERSION.SDK_INT >= 11) {
             Switch s = new Switch(this);
             s.setChecked(false);
-            s.setOnClickListener(new View.OnClickListener() {
+            s.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
-                public void onClick(View v) {
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                     mMapActivity.toggleScanning(mMenuItemStartStop);
                 }
             });


### PR DESCRIPTION
This fixes #980.

Changes the toggle switch to use onCheckedChanged() which corrects tap vs swipe gestures on the on/off switch.
