### PR TITLE
 Cell/WiFi count is only set when the MLS layer is enabled

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -125,21 +125,23 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             lastObservation = mCollectionPoints.getLast();
         }
 
-        if (service != null) {
+        if (lastObservation != null && service != null) {
             JSONObject currentBundle = service.getLastReportedBundle();
-            if (mPreviousBundleForDuplicateCheck == currentBundle) {
-                return;
-            }
-            mPreviousBundleForDuplicateCheck = currentBundle;
+            if (currentBundle != null) {
+                lastObservation.setCounts(currentBundle);
 
-            if (lastObservation != null) {
-                if (ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap()) {
+                if (mPreviousBundleForDuplicateCheck == currentBundle) {
+                    return;
+                }
+
+                boolean getInfoForMLS = ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap();
+                if (getInfoForMLS) {
                     lastObservation.setMLSQuery(currentBundle);
+                    mPreviousBundleForDuplicateCheck = currentBundle;
+
                     if (mQueuedForMLS.size() < MAX_SIZE_OF_POINT_LISTS) {
                         mQueuedForMLS.addFirst(lastObservation);
                     }
-                } else {
-                    lastObservation.setCounts(currentBundle);
                 }
             }
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -19,6 +19,7 @@ import org.mozilla.mozstumbler.client.mapview.ObservationPoint;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 import org.mozilla.mozstumbler.service.utils.CoordinateUtils;
 import org.osmdroid.util.GeoPoint;
+
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -124,17 +125,22 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             lastObservation = mCollectionPoints.getLast();
         }
 
-        boolean getInfoForMLS = ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap();
-        if (getInfoForMLS && lastObservation != null && service != null) {
+        if (service != null) {
             JSONObject currentBundle = service.getLastReportedBundle();
             if (mPreviousBundleForDuplicateCheck == currentBundle) {
                 return;
             }
-            lastObservation.setMLSQuery(currentBundle);
             mPreviousBundleForDuplicateCheck = currentBundle;
 
-            if (mQueuedForMLS.size() < MAX_SIZE_OF_POINT_LISTS) {
-                mQueuedForMLS.addFirst(lastObservation);
+            if (lastObservation != null) {
+                if (ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap()) {
+                    lastObservation.setMLSQuery(currentBundle);
+                    if (mQueuedForMLS.size() < MAX_SIZE_OF_POINT_LISTS) {
+                        mQueuedForMLS.addFirst(lastObservation);
+                    }
+                } else {
+                    lastObservation.setCounts(currentBundle);
+                }
             }
         }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -41,7 +41,6 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
 
     public void setMLSQuery(JSONObject ichnaeaQueryObj) {
         mMLSQuery = ichnaeaQueryObj;
-        setCounts(ichnaeaQueryObj);
     }
 
     public void setCounts(JSONObject ichnaeaQueryObj) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -46,8 +46,8 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
 
     public void setCounts(JSONObject ichnaeaQueryObj) {
         try {
-            mCellCount = mMLSQuery.getInt(DataStorageContract.ReportsColumns.CELL_COUNT);
-            mWifiCount = mMLSQuery.getInt(DataStorageContract.ReportsColumns.WIFI_COUNT);
+            mCellCount = ichnaeaQueryObj.getInt(DataStorageContract.ReportsColumns.CELL_COUNT);
+            mWifiCount = ichnaeaQueryObj.getInt(DataStorageContract.ReportsColumns.WIFI_COUNT);
         } catch (JSONException ex) {}
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -41,6 +41,10 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
 
     public void setMLSQuery(JSONObject ichnaeaQueryObj) {
         mMLSQuery = ichnaeaQueryObj;
+        setCounts(ichnaeaQueryObj);
+    }
+
+    public void setCounts(JSONObject ichnaeaQueryObj) {
         try {
             mCellCount = mMLSQuery.getInt(DataStorageContract.ReportsColumns.CELL_COUNT);
             mWifiCount = mMLSQuery.getInt(DataStorageContract.ReportsColumns.WIFI_COUNT);


### PR DESCRIPTION
Currently the cell/WiFi count is only set when the MLS layer is enabled. As a result the points overlay always draws the green dot icon, never any cell/WiFi only icon.
