### PR TITLE
1169: ACRA Report: NPE WifiScanner.java:98

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -58,6 +58,10 @@ public class WifiScanner extends BroadcastReceiver {
     }
 
     private List<ScanResult> getScanResults() {
+        WifiManager manager = getWifiManager();
+        if (manager == null) {
+            return null;
+        }
         return getWifiManager().getScanResults();
     }
 
@@ -94,8 +98,12 @@ public class WifiScanner extends BroadcastReceiver {
                 deactivatePeriodicScan();
             }
         } else if (WifiManager.SCAN_RESULTS_AVAILABLE_ACTION.equals(action)) {
-            ArrayList<ScanResult> scanResults = new ArrayList<ScanResult>();
-            for (ScanResult scanResult : getScanResults()) {
+            final List<ScanResult> scanResultList = getScanResults();
+            if (scanResultList == null) {
+                return;
+            }
+            final ArrayList<ScanResult> scanResults = new ArrayList<ScanResult>();
+            for (ScanResult scanResult : scanResultList) {
                 scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
                 if (shouldLog(scanResult)) {
                     scanResults.add(scanResult);


### PR DESCRIPTION
#1169

Added null pointer checks to getting wifi manager and scan result. In theory neither of these should have ever been null.
