### PR TITLE
Reduce log size to 200, on old devices a full log can take 5 seconds for screen to load

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LogActivity extends ActionBarActivity {
     static LinkedList<String> buffer = new LinkedList<String>();
-    static final int MAX_SIZE = 500;
+    static final int MAX_SIZE = 200;
     private static LogMessageReceiver sInstance;
 
     public static class LogMessageReceiver extends BroadcastReceiver {


### PR DESCRIPTION
Found this when using an older 2.3.6 device.
