### PR TITLE
1170 ACRA report: provider doesn't exist: gps

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -60,7 +60,12 @@ public class StumblerService extends PersistentIntentService
     }
 
     public synchronized void startScanning() {
-        mScanManager.startScanning(this);
+        try {
+            mScanManager.startScanning(this);
+        } catch (IllegalArgumentException ex) {
+            // If a provider is unsupported on this device, it will be reported as this exception
+            Log.w(LOG_TAG, "Stumbling is not supported on this device:" + ex.toString());
+        }
     }
 
     // This is optional, not used in Fennec, and is for clients to specify a (potentially long) list


### PR DESCRIPTION
#1170

Wrap the startScanning in a catch for IllegalArgumentException (which is thrown when no GPS is available).
