### PR TITLE
1103: On 400 error, print the stumble to the log without truncating it

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
@@ -102,7 +102,7 @@ public class LogActivity extends ActionBarActivity {
                 }
             }
 
-            if (s.length() > maxChars) {
+            if (s.length() > maxChars && !AppGlobals.NO_TRUNCATE_FLAG.equals(s.charAt(0))) {
                 // 1/3 of max length, ellipse, then last 2/3 of max length
                 s = s.substring(0, maxChars / 3) + " ... " + s.substring(s.length() - 1 - maxChars * 2/3);
             }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -40,26 +40,28 @@ public class AppGlobals {
     public static boolean isRobolectric;
 
     private static final SimpleDateFormat formatter = new SimpleDateFormat("HH:mm:ss: ");
+    public static final String NO_TRUNCATE_FLAG = "~";
 
     /* The log activity will clear this periodically, and display the messages.
      * Always null when the stumbler service is used stand-alone. */
     public static volatile ConcurrentLinkedQueue<String> guiLogMessageBuffer;
 
     public static void guiLogError(String msg) {
-        guiLogInfo(msg, "red", true);
+        guiLogInfo(msg, "red", true, false);
     }
 
     public static void guiLogInfo(String msg) {
-        guiLogInfo(msg, "white", false);
+        guiLogInfo(msg, "white", false, false);
     }
 
-    public static void guiLogInfo(String msg, String color, boolean isBold) {
+    public static void guiLogInfo(String msg, String color, boolean isBold, boolean doNotTruncateLongString) {
         if (guiLogMessageBuffer != null) {
             if (isBold) {
                 msg = "<b>" + msg + "</b>";
             }
+            String noTruncateFlag = doNotTruncateLongString? NO_TRUNCATE_FLAG : "";
             String ts = formatter.format(new Date());
-            guiLogMessageBuffer.add(ts + "<font color='" + color +"'>" + msg + "</font>");
+            guiLogMessageBuffer.add(noTruncateFlag + ts + "<font color='" + color +"'>" + msg + "</font>");
         }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -142,7 +142,7 @@ public class GPSScanner implements LocationListener {
     }
 
     private void sendToLogActivity(String msg) {
-        AppGlobals.guiLogInfo(msg, "#33ccff", false);
+        AppGlobals.guiLogInfo(msg, "#33ccff", false, false);
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -15,6 +15,7 @@ import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.core.http.MLS;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
+import org.mozilla.mozstumbler.service.utils.Zipper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -130,7 +131,7 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
                     totalBytesSent += result.bytesSent();
 
                     String logMsg =  "MLS Submit: [HTTP Status:" + result.httpResponse() + "], [Bytes Sent:" + result.bytesSent() + "]";
-                    AppGlobals.guiLogInfo(logMsg, "#FFFFCC", true);
+                    AppGlobals.guiLogInfo(logMsg, "#FFFFCC", true, false);
 
                     dm.delete(batch.filename);
 
@@ -145,6 +146,10 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
                     
                     if (result != null && result.isErrorCode400BadRequest()) {
                         logMsg += ", 400 Error, deleting bad report";
+                        if (AppGlobals.guiLogMessageBuffer != null) { // if true, this is a GUI app
+                            String unzipped = Zipper.unzipData(batch.data);
+                            AppGlobals.guiLogInfo(unzipped, "red", false, true);
+                        }
                         dm.delete(batch.filename);
                     } else {
                         DataStorageManager.getInstance().saveCurrentReportsSendBufferToDisk();


### PR DESCRIPTION
We want to figure out these 400 errors which are caused by problems in the stumble JSON. This _should_ help catch the problem.
#1103
