### PR TITLE
Delete stumbles on 400 (bad request) errors only

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -142,9 +142,8 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
                         logMsg = "HTTP non-success code: " + result.httpResponse();
                     }
                     
-                    if (result != null && result.isErrorCode4xx()) {
-                        logMsg += ", Error, deleting bad report";
-                        // delete on 4xx, no point in resending
+                    if (result != null && result.isErrorCode400BadRequest()) {
+                        logMsg += ", 400 Error, deleting bad report";
                         dm.delete(batch.filename);
                     } else {
                         DataStorageManager.getInstance().saveCurrentReportsSendBufferToDisk();


### PR DESCRIPTION
In theory other errors, particularly 404 can be temporary (and incorrectly) be returned by proxies.
Due to complaints about data disappearing I am trying to minimize the possibilities of stumbles being disposed. 
