### PR TITLE
1121 - NPE due to calling newMLSPoint with a null point

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -85,7 +85,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
                         obs.fetchMLS();
                         count++;
                     } else {
-                        if (getMapActivity() != null) {
+                        if (getMapActivity() != null && obs.pointMLS != null) {
                             getMapActivity().newMLSPoint(obs);
                         }
                         li.remove();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -84,7 +84,7 @@ class ObservationPointsOverlay extends Overlay {
         final Projection pj = mapView.getProjection();
         GeoPoint geoPoint = (isMlsPointUpdate)? obsPoint.pointMLS : obsPoint.pointGPS;
         if (geoPoint == null) {
-            Log.i(LOG_TAG, "Caller error: geoPoint is null");
+            Log.w(LOG_TAG, "Caller error: geoPoint is null");
             return;
         }
         final Point point = pj.toPixels(geoPoint, null);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -18,6 +18,7 @@ import org.mozilla.osmdroid.util.GeoPoint;
 import org.mozilla.osmdroid.views.MapView;
 import org.mozilla.osmdroid.views.Projection;
 import org.mozilla.osmdroid.views.overlay.Overlay;
+import org.mozilla.mozstumbler.service.core.logging.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,6 +83,10 @@ class ObservationPointsOverlay extends Overlay {
     void update(ObservationPoint obsPoint, MapView mapView, boolean isMlsPointUpdate) {
         final Projection pj = mapView.getProjection();
         GeoPoint geoPoint = (isMlsPointUpdate)? obsPoint.pointMLS : obsPoint.pointGPS;
+        if (geoPoint == null) {
+            Log.i(LOG_TAG, "Caller error: geoPoint is null");
+            return;
+        }
         final Point point = pj.toPixels(geoPoint, null);
         final int size = mSize3px * 2; // update a rectangle 2x large as the point radius
         final Rect dirty = new Rect(point.x - size, point.y - size, point.x + size, point.y + size);


### PR DESCRIPTION
#1121

This happens due to 400 errors in requesting MLS point. Which leads to the next question as to _why_ we are getting 400 errors here. These should be logged already, so we should investigate.
