### PR TITLE
1089: For screens less than 500px wide, allow higher zooming on the map. 

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -98,7 +98,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
     private class BlankTileSource extends OnlineTileSourceBase {
         BlankTileSource() {
             super("fake", ResourceProxy.string.mapquest_aerial /* arbitrary value */,
-                    AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP,
+                    AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel(),
                     AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP, AbstractMapOverlay.TILE_PIXEL_SIZE,
                     "", new String[] {""});
         }
@@ -114,6 +114,8 @@ public final class MapFragment extends android.support.v4.app.Fragment
         super.onCreateView(inflater, container, savedInstanceState);
 
         mRootView = inflater.inflate(R.layout.activity_map, container, false);
+
+        AbstractMapOverlay.setDisplayBasedMinimumZoomLevel(getApplication());
 
         showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
 
@@ -179,7 +181,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
         final int zoom = zoomLevel;
         mMap.getController().setZoom(zoom);
         mMap.getController().setCenter(loc);
-        mMap.setMinZoomLevel(AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP);
+        mMap.setMinZoomLevel(AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel());
 
         mMap.postDelayed(new Runnable() {
             @Override
@@ -306,9 +308,9 @@ public final class MapFragment extends android.support.v4.app.Fragment
 
     private void initCoverageTiles(String coverageUrl) {
         Log.i(LOG_TAG, "initCoverageTiles: " + coverageUrl);
-        mCoverageTilesOverlayLowZoom = new CoverageOverlay(CoverageOverlay.LOW_ZOOM,
+        mCoverageTilesOverlayLowZoom = new CoverageOverlay(CoverageOverlay.LowResType.LOWER_ZOOM,
                 mRootView.getContext(), coverageUrl, mMap);
-        mCoverageTilesOverlayHighZoom = new CoverageOverlay(CoverageOverlay.HIGH_ZOOM,
+        mCoverageTilesOverlayHighZoom = new CoverageOverlay(CoverageOverlay.LowResType.HIGHER_ZOOM,
                 mRootView.getContext(), coverageUrl, mMap);
     }
 
@@ -441,9 +443,9 @@ public final class MapFragment extends android.support.v4.app.Fragment
             }
             mMap.setTileSource(new BlankTileSource());
             if (mLowResMapOverlayHighZoom == null) {
-                mLowResMapOverlayLowZoom = new LowResMapOverlay(LowResMapOverlay.LOW_ZOOM,
+                mLowResMapOverlayLowZoom = new LowResMapOverlay(LowResMapOverlay.LowResType.LOWER_ZOOM,
                         this.getActivity(), isMLSTileStore, mMap);
-                mLowResMapOverlayHighZoom = new LowResMapOverlay(LowResMapOverlay.HIGH_ZOOM,
+                mLowResMapOverlayHighZoom = new LowResMapOverlay(LowResMapOverlay.LowResType.HIGHER_ZOOM,
                         this.getActivity(), isMLSTileStore, mMap);
 
                 updateOverlayBaseLayer(mMap.getZoomLevel());

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -9,6 +9,10 @@ import android.graphics.Canvas;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
 
 import org.mozilla.osmdroid.DefaultResourceProxyImpl;
 import org.mozilla.osmdroid.tileprovider.BetterTileProvider;
@@ -24,7 +28,7 @@ import java.util.Set;
 public abstract class AbstractMapOverlay extends TilesOverlay {
     // We want the map to zoom to level 20, even if tiles have less zoom available
     public static final int MAX_ZOOM_LEVEL_OF_MAP = 20;
-    public static final int MIN_ZOOM_LEVEL_OF_MAP = 13;
+    private static int sMinZoomLevelOfMapDisplaySizeBased;
 
     public static final int TILE_PIXEL_SIZE = 256;
     // Use png32 which is a 32-color indexed image, the tiles are ~30% smaller
@@ -35,8 +39,25 @@ public abstract class AbstractMapOverlay extends TilesOverlay {
     private final Set<MapTile> mDrawnSet = new HashSet<MapTile>();
     private Projection mProjection;
 
-    public AbstractMapOverlay(final Context aContext) {
-        super(new BetterTileProvider(aContext), new DefaultResourceProxyImpl(aContext));
+    public enum LowResType {
+        HIGHER_ZOOM, LOWER_ZOOM
+    }
+
+    public AbstractMapOverlay(final Context context) {
+        super(new BetterTileProvider(context), new DefaultResourceProxyImpl(context));
+    }
+
+    public static void setDisplayBasedMinimumZoomLevel(Context c) {
+        WindowManager wm = (WindowManager) c.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+        DisplayMetrics outMetrics = new DisplayMetrics();
+        display.getMetrics(outMetrics);
+
+        sMinZoomLevelOfMapDisplaySizeBased = (outMetrics.widthPixels < 500)? 11 : 13;
+    }
+
+    public static int getDisplaySizeBasedMinZoomLevel() {
+        return sMinZoomLevelOfMapDisplaySizeBased;
     }
 
     // Though the tile provider can only provide up to 13, this overlay will display higher.

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -39,6 +39,11 @@ public abstract class AbstractMapOverlay extends TilesOverlay {
     private final Set<MapTile> mDrawnSet = new HashSet<MapTile>();
     private Projection mProjection;
 
+    // TODO make this a single value configurable in deveoper settings
+    private static final int SMALL_SCREEN_MIN_ZOOM = 11;
+    private static final int LARGE_SCREEN_MIN_ZOOM = 13;
+
+
     public enum LowResType {
         HIGHER_ZOOM, LOWER_ZOOM
     }
@@ -53,7 +58,7 @@ public abstract class AbstractMapOverlay extends TilesOverlay {
         DisplayMetrics outMetrics = new DisplayMetrics();
         display.getMetrics(outMetrics);
 
-        sMinZoomLevelOfMapDisplaySizeBased = (outMetrics.widthPixels < 500)? 11 : 13;
+        sMinZoomLevelOfMapDisplaySizeBased = (outMetrics.widthPixels < 500)? SMALL_SCREEN_MIN_ZOOM : LARGE_SCREEN_MIN_ZOOM;
     }
 
     public static int getDisplaySizeBasedMinZoomLevel() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -16,12 +16,15 @@ import org.mozilla.osmdroid.views.MapView;
  * This class provides the Mozilla Coverage overlay
  */
 public class CoverageOverlay extends AbstractMapOverlay {
-    public static final int HIGH_ZOOM = AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP;
     // Use a lower zoom than the LowResMapOverlay, the coverage can be very low detail and still look ok
-    public static final int LOW_ZOOM = 10;
+    private static final int LOW_ZOOM_LEVEL = 10;
 
-    public CoverageOverlay(int zoomLevel, final Context aContext, final String coverageUrl, MapView mapView) {
+    public CoverageOverlay(LowResType type, final Context aContext, final String coverageUrl, MapView mapView) {
         super(aContext);
+
+        final int zoomLevel = (type == LowResType.HIGHER_ZOOM)?
+                AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
+
         final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
                 null,
                 zoomLevel, zoomLevel,

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -15,11 +15,13 @@ import org.mozilla.osmdroid.tileprovider.util.SimpleInvalidationHandler;
 import org.mozilla.osmdroid.views.MapView;
 
 public class LowResMapOverlay extends AbstractMapOverlay {
-    public static final int HIGH_ZOOM = AbstractMapOverlay.MIN_ZOOM_LEVEL_OF_MAP;
-    public static final int LOW_ZOOM = 11;
+    private static final int LOW_ZOOM_LEVEL = 11;
 
-    public LowResMapOverlay(int zoomLevel, final Context aContext, boolean isMLSTileStore, MapView mapView) {
+    public LowResMapOverlay(LowResType type, final Context aContext, boolean isMLSTileStore, MapView mapView) {
         super(aContext);
+
+        final int zoomLevel = (type == LowResType.HIGHER_ZOOM)?
+                AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
 
         ITileSource coverageTileSource;
         if (isMLSTileStore) {


### PR DESCRIPTION
On the 320px screen I tested, full zoom out was 20x20km, previously it was 5x5km. 
Screens over 500px wide are unchanged.
#1089
