### PR TITLE
check if WiFi is mobile hotspot

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -39,6 +39,7 @@ public final class NetworkInfo {
 
         if (Build.VERSION.SDK_INT >= 16) {
             if (mConnectivityManager.isActiveNetworkMetered()) {
+                Log.d(LOG_TAG, "Network is metered");
                 return false;
             }
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -6,6 +6,7 @@ package org.mozilla.mozstumbler.service.utils;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.os.Build;
 import android.util.Log;
 import org.mozilla.mozstumbler.service.AppGlobals;
 
@@ -34,6 +35,12 @@ public final class NetworkInfo {
         if (mConnectivityManager == null) {
             Log.e(LOG_TAG, "ConnectivityManager is null!");
             return false;
+        }
+
+        if (Build.VERSION.SDK_INT >= 16) {
+            if (mConnectivityManager.isActiveNetworkMetered()) {
+                return false;
+            }
         }
 
         android.net.NetworkInfo aNet = mConnectivityManager.getActiveNetworkInfo();


### PR DESCRIPTION
WiFi can be declared as mobile hotspot, you might want to check that case. I am not sure how `ConnectivityManager.isActiveNetworkMetered()` works for mobile data connections, so I leave the type comparison.
