### PR TITLE
Use scripts to get the versionCode and versionName from the git tag

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,5 @@
-// each of the version numbers must be 0-99
-def versionMajor = 0
-def versionMinor = 42
-def versionPatch = 0
-def versionBuild = 2 // this is non-zero for any dev build
+def buildCode = file("../version-code.sh").toString().execute().text.trim().toInteger()
+def buildName = file("../version-name.sh").toString().execute().text.trim()
 
 buildscript {
     repositories {
@@ -51,8 +48,8 @@ android {
         minSdkVersion 10
         targetSdkVersion 18
 
-        versionCode versionMajor * 1000000 + versionMinor * 10000 + versionPatch * 100 + versionBuild
-        versionName "${versionMajor}.${versionMinor}.${versionPatch}.${versionBuild}"
+        versionCode buildCode
+        versionName buildName
 
         // I'm so happy I have to compute the versionCode, versionName
         // and then duplicate it in the manifest.  yay android.

--- a/version-code.sh
+++ b/version-code.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+GIT_TAG=$(git describe --tags --match "v*")
+
+# Remove the "v" at the beginning
+FULL_VERSION=${GIT_TAG#v}
+
+# Remove anything after a "-"
+FULL_VERSION=${FULL_VERSION%%-*}
+
+MAJOR=${FULL_VERSION%%.*}
+BUILD=${FULL_VERSION##*.}
+
+MINOR_PATCH_BUILD=${FULL_VERSION#*.}
+MINOR=${MINOR_PATCH_BUILD%%.*}
+
+PATCH_BUILD=${MINOR_PATCH_BUILD%.*}
+PATCH=${PATCH_BUILD##*.}
+
+VERSION_CODE=$((${MAJOR} * 1000000 + ${MINOR} * 10000 + ${PATCH} * 100 + ${BUILD}))
+echo ${VERSION_CODE}

--- a/version-name.sh
+++ b/version-name.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+GIT_TAG=$(git describe --tags --match "v*")
+
+echo ${GIT_TAG}


### PR DESCRIPTION
The version-code.sh script could be made more straightforward if a dependency on "sed" or "cut" is allowed, but a straight /bin/sh version works fine.
