### PR TITLE
Start scanning after first booting the app

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -231,11 +231,17 @@ public class MainApp extends Application
     public void startScanning() {
         mStumblerService.startForeground(NOTIFICATION_ID, buildNotification());
         mStumblerService.startScanning();
+        if (mMainActivity.get() != null) {
+            mMainActivity.get().updateUiOnMainThread();
+        }
     }
 
     public void stopScanning() {
         mStumblerService.stopForeground(true);
         mStumblerService.stopScanning();
+        if (mMainActivity.get() != null) {
+            mMainActivity.get().updateUiOnMainThread();
+        }
 
         AsyncUploader uploader = new AsyncUploader();
         AsyncUploadParam param = new AsyncUploadParam(
@@ -402,5 +408,12 @@ public class MainApp extends Application
         if (mMainActivity.get() != null) {
             mMainActivity.get().keepScreenOnChanged(isEnabled);
         }
+    }
+
+    private static boolean sHasBootedOnce;
+    public static boolean getAndSetHasBootedOnce() {
+        boolean b = sHasBootedOnce;
+        sHasBootedOnce = true;
+        return b;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -432,18 +432,6 @@ public final class MapFragment extends android.support.v4.app.Fragment
         setHighBandwidthMap(hasWifi);
     }
 
-    private void setStartStopMenuState(MenuItem menuItem, boolean scanning) {
-        if (scanning) {
-            menuItem.setIcon(android.R.drawable.ic_media_pause);
-            menuItem.setTitle(R.string.stop_scanning);
-        } else {
-            menuItem.setIcon(android.R.drawable.ic_media_play);
-            menuItem.setTitle(R.string.start_scanning);
-        }
-
-        dimToolbar();
-    }
-
     @SuppressLint("NewApi")
     public void dimToolbar() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
@@ -464,13 +452,15 @@ public final class MapFragment extends android.support.v4.app.Fragment
         if (app.getService() == null) {
             return;
         }
+
         boolean isScanning = app.getService().isScanning();
         if (isScanning) {
             app.stopScanning();
         } else {
             app.startScanning();
         }
-        setStartStopMenuState(menuItem, !isScanning);
+
+        dimToolbar();
     }
 
     private void showCopyright() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FirstRunFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FirstRunFragment.java
@@ -16,6 +16,10 @@ import android.widget.Button;
 import android.widget.TextView;
 import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
+import org.mozilla.mozstumbler.client.IMainActivity;
+import org.mozilla.mozstumbler.client.MainApp;
+
+import java.lang.ref.WeakReference;
 
 public class FirstRunFragment extends DialogFragment {
     private static FirstRunFragment mInstance;
@@ -43,6 +47,7 @@ public class FirstRunFragment extends DialogFragment {
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                ((MainApp) getActivity().getApplication()).startScanning();
                 ClientPrefs.getInstance().setFirstRun(false);
                 getDialog().dismiss();
             }


### PR DESCRIPTION
Also cleaned up some of the start/stop button logic

Addresses issue #948. With the addition that after ANY cold boot, it will toggle on. After that if the user turns the switch off, then hides and shows the app, the switch will stay off.
