### PR TITLE
1002: Point draw performance. Use hash of x and y to reduce number of points drawn

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.location.Location;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.content.LocalBroadcastManager;
@@ -42,7 +43,9 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
     private final Handler mHandler = new Handler(Looper.getMainLooper());
 
     // Upper bound on the size of the linked lists of points, for memory and performance safety.
-    private final int MAX_SIZE_OF_POINT_LISTS = 5000;
+    // On older devices, store fewer observations
+    private final int MAX_SIZE_OF_POINT_LISTS = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)?
+                                                5000 : 2500;
 
     private ObservedLocationsReceiver() {
         mHandler.postDelayed(mFetchMLSRunnable, FREQ_FETCH_MLS_MS);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -646,11 +646,11 @@ public final class MapFragment extends android.support.v4.app.Fragment
     }
 
     public void newMLSPoint(ObservationPoint point) {
-        mObservationPointsOverlay.update();
+        mObservationPointsOverlay.update(point.pointMLS, mMap);
     }
 
     public void newObservationPoint(ObservationPoint point) {
-        mObservationPointsOverlay.update();
+        mObservationPointsOverlay.update(point.pointGPS, mMap);
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -219,7 +219,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
                 int z = e.getZoomLevel();
                 updateOverlayBaseLayer(z);
                 updateOverlayCoverageLayer(z);
-                mObservationPointsOverlay.zoomChanged();
+                mObservationPointsOverlay.zoomChanged(mMap);
                 return true;
             }
 
@@ -562,6 +562,8 @@ public final class MapFragment extends android.support.v4.app.Fragment
 
         ClientPrefs prefs = ClientPrefs.createGlobalInstance(getActivity().getApplicationContext());
         setShowMLS(prefs.getOnMapShowMLS());
+
+        mObservationPointsOverlay.zoomChanged(mMap);
     }
 
     private void saveStateToPrefs() {
@@ -647,11 +649,11 @@ public final class MapFragment extends android.support.v4.app.Fragment
     }
 
     public void newMLSPoint(ObservationPoint point) {
-        mObservationPointsOverlay.update(point.pointMLS, mMap);
+        mObservationPointsOverlay.update(point, mMap, true);
     }
 
     public void newObservationPoint(ObservationPoint point) {
-        mObservationPointsOverlay.update(point.pointGPS, mMap);
+        mObservationPointsOverlay.update(point, mMap, false);
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -219,6 +219,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
                 int z = e.getZoomLevel();
                 updateOverlayBaseLayer(z);
                 updateOverlayCoverageLayer(z);
+                mObservationPointsOverlay.zoomChanged();
                 return true;
             }
 


### PR DESCRIPTION
For #1002 

This uses a hash to simulate a 2D grid, by hashing on the x and y values combined.
It reduces the number of points drawn at a given zoom level. 
Recalculate each time the zoom level changes. The hash value is based on the x and y pixel, but scaled down to reduce the detail level (and increase collisions and reduce the data). If a particular hash slot is occupied already, then don't draw the point. 
_Note_, I added a bit of logic here, so that if the observation point is "better" [i.e. cell+wifi is better than cell], then it takes the hash slot.

Tested on Nexus 5 4.4.4 and Samsung Duos 2.3.6.

Testing is performed with: 
4800 point kml file
https://drive.google.com/file/d/0B1sYPwjczMsQM1VDdXdacGpDdEE/view?usp=sharing

Put it in: sdcard/Android/data/org.mozilla.mozstumbler/files

The go to load KML in the app.
