### PR TITLE
Fix observations display

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -14,7 +14,6 @@ package org.mozilla.mozstumbler.client;
 
 public interface IMainActivity {
     public void updateUiOnMainThread();
-    public void displayObservationCount(int count);
     public void setUploadState(boolean isUploadingObservations);
     public void keepScreenOnChanged(boolean isEnabled);
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -25,6 +25,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import org.acra.ACRA;
+import org.acra.annotation.ReportsCrashes;
 import org.acra.sender.HttpSender;
 import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.R;
@@ -50,8 +51,6 @@ import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.acra.annotation.ReportsCrashes;
 
 @ReportsCrashes(
     formKey="",

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -69,6 +69,7 @@ public class MainApp extends Application
     private ServiceConnection mConnection;
     private ServiceBroadcastReceiver mReceiver;
     private WeakReference<IMainActivity> mMainActivity = new WeakReference<IMainActivity>(null);
+    private int mObservationCount = 0;
     private final long MAX_BYTES_DISK_STORAGE = 1000 * 1000 * 20; // 20MB for MozStumbler by default, is ok?
     private final int MAX_WEEKS_OLD_STORED = 4;
     public static final String INTENT_TURN_OFF = "org.mozilla.mozstumbler.turnMeOff";
@@ -380,12 +381,12 @@ public class MainApp extends Application
         }
     }
 
-    private int observationCount = 0;
     public void observedLocationCountIncrement() {
-        observationCount++;
-        if (mMainActivity.get() != null) {
-            mMainActivity.get().displayObservationCount(observationCount);
-        }
+        mObservationCount++;
+    }
+
+    public int getObservedLocationCount() {
+        return mObservationCount;
     }
 
     public void showDeveloperDialog(Activity activity) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -47,12 +47,12 @@ public class MainDrawerActivity
     private MenuItem mMenuItemStartStop;
 
     final CompoundButton.OnCheckedChangeListener mStartStopButtonListener =
-        new CompoundButton.OnCheckedChangeListener() {
-        @Override
-        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-            mMapFragment.toggleScanning(mMenuItemStartStop);
-        }
-    };
+            new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    mMapFragment.toggleScanning(mMenuItemStartStop);
+                }
+            };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -257,19 +257,9 @@ public class MainDrawerActivity
 
         mMapFragment.formatTextView(R.id.text_cells_visible, "%d", service.getCurrentCellInfoCount());
         mMapFragment.formatTextView(R.id.text_wifis_visible, "%d", service.getVisibleAPCount());
+        mMapFragment.formatTextView(R.id.text_observation_count, "%d", getApp().getObservedLocationCount());
 
         mMetricsView.update();
-    }
-
-    @Override
-    public void displayObservationCount(final int count) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mMapFragment.formatTextView(R.id.text_observation_count, "%d", count);
-                mMetricsView.setObservationCount(count);
-            }
-        });
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -257,7 +257,10 @@ public class MainDrawerActivity
 
         mMapFragment.formatTextView(R.id.text_cells_visible, "%d", service.getCurrentCellInfoCount());
         mMapFragment.formatTextView(R.id.text_wifis_visible, "%d", service.getVisibleAPCount());
-        mMapFragment.formatTextView(R.id.text_observation_count, "%d", getApp().getObservedLocationCount());
+
+        int count = getApp().getObservedLocationCount();
+        mMapFragment.formatTextView(R.id.text_observation_count, "%d", count);
+        mMetricsView.setObservationCount(count);
 
         mMetricsView.update();
     }


### PR DESCRIPTION
This fixes a bug where the number of observed locations displayed in the map was reset to 0 after device rotation and only updated when a new location was observed.
