### PR TITLE
Features/933 github only updater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,13 @@ unittest:
 debug:
 	./gradlew assembleDebug
 
-release: release_check
-	./gradlew assembleRelease
-	sh rename_release.sh
+github: release_check
+	./gradlew assembleGithub
+	sh rename_release.sh github
+
+playstore: release_check
+	./gradlew assemblePlaystore
+	sh rename_release.sh playstore
 
 clean:
 	rm -rf android/libs/*.jar

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,6 +65,9 @@ android {
 
         buildConfigField "boolean", "LABEL_MAP_TILES", "false"
 
+        buildConfigField "boolean", "GITHUB", "false"
+        buildConfigField "boolean", "PLAYSTORE", "false"
+
         // Crash report settings
         buildConfigField "String", "ACRA_URI", getAcraURI()
         buildConfigField "String", "ACRA_USER", getAcraUser()
@@ -90,6 +93,16 @@ android {
             runProguard true
             proguardFile 'proguard.cfg'
             signingConfig signingConfigs.release
+        }
+
+        github.initWith(buildTypes.release)
+        github {
+            buildConfigField "boolean", "GITHUB", "true"
+        }
+
+        playstore.initWith(buildTypes.release)
+        playstore {
+            buildConfigField "boolean", "PLAYSTORE", "true"
         }
 
         unittest.initWith(buildTypes.debug)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,9 +34,6 @@ repositories {
 import de.undercouch.gradle.tasks.download.Download
 import java.util.regex.Pattern
 
-def libDir = new File("android/libs")
-libDir.mkdirs()
-
 android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
@@ -118,9 +115,6 @@ dependencies {
 
     testCompile 'junit:junit:4.10'
     testCompile 'org.robolectric:robolectric:2.3'
-
-    // pickup osmdroid
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 
     compile 'com.crankycoder:SimpleKML:1.0'
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -107,8 +107,10 @@ public class MainDrawerActivity
         getApp().setMainActivity(this);
 
         IHttpUtil httpUtil = new HttpUtil();
-        Updater upd = new Updater(httpUtil);
-        upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
+        if (BuildConfig.GITHUB) {
+            Updater upd = new Updater(httpUtil);
+            upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
+        }
 
         mMetricsView = new MetricsView(findViewById(R.id.left_drawer));
     }

--- a/rename_release.sh
+++ b/rename_release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # bad hack to rename the final apk
 mkdir -p outputs
-cmd="cp android/build/outputs/apk/MozStumbler-release.apk outputs/MozStumbler-v`cat VERSION`.apk"
+cmd="cp android/build/outputs/apk/MozStumbler-$1.apk outputs/MozStumbler-v`cat VERSION`.apk"
 `${cmd}`


### PR DESCRIPTION
Fix #933

I've removed the android/libs/\* classpath from the build and added BuildConfig booleans for GITHUB and PLAYSTORE releases.

The Updater code is only enabled for GITHUB==true from now on.
