### PR TITLE
1129 / 1087: in follow mode, dots not drawn

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -201,7 +201,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
         mAccuracyOverlay = new AccuracyCircleOverlay(mRootView.getContext(), sGPSColor);
         mMap.getOverlays().add(mAccuracyOverlay);
 
-        mObservationPointsOverlay = new ObservationPointsOverlay(mRootView.getContext(), mMap);
+        mObservationPointsOverlay = new ObservationPointsOverlay(mRootView.getContext());
         mMap.getOverlays().add(mObservationPointsOverlay);
 
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();


### PR DESCRIPTION
The pixel grid hashing was not accounting for the panning. Now when the
pixel hash is created, track the current pan state.
#1129 / #1087
