### PR TITLE
 #893 Drawer: uploads+settings as non-scrolling footer row

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -131,8 +131,6 @@ public class MainDrawerActivity
         }
         else {
             MenuItemCompat.setShowAsAction(mMenuItemStartStop, MenuItemCompat.SHOW_AS_ACTION_ALWAYS);
-            MenuItem item = menu.findItem(R.id.action_preferences);
-            MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_ALWAYS);
         }
 
         updateStartStopMenuItemState();
@@ -231,9 +229,6 @@ public class MainDrawerActivity
         switch (item.getItemId()) {
             case MENU_START_STOP:
                 mMapFragment.toggleScanning(item);
-                return true;
-            case R.id.action_preferences:
-                startActivity(new Intent(getApplication(), PreferencesScreen.class));
                 return true;
             case R.id.action_view_leaderboard:
                 startActivity(new Intent(getApplication(), LeaderboardActivity.class));

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.mozstumbler.client.navdrawer;
 
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -11,6 +12,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.ImageButton;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.ocpsoft.pretty.time.PrettyTime;
@@ -18,6 +20,7 @@ import com.ocpsoft.pretty.time.PrettyTime;
 import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.DateTimeUtils;
+import org.mozilla.mozstumbler.client.subactivities.PreferencesScreen;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageContract;
@@ -56,7 +59,9 @@ public class MetricsView {
     private final Handler mHandler = new Handler(Looper.getMainLooper());
     private final long FREQ_UPDATE_UPLOADTIME = 10 * 1000;
 
-    private ImageButton mUploadButton;
+    private final ImageButton mUploadButton;
+    private final ImageButton mSettingsdButton;
+    private final RelativeLayout mButtonsContainer;
     private final View mView;
     private long mTotalBytesUploadedThisSession_lastDisplayed = -1;
     private long mLastUploadTime = 0;
@@ -110,6 +115,18 @@ public class MetricsView {
                 setUploadButtonToSyncing(true);
             }
         });
+
+        mSettingsdButton = (ImageButton) mView.findViewById(R.id.metrics_settings_button);
+        mSettingsdButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                view.getContext().startActivity(new Intent(view.getContext(), PreferencesScreen.class));
+            }
+        });
+
+        // Remove listener of the Drawer buttons container to avoid to get it triggered on the Map view
+        mButtonsContainer = (RelativeLayout) mView.findViewById(R.id.metrics_buttons_container);
+        mButtonsContainer.setOnClickListener(null);
 
         mHandler.postDelayed(mUpdateLastUploadedLabel, FREQ_UPDATE_UPLOADTIME);
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -124,7 +124,7 @@ public class MetricsView {
             }
         });
 
-        // Remove listener of the Drawer buttons container to avoid to get it triggered on the Map view
+        // Remove click listener of the Drawer buttons container to avoid to get it triggered on the Map view
         mButtonsContainer = (RelativeLayout) mView.findViewById(R.id.metrics_buttons_container);
         mButtonsContainer.setOnClickListener(null);
 

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -1,329 +1,351 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <RelativeLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="4dp"
-        android:paddingEnd="16dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="4dp">
+        android:layout_weight="10">
 
-        <TextView
-            android:id="@+id/metrics_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:paddingTop="@dimen/padding_above_for_metrics_titles"
-            android:text="@string/metrics_activity_title"
-            android:textColor="#ff33b5e5"
-            android:textSize="@dimen/font_size_for_metrics_top_title"
-            android:textStyle="bold" />
-
-        <TableLayout
-            android:id="@+id/metrics_table"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/metrics_title">
+            android:paddingBottom="4dp"
+            android:paddingEnd="16dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:paddingStart="16dp"
+            android:paddingTop="4dp">
 
-            <TableRow>
+            <TextView
+                android:id="@+id/metrics_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:paddingTop="@dimen/padding_above_for_metrics_titles"
+                android:text="@string/metrics_activity_title"
+                android:textColor="#ff33b5e5"
+                android:textSize="@dimen/font_size_for_metrics_top_title"
+                android:textStyle="bold" />
 
-                <TextView
-                    android:id="@+id/this_session_header"
-                    android:layout_gravity="start"
-                    android:layout_span="2"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingTop="@dimen/padding_above_for_metrics_titles"
-                    android:text="@string/metrics_this_session"
-                    android:textSize="@dimen/font_size_for_metrics_titles"
-                    android:textStyle="bold" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/this_session_observations_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/this_session_observations_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="50" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/sent_header"
-                    android:layout_gravity="start"
-                    android:layout_span="2"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingTop="@dimen/padding_above_for_metrics_titles"
-                    android:text="@string/upload_observations_sent_title"
-                    android:textSize="@dimen/font_size_for_metrics_titles"
-                    android:textStyle="bold" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/last_upload_time_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_last_upload_time_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/last_upload_time_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="16.02.14 13:07" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/observations_sent_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/observations_sent_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="100" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/cells_sent_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_cell_towers_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/cells_sent_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="50" />
-            </TableRow>
-
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/wifis_sent_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_wifis_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/wifis_sent_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="500" />
-            </TableRow>
-
-            <TableRow
+            <TableLayout
+                android:id="@+id/metrics_table"
                 android:layout_width="match_parent"
-                android:layout_marginTop="5dp"
-                android:background="@android:color/darker_gray">
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/metrics_title">
 
-                <View android:layout_height="1dp" />
-            </TableRow>
+                <TableRow>
 
-            <TableRow>
+                    <TextView
+                        android:id="@+id/this_session_header"
+                        android:layout_gravity="start"
+                        android:layout_span="2"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingTop="@dimen/padding_above_for_metrics_titles"
+                        android:text="@string/metrics_this_session"
+                        android:textSize="@dimen/font_size_for_metrics_titles"
+                        android:textStyle="bold" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/this_session_observations_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/this_session_observations_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/sent_header"
+                        android:layout_gravity="start"
+                        android:layout_span="2"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingTop="@dimen/padding_above_for_metrics_titles"
+                        android:text="@string/upload_observations_sent_title"
+                        android:textSize="@dimen/font_size_for_metrics_titles"
+                        android:textStyle="bold" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/last_upload_time_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_last_upload_time_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/last_upload_time_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="16.02.14 13:07" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/observations_sent_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/observations_sent_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="100" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/cells_sent_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_cell_towers_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/cells_sent_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/wifis_sent_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_wifis_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/wifis_sent_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="500" />
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="5dp"
+                    android:background="@android:color/darker_gray">
+
+                    <View android:layout_height="1dp" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/queued_header"
+                        android:layout_gravity="start"
+                        android:layout_span="2"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingTop="@dimen/padding_above_for_metrics_titles"
+                        android:text="@string/upload_observations_in_queue_title"
+                        android:textSize="@dimen/font_size_for_metrics_titles"
+                        android:textStyle="bold" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/observations_queued_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/observations_queued_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/cells_queued_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_cell_towers_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/cells_queued_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="10" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/wifis_queued_title"
+                        android:layout_gravity="start"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_wifis_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/wifis_queued_value"
+                        android:layout_gravity="start"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+            </TableLayout>
+
+            <TextView
+                android:id="@+id/map_info_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/metrics_table"
+                android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                android:paddingTop="20dp"
+                android:text="@string/drawer_map_layers_title"
+                android:textColor="#ff33b5e5"
+                android:textSize="@dimen/font_size_for_metrics_top_title"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:id="@+id/cell_only_layout"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/map_info_title"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/cell_only_imageview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:maxHeight="14dp"
+                    android:maxWidth="14dp"
+                    android:src="@drawable/ic_purplering" />
 
                 <TextView
-                    android:id="@+id/queued_header"
-                    android:layout_gravity="start"
-                    android:layout_span="2"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingTop="@dimen/padding_above_for_metrics_titles"
-                    android:text="@string/upload_observations_in_queue_title"
-                    android:textSize="@dimen/font_size_for_metrics_titles"
-                    android:textStyle="bold" />
-            </TableRow>
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="5dp"
+                    android:paddingStart="5dp"
+                    android:text="@string/wifi_only_observation"
+                    android:textSize="@dimen/font_size_for_metrics" />
+            </LinearLayout>
 
-            <TableRow>
+            <LinearLayout
+                android:id="@+id/wifi_only_layout"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@id/cell_only_layout"
+                android:orientation="horizontal"
+                android:paddingBottom="10dp">
+
+                <ImageView
+                    android:id="@+id/wifi_only_imageview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:maxHeight="14dp"
+                    android:maxWidth="14dp"
+                    android:src="@drawable/ic_bluerect" />
 
                 <TextView
-                    android:id="@+id/observations_queued_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="5dp"
+                    android:paddingStart="5dp"
+                    android:text="@string/cell_only_observation"
                     android:textSize="@dimen/font_size_for_metrics" />
 
-                <TextView
-                    android:id="@+id/observations_queued_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="50" />
-            </TableRow>
+            </LinearLayout>
 
-            <TableRow>
+            <CheckBox
+                android:id="@+id/checkBox_show_mls"
+                android:layout_width="wrap_content"
+                android:layout_height="34dp"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@id/wifi_only_layout"
+                android:checked="false"
+                android:text="@string/drawer_map_option_show_mls_locations"
+                android:textSize="14sp" />
 
-                <TextView
-                    android:id="@+id/cells_queued_title"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_cell_towers_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
+        </RelativeLayout>
 
-                <TextView
-                    android:id="@+id/cells_queued_value"
-                    android:layout_gravity="start"
-                    android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="10" />
-            </TableRow>
+    </ScrollView>
 
-            <TableRow>
-
-                <TextView
-                    android:id="@+id/wifis_queued_title"
-                    android:layout_gravity="start"
-                    android:paddingEnd="3dp"
-                    android:paddingRight="3dp"
-                    android:text="@string/metrics_observations_wifis_title"
-                    android:textSize="@dimen/font_size_for_metrics" />
-
-                <TextView
-                    android:id="@+id/wifis_queued_value"
-                    android:layout_gravity="start"
-                    android:textSize="@dimen/font_size_for_metrics"
-                    tools:text="50" />
-            </TableRow>
-
-        </TableLayout>
+    <RelativeLayout
+        android:id="@+id/metrics_buttons_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="bottom"
+        android:padding="5dp">
 
         <ImageButton
             android:id="@+id/upload_observations_button"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_alignBottom="@+id/metrics_table"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_marginBottom="-5dp"
+            android:layout_width="42dp"
+            android:layout_height="42dp"
+            android:layout_alignParentLeft="true"
             android:enabled="false"
             android:src="@drawable/ic_action_upload" />
 
-        <TextView
-            android:id="@+id/map_info_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/metrics_table"
-            android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-            android:paddingTop="20dp"
-            android:text="@string/drawer_map_layers_title"
-            android:textColor="#ff33b5e5"
-            android:textSize="@dimen/font_size_for_metrics_top_title"
-            android:textStyle="bold" />
-
-        <LinearLayout
-            android:id="@+id/cell_only_layout"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/map_info_title"
-            android:orientation="horizontal">
-
-            <ImageView
-                android:id="@+id/cell_only_imageview"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:adjustViewBounds="true"
-                android:maxHeight="14dp"
-                android:maxWidth="14dp"
-                android:src="@drawable/ic_purplering" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingLeft="5dp"
-                android:paddingStart="5dp"
-                android:text="@string/wifi_only_observation"
-                android:textSize="@dimen/font_size_for_metrics" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/wifi_only_layout"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@id/cell_only_layout"
-            android:orientation="horizontal"
-            android:paddingBottom="10dp">
-
-            <ImageView
-                android:id="@+id/wifi_only_imageview"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:adjustViewBounds="true"
-                android:maxHeight="14dp"
-                android:maxWidth="14dp"
-                android:src="@drawable/ic_bluerect" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingLeft="5dp"
-                android:paddingStart="5dp"
-                android:text="@string/cell_only_observation"
-                android:textSize="@dimen/font_size_for_metrics" />
-
-        </LinearLayout>
-
-        <CheckBox
-            android:id="@+id/checkBox_show_mls"
-            android:layout_width="wrap_content"
-            android:layout_height="34dp"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_below="@id/wifi_only_layout"
-            android:checked="false"
-            android:text="@string/drawer_map_option_show_mls_locations"
-            android:textSize="14sp" />
-
+        <ImageButton
+            android:id="@+id/metrics_settings_button"
+            android:layout_width="42dp"
+            android:layout_height="42dp"
+            android:layout_alignParentRight="true"
+            android:enabled="false"
+            android:src="@drawable/ic_action_settings" />
     </RelativeLayout>
-</ScrollView>
+</LinearLayout>

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -346,6 +346,7 @@
             android:layout_height="42dp"
             android:layout_alignParentRight="true"
             android:enabled="false"
+            android:contentDescription="@string/action_preferences"
             android:src="@drawable/ic_action_settings" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/src/main/res/menu/main.xml
+++ b/android/src/main/res/menu/main.xml
@@ -6,10 +6,4 @@
         android:menuCategory="system"
         android:title="@string/view_leaderboard"
         app:showAsAction="never" />
-    <item
-        android:id="@+id/action_preferences"
-        android:icon="@drawable/ic_action_settings"
-        android:menuCategory="system"
-        android:title="@string/action_preferences"
-        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
# Description

The upload reports button was added to the bottom of the Drawer together with the preferences button.

This feature is working on portrait and landscape mode as well (in this case, the the report is scrollable). This bottom buttons on the drawer remain always visible. Below you can find screenshots of both modes.
# Implementation
### Layout design explanation

On the xml file (fragment_metrics_drawer.xml), the ScrollView was moved inside a LinearLayout with vertical orientation.

The only thing that changed on the ScrollView is that now it has a weight of 10.

Below of the ScrollView there is a RelativeLayout (aka "buttons container") which has the upload button and the preferences button. This RelativeLayout has a weight of 1 and its buttons are established one on the left side and the other on the right one according to the bug #893.

Also, following the AC of #893, the preferences menu item was removed.
### Java code explanation

Regarding to the code, the references to the preferences menu item were removed.

Also, the preferences button was added to the MetricsView with its click listener. Besides that, the click listener was removed of the drawer buttons container because when the drawer was open, if you touched the container, the event went directly to the map view which leaded on a wrong behavior.
# Screenshots

![screenshot_2014-11-03-22-40-43](https://cloud.githubusercontent.com/assets/4610807/4893591/2bc907be-63c4-11e4-891e-a9c7e224c325.png)
![screenshot_2014-11-03-22-40-51](https://cloud.githubusercontent.com/assets/4610807/4893592/2bd0adde-63c4-11e4-9e92-9e22e7b82f1c.png)
