### PR TITLE
Update Reporter to send flushed bundles to ObservedLocationsReceiver

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -83,7 +83,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
                         count++;
                     } else {
                         if (getMapActivity() != null) {
-                            getMapActivity().newMLSPoint();
+                            getMapActivity().newMLSPoint(obs);
                         }
                         li.remove();
                     }
@@ -161,16 +161,16 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
         getMapActivity().getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                updateMap();
+                addObservationPointToMap();
             }
         });
     }
 
-    private synchronized void updateMap() {
+    private synchronized void addObservationPointToMap() {
         if (getMapActivity() == null) {
             return;
         }
 
-        getMapActivity().newObservationPoint();
+        getMapActivity().newObservationPoint(mCollectionPoints.getLast());
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -645,11 +645,11 @@ public final class MapFragment extends android.support.v4.app.Fragment
         textView.setText("0");
     }
 
-    public void newMLSPoint(ObservationPoint point) {
+    public void newMLSPoint() {
         mObservationPointsOverlay.update();
     }
 
-    public void newObservationPoint(ObservationPoint point) {
+    public void newObservationPoint() {
         mObservationPointsOverlay.update();
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -645,11 +645,11 @@ public final class MapFragment extends android.support.v4.app.Fragment
         textView.setText("0");
     }
 
-    public void newMLSPoint() {
+    public void newMLSPoint(ObservationPoint point) {
         mObservationPointsOverlay.update();
     }
 
-    public void newObservationPoint() {
+    public void newObservationPoint(ObservationPoint point) {
         mObservationPointsOverlay.update();
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -103,19 +103,24 @@ class ObservationPointsOverlay extends Overlay {
         mIsDirty = false;
 
         LinkedList<ObservationPoint> points = ObservedLocationsReceiver.getInstance().getObservationPoints();
-        if (shadow || points.size() < 1) {
+        ObservationPoint point = ObservedLocationsReceiver.getInstance().getCurrentObservationPoint();
+        if (shadow || (points.size() < 1 && point == null)) {
             return;
         }
 
         final Projection pj = osmv.getProjection();
         final float radiusInnerRing = mConvertPx.pxToDp(3);
 
+        if (point != null) {
+            drawDot(c, pj.toPixels(point.pointGPS, null), radiusInnerRing, mGreenPaint, mBlackStrokePaint);
+        }
+
         int count = 0;
 
         // iterate newest to oldest
         Iterator<ObservationPoint> i = points.descendingIterator();
         while (i.hasNext()) {
-            ObservationPoint point = i.next();
+            point = i.next();
             final Point gps = pj.toPixels(point.pointGPS, null);
 
             boolean hasWifiScan = point.mWifiCount > 0;
@@ -142,7 +147,7 @@ class ObservationPointsOverlay extends Overlay {
         // Draw as a 2nd layer over the observation points
         i = points.descendingIterator();
         while (i.hasNext()) {
-            ObservationPoint point = i.next();
+            point = i.next();
             if (point.pointMLS != null) {
                 final Point gps = pj.toPixels(point.pointGPS, null);
                 final Point mls = pj.toPixels(point.pointMLS, null);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -103,24 +103,19 @@ class ObservationPointsOverlay extends Overlay {
         mIsDirty = false;
 
         LinkedList<ObservationPoint> points = ObservedLocationsReceiver.getInstance().getObservationPoints();
-        ObservationPoint point = ObservedLocationsReceiver.getInstance().getCurrentObservationPoint();
-        if (shadow || (points.size() < 1 && point == null)) {
+        if (shadow || points.size() < 1) {
             return;
         }
 
         final Projection pj = osmv.getProjection();
         final float radiusInnerRing = mConvertPx.pxToDp(3);
 
-        if (point != null) {
-            drawDot(c, pj.toPixels(point.pointGPS, null), radiusInnerRing, mGreenPaint, mBlackStrokePaint);
-        }
-
         int count = 0;
 
         // iterate newest to oldest
         Iterator<ObservationPoint> i = points.descendingIterator();
         while (i.hasNext()) {
-            point = i.next();
+            ObservationPoint point = i.next();
             final Point gps = pj.toPixels(point.pointGPS, null);
 
             boolean hasWifiScan = point.mWifiCount > 0;
@@ -147,7 +142,7 @@ class ObservationPointsOverlay extends Overlay {
         // Draw as a 2nd layer over the observation points
         i = points.descendingIterator();
         while (i.hasNext()) {
-            point = i.next();
+            ObservationPoint point = i.next();
             if (point.pointMLS != null) {
                 final Point gps = pj.toPixels(point.pointGPS, null);
                 final Point mls = pj.toPixels(point.pointMLS, null);
@@ -160,6 +155,4 @@ class ObservationPointsOverlay extends Overlay {
             }
         }
     }
-
-
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -32,6 +32,8 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
 public final class Reporter extends BroadcastReceiver implements IReporter {
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Reporter.class.getSimpleName();
     public static final String ACTION_FLUSH_TO_BUNDLE = AppGlobals.ACTION_NAMESPACE + ".FLUSH";
+    public static final String ACTION_NEW_BUNDLE = AppGlobals.ACTION_NAMESPACE + ".NEW_BUNDLE";
+    public static final String NEW_BUNDLE_ARG_BUNDLE = "bundle";
     private boolean mIsStarted;
 
     /* The maximum number of Wi-Fi access points in a single observation. */
@@ -223,6 +225,11 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         mPreviousBundleJSON = mlsObj;
 
         AppGlobals.guiLogInfo("MLS record: " + mlsObj.toString());
+
+        Intent i = new Intent(ACTION_NEW_BUNDLE);
+        i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
+        i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
+        LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
         try {
             DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);


### PR DESCRIPTION
This fixes the case that green dots are drawn on the map when there are no cell/wifi observations, see #996.
I think it also cleans up the data flow and fixes another glitch.
This way `ObservedLocationsReceiver` will get the location that is currently being observed from the GPS, but only adds observations to the map when they are validated and flushed by the `Reporter`.
