### PR TITLE
1023 - Failing to check for null service onStart and onStop

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -229,6 +229,9 @@ public class MainApp extends Application
     }
 
     public void startScanning() {
+        if (mStumblerService == null) {
+            return;
+        }
         mStumblerService.startForeground(NOTIFICATION_ID, buildNotification());
         mStumblerService.startScanning();
         if (mMainActivity.get() != null) {
@@ -237,6 +240,9 @@ public class MainApp extends Application
     }
 
     public void stopScanning() {
+        if (mStumblerService == null) {
+            return;
+        }
         mStumblerService.stopForeground(true);
         mStumblerService.stopScanning();
         if (mMainActivity.get() != null) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/TurnOffReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/TurnOffReceiver.java
@@ -12,7 +12,7 @@ import org.mozilla.mozstumbler.service.core.logging.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 
-/* Test low power in adb with am broad  cast -a android.intent.action.BATTERY_LOW
+/* Test low power in adb with am broadcast -a android.intent.action.BATTERY_LOW
  * Test cancel button in notification list by swiping down on the entry for the
  * stumbler, and [X] Stop Scanning will appear.
  */


### PR DESCRIPTION
When the app starts with <15% battery, it immediately gets notified and
then calls onStop before the service is created, and crashed on a null
pointer.

Issue #1023
