### PR TITLE
972 - default crash reporting pref to off

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -96,7 +96,7 @@ public class ClientPrefs extends Prefs {
     }
 
     public boolean isCrashReportingEnabled() {
-        return getBoolPrefWithDefault(CRASH_REPORTING, true);
+        return getBoolPrefWithDefault(CRASH_REPORTING, false);
     }
 
     public void setMapTileResolutionType(int mapTileResolutionType) {


### PR DESCRIPTION
Perhaps we can change this to "if github build, then default to on"
#1127
