### PR TITLE
1084 - Upper bounds on log lines

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LogActivity extends ActionBarActivity {
     static LinkedList<String> buffer = new LinkedList<String>();
-    static final int MAX_SIZE = 1000;
+    static final int MAX_SIZE = 500;
     private static LogMessageReceiver sInstance;
 
     public static class LogMessageReceiver extends BroadcastReceiver {
@@ -87,17 +87,23 @@ public class LogActivity extends ActionBarActivity {
                 buffer.removeFirst();
             }
 
-            int kMaxChars = 150;
-            int kBufSizeBeforeTruncate = 30;
+            // size of log is: 1000 * 30 + 200 * 470 = 30 kb + 94 kb, should be a very safe size
+
+            final int kMaxCharsOfLongerLines = 1000;
+            final int kMaxCharsOfTruncatedLine = 200;
+            final int kBufSizeBeforeTruncate = 30;
+            final int maxChars = (buffer.size() > kBufSizeBeforeTruncate)? kMaxCharsOfTruncatedLine :kMaxCharsOfLongerLines;
             if (buffer.size() == kBufSizeBeforeTruncate + 1) {
-                String msg = "BUFFER REACHED " + kBufSizeBeforeTruncate +" MESSAGES. TRUNCATING MESSAGES.";
+                String msg = "LOG VIEWER REACHED " + kBufSizeBeforeTruncate +" MESSAGES. TRUNCATING MESSAGES.";
                 buffer.add(msg);
                 if (sConsoleView != null) {
                     sConsoleView.println(msg);
                 }
             }
-            if (buffer.size() > kBufSizeBeforeTruncate && s.length() > kMaxChars) {
-                s = s.substring(0, kMaxChars) + " ...";
+
+            if (s.length() > maxChars) {
+                // 1/3 of max length, ellipse, then last 2/3 of max length
+                s = s.substring(0, maxChars / 3) + " ... " + s.substring(s.length() - 1 - maxChars * 2/3);
             }
 
             buffer.add(s);

--- a/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -39,7 +39,7 @@ public class AppGlobals {
     public static boolean isDebug;
     public static boolean isRobolectric;
 
-    private static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS : ");
+    private static final SimpleDateFormat formatter = new SimpleDateFormat("HH:mm:ss: ");
 
     /* The log activity will clear this periodically, and display the messages.
      * Always null when the stumbler service is used stand-alone. */


### PR DESCRIPTION
#1084

The log is now 500 lines max, with longest lines bounded at 1000 chars
(the first 30), and the remaining lines bounded at 200.
- Add ellipse in the middle instead of the end, se we get line numbers
  of exception
- Make the timestamp shorter
