### PR TITLE
1094 - shorter log messages for exceptions

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/logging/Log.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/logging/Log.java
@@ -22,22 +22,23 @@ public class Log {
     }
 
     public static void e(String logTag, String s, Throwable e) {
+        String msg;
+        if (e == null) {
+            msg = "";
+        } else {
+            msg = e.toString();
+        }
+
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
             System.out.println("E: " + logTag + ", " + s);
             if (e != null) {
                 e.printStackTrace();
             }
         } else {
-            android.util.Log.e(logTag, s, e);
+            android.util.Log.e(logTag, s + ":" + msg);
         }
 
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-
-        if (e != null) {
-            e.printStackTrace(pw);
-        }
-        AppGlobals.guiLogError(logTag + ":" + s  + sw.toString());
+        AppGlobals.guiLogError(logTag + ":" + s  + ":" + msg);
     }
 
     public static void i(String logTag, String s) {


### PR DESCRIPTION
Fix for #1094 

Full stacktraces should only show up in stdout in unittest builds.
Anything else should use e.toString() or "" if the exception is null.
