### PR TITLE
1092 reduce heap usage to prevent OOM

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/BitmapPool.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/BitmapPool.java
@@ -31,7 +31,7 @@ public class BitmapPool {
     public void applyReusableOptions(final BitmapFactory.Options aBitmapOptions) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             aBitmapOptions.inBitmap = obtainBitmapFromPool();
-            aBitmapOptions.inSampleSize = 2;
+            aBitmapOptions.inSampleSize = 1;
             aBitmapOptions.inMutable = true;
         }
     }

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/BitmapPool.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/BitmapPool.java
@@ -31,7 +31,7 @@ public class BitmapPool {
     public void applyReusableOptions(final BitmapFactory.Options aBitmapOptions) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             aBitmapOptions.inBitmap = obtainBitmapFromPool();
-            aBitmapOptions.inSampleSize = 1;
+            aBitmapOptions.inSampleSize = 2;
             aBitmapOptions.inMutable = true;
         }
     }

--- a/android/src/main/java/org/mozilla/osmdroid/views/overlay/TilesOverlay.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/overlay/TilesOverlay.java
@@ -76,7 +76,7 @@ public class TilesOverlay extends Overlay implements IOverlayMenuProvider {
     // is no formal policy for when a tile is evicted from the LRU
     // cache.  The caches really need to just go away and we should
     // load directly from storage.
-    public static final int OVERSHOOT_TILE_CACHE_SIZE = 100;
+    public static final int OVERSHOOT_TILE_CACHE_SIZE = 0;
 
     public TilesOverlay(final MapTileProviderBase aTileProvider, final ResourceProxy pResourceProxy) {
         super(pResourceProxy);


### PR DESCRIPTION
This is a fix for #1092 

This lowers the LRUCache size for the drawable pool down to it's original size as well as subsampling the images before they are loaded into heap.

On my MotoG before the changes I could easily get heap usage to exceed 85MB causing OOM errors.

Lowering the LRU size reduces the heap consumption to around 60MB on my device.  Subsampling cuts the heap down to ~45MB usage.

Subsampling makes road labels a bit hard to read, so we should increase the font size on the road mapstyling on our mapbox account.
