### PR TITLE
Change keep_screen_on pref default to false

### DIFF
--- a/android/src/main/res/xml/stumbler_preferences.xml
+++ b/android/src/main/res/xml/stumbler_preferences.xml
@@ -18,7 +18,7 @@
     <CheckBoxPreference
         android:key="keep_screen_on"
         android:title="@string/keep_screen_on_title"
-        android:defaultValue="true" />
+        android:defaultValue="false" />
     <CheckBoxPreference
         android:key="enable_the_option_to_show_mls_on_map"
         android:title="@string/enable_option_show_mls_on_map"


### PR DESCRIPTION
This pref was introduced when the map was not the default screen.
Now this pref is basically always in effect when the app is in the foreground. This is not a good default because users will be unaware of it (at first), so if they do not turn off the screen manually, they might only notice it when the battery is almost empty. On the other hand, users that want to have this feature will look for it in the menu.
