### PR TITLE
Round KB to nearest whole number instead of showing fractional metrics like "123.4 KB"

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -178,12 +178,13 @@ public class MetricsView {
         mThisSessionObservationsView.setText(val);
     }
 
-    String formatKb(long bytes) {
-        float kb = bytes / 1000.0f;
+    private static String formatKb(long bytes) {
+        final float kb = bytes / 1000.0f;
         if (kb < 0.1) {
-            return ""; // don't show 0.0 for size.
+            return ""; // Don't show "0 KB".
         }
-        return "(" + (Math.round(kb * 10.0f) / 10.0f) + " KB)";
+        // Round KB up to nearest whole number.
+        return = "(" + (int) Math.ceil(kb) + " KB)";
     }
 
     private void updateSentStats(DataStorageManager dataStorageManager) {


### PR DESCRIPTION
I think the fractional KB metrics clutter the UI. We don't need that much precision. :)
