### PR TITLE
1187 - NPE - Appears to be from no app context

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -102,6 +102,10 @@ public class ScanManager {
         }
 
         mContext = context.getApplicationContext();
+        if (mContext == null) {
+            Log.w(LOG_TAG, "No app context available.");
+            return;
+        }
         if (mGPSScanner == null) {
             mGPSScanner = new GPSScanner(context, this);
             mWifiScanner = new WifiScanner(context);


### PR DESCRIPTION
The line nums in the report don't match exactly with the code (form what I can see), but it appears to be a null app context is causing this.
#1187
