### PR TITLE
Show unique number of networks in metrics

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -59,15 +59,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
     formUriBasicAuthLogin = BuildConfig.ACRA_USER,
     formUriBasicAuthPassword = BuildConfig.ACRA_PASS)
 public class MainApp extends Application
-        implements ObservedLocationsReceiver.ICountObserver,
-        AsyncUploader.AsyncUploaderListener {
+        implements AsyncUploader.AsyncUploaderListener {
     public static final AtomicBoolean isUploading = new AtomicBoolean();
     private final String LOG_TAG = AppGlobals.LOG_PREFIX + MainApp.class.getSimpleName();
     private ClientStumblerService mStumblerService;
     private ServiceConnection mConnection;
     private ServiceBroadcastReceiver mReceiver;
     private WeakReference<IMainActivity> mMainActivity = new WeakReference<IMainActivity>(null);
-    private int mObservationCount = 0;
     private final long MAX_BYTES_DISK_STORAGE = 1000 * 1000 * 20; // 20MB for Mozilla Stumbler by default, is ok?
     private final int MAX_WEEKS_OLD_STORED = 4;
     public static final String INTENT_TURN_OFF = "org.mozilla.mozstumbler.turnMeOff";
@@ -140,7 +138,7 @@ public class MainApp extends Application
         NetworkInfo.createGlobalInstance(this);
         LogActivity.LogMessageReceiver.createGlobalInstance(this);
         // This will create, and register the receiver
-        ObservedLocationsReceiver.createGlobalInstance(this.getApplicationContext(), this);
+        ObservedLocationsReceiver.createGlobalInstance(this.getApplicationContext());
 
         enableStrictMode();
 
@@ -376,14 +374,6 @@ public class MainApp extends Application
             }
             dbFile.delete();
         }
-    }
-
-    public void observedLocationCountIncrement() {
-        mObservationCount++;
-    }
-
-    public int getObservedLocationCount() {
-        return mObservationCount;
     }
 
     public void showDeveloperDialog(Activity activity) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -29,17 +29,12 @@ import java.util.LinkedList;
 
 public class ObservedLocationsReceiver extends BroadcastReceiver {
 
-    public interface ICountObserver {
-        public void observedLocationCountIncrement();
-    }
-
     private static final String LOG_TAG = ObservedLocationsReceiver.class.getSimpleName();
     private WeakReference<MapFragment> mMapActivity = new WeakReference<MapFragment>(null);
     private final LinkedList<ObservationPoint> mCollectionPoints = new LinkedList<ObservationPoint>();
     private final LinkedList<ObservationPoint> mQueuedForMLS = new LinkedList<ObservationPoint>();
     private static final int MAX_QUEUED_MLS_POINTS_TO_FETCH = 10;
     private static final long FREQ_FETCH_MLS_MS = 5 * 1000;
-    private WeakReference<ICountObserver> mCountObserver = new WeakReference<ICountObserver>(null);
     private final Handler mHandler = new Handler(Looper.getMainLooper());
 
     // Upper bound on the size of the linked lists of points, for memory and performance safety.
@@ -53,9 +48,8 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
 
     private static ObservedLocationsReceiver sInstance;
 
-    public static void createGlobalInstance(Context context, ICountObserver countObserver) {
+    public static void createGlobalInstance(Context context) {
         sInstance = new ObservedLocationsReceiver();
-        sInstance.mCountObserver = new WeakReference<ICountObserver>(countObserver);
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(Reporter.ACTION_NEW_BUNDLE);
         LocalBroadcastManager.getInstance(context).registerReceiver(sInstance, intentFilter);
@@ -141,11 +135,6 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             }
         } catch (JSONException e) {
             Log.w(LOG_TAG, "Failed to convert bundle to JSON: " + e);
-        }
-
-        // Notify main app of observation
-        if (mCountObserver.get() != null) {
-            mCountObserver.get().observedLocationCountIncrement();
         }
 
         while (mCollectionPoints.size() > MAX_SIZE_OF_POINT_LISTS) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -37,8 +37,8 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
     private WeakReference<MapFragment> mMapActivity = new WeakReference<MapFragment>(null);
     private final LinkedList<ObservationPoint> mCollectionPoints = new LinkedList<ObservationPoint>();
     private final LinkedList<ObservationPoint> mQueuedForMLS = new LinkedList<ObservationPoint>();
-    private final int MAX_QUEUED_MLS_POINTS_TO_FETCH = 10;
-    private final long FREQ_FETCH_MLS_MS = 5 * 1000;
+    private static final int MAX_QUEUED_MLS_POINTS_TO_FETCH = 10;
+    private static final long FREQ_FETCH_MLS_MS = 5 * 1000;
     private WeakReference<ICountObserver> mCountObserver = new WeakReference<ICountObserver>(null);
     private final Handler mHandler = new Handler(Looper.getMainLooper());
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -256,12 +256,12 @@ public class MainDrawerActivity
             return;
         }
 
-        mMapFragment.formatTextView(R.id.text_cells_visible, "%d", service.getCellInfoCount());
+        mMapFragment.formatTextView(R.id.text_cells_visible, "%d", service.getVisibleCellInfoCount());
         mMapFragment.formatTextView(R.id.text_wifis_visible, "%d", service.getVisibleAPCount());
 
-        int count = getApp().getObservedLocationCount();
-        mMapFragment.formatTextView(R.id.text_observation_count, "%d", count);
-        mMetricsView.setObservationCount(count);
+        int observationCount = getApp().getObservedLocationCount();
+        mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
+        mMetricsView.setObservationCount(observationCount);
 
         mMetricsView.update();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -259,7 +259,7 @@ public class MainDrawerActivity
         mMapFragment.formatTextView(R.id.text_cells_visible, "%d", service.getVisibleCellInfoCount());
         mMapFragment.formatTextView(R.id.text_wifis_visible, "%d", service.getVisibleAPCount());
 
-        int observationCount = getApp().getObservedLocationCount();
+        int observationCount = service.getObservationCount();
         mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
         mMetricsView.setObservationCount(observationCount);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -261,7 +261,7 @@ public class MainDrawerActivity
 
         int observationCount = service.getObservationCount();
         mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
-        mMetricsView.setObservationCount(observationCount);
+        mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(), service.getUniqueAPCount());
 
         mMetricsView.update();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -68,6 +68,8 @@ public class MetricsView {
     private boolean mHasQueuedObservations;
 
     private static int sThisSessionObservationsCount;
+    private static int sThisSessionUniqueWifiCount;
+    private static int sThisSessionUniqueCellCount;
 
     public MetricsView(View view) {
         mView = view;
@@ -272,7 +274,9 @@ public class MetricsView {
         updateUploadButtonEnabled();
     }
 
-    public void setObservationCount(int observations) {
+    public void setObservationCount(int observations, int cells, int wifis) {
         sThisSessionObservationsCount = observations;
+        sThisSessionUniqueCellCount = cells;
+        sThisSessionUniqueWifiCount = wifis;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -58,7 +58,7 @@ public class MetricsView {
     private final long FREQ_UPDATE_UPLOADTIME = 10 * 1000;
 
     private final ImageButton mUploadButton;
-    private final ImageButton mSettingsdButton;
+    private final ImageButton mSettingsButton;
     private final RelativeLayout mButtonsContainer;
     private final View mView;
     private long mTotalBytesUploadedThisSession_lastDisplayed = -1;
@@ -67,7 +67,7 @@ public class MetricsView {
 
     private boolean mHasQueuedObservations;
 
-    private static int mThisSessionObservationsCount;
+    private static int sThisSessionObservationsCount;
 
     public MetricsView(View view) {
         mView = view;
@@ -114,8 +114,8 @@ public class MetricsView {
             }
         });
 
-        mSettingsdButton = (ImageButton) mView.findViewById(R.id.metrics_settings_button);
-        mSettingsdButton.setOnClickListener(new View.OnClickListener() {
+        mSettingsButton = (ImageButton) mView.findViewById(R.id.metrics_settings_button);
+        mSettingsButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 view.getContext().startActivity(new Intent(view.getContext(), PreferencesScreen.class));
@@ -191,13 +191,13 @@ public class MetricsView {
     }
 
     private void updateThisSessionStats() {
-        if (mThisSessionObservationsCount < 1) {
+        if (sThisSessionObservationsCount < 1) {
             mThisSessionObservationsView.setText("0");
             return;
         }
 
         long bytesUploadedThisSession = AsyncUploader.sTotalBytesUploadedThisSession.get();
-        String val = String.format(mObservationAndSize, mThisSessionObservationsCount, formatKb(bytesUploadedThisSession));
+        String val = String.format(mObservationAndSize, sThisSessionObservationsCount, formatKb(bytesUploadedThisSession));
         mThisSessionObservationsView.setText(val);
     }
 
@@ -245,9 +245,9 @@ public class MetricsView {
             Properties props = dataStorageManager.readSyncStats();
             String value;
             value = props.getProperty(DataStorageContract.Stats.KEY_CELLS_SENT, "0");
-            mAllTimeCellsSentView.setText(String.valueOf(value));
+            mAllTimeCellsSentView.setText(value);
             value = props.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0");
-            mAllTimeWifisSentView.setText(String.valueOf(value));
+            mAllTimeWifisSentView.setText(value);
             value = props.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0");
             String bytes = props.getProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "0");
             value = String.format(mObservationAndSize, Integer.parseInt(value), formatKb(Long.parseLong(bytes)));
@@ -272,8 +272,7 @@ public class MetricsView {
         updateUploadButtonEnabled();
     }
 
-    public void setObservationCount(int count) {
-        mThisSessionObservationsCount = count;
-        updateThisSessionStats();
+    public void setObservationCount(int observations) {
+        sThisSessionObservationsCount = observations;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -43,11 +43,7 @@ public class MetricsView {
     private final TextView
             mLastUpdateTimeView,
             mAllTimeObservationsSentView,
-            mAllTimeCellsSentView,
-            mAllTimeWifisSentView,
             mQueuedObservationsView,
-            mQueuedCellsView,
-            mQueuedWifisView,
             mThisSessionObservationsView,
             mThisSessionUniqueCellsView,
             mThisSessionUniqueAPsView;
@@ -90,11 +86,7 @@ public class MetricsView {
 
         mLastUpdateTimeView = (TextView) mView.findViewById(R.id.last_upload_time_value);
         mAllTimeObservationsSentView = (TextView) mView.findViewById(R.id.observations_sent_value);
-        mAllTimeCellsSentView = (TextView) mView.findViewById(R.id.cells_sent_value);
-        mAllTimeWifisSentView = (TextView) mView.findViewById(R.id.wifis_sent_value);
         mQueuedObservationsView = (TextView) mView.findViewById(R.id.observations_queued_value);
-        mQueuedCellsView = (TextView) mView.findViewById(R.id.cells_queued_value);
-        mQueuedWifisView = (TextView) mView.findViewById(R.id.wifis_queued_value);
         mThisSessionObservationsView = (TextView) mView.findViewById(R.id.this_session_observations_value);
         mThisSessionUniqueCellsView = (TextView) mView.findViewById(R.id.cells_unique_value);
         mThisSessionUniqueAPsView = (TextView) mView.findViewById(R.id.wifis_unique_value);
@@ -254,9 +246,7 @@ public class MetricsView {
             Properties props = dataStorageManager.readSyncStats();
             String value;
             value = props.getProperty(DataStorageContract.Stats.KEY_CELLS_SENT, "0");
-            mAllTimeCellsSentView.setText(value);
             value = props.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0");
-            mAllTimeWifisSentView.setText(value);
             value = props.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0");
             String bytes = props.getProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "0");
             value = String.format(mObservationAndSize, Integer.parseInt(value), formatKb(Long.parseLong(bytes)));
@@ -271,9 +261,6 @@ public class MetricsView {
 
     private void updateQueuedStats(DataStorageManager dataStorageManager) {
         DataStorageManager.QueuedCounts q = dataStorageManager.getQueuedCounts();
-        mQueuedCellsView.setText(String.valueOf(q.mCellCount));
-        mQueuedWifisView.setText(String.valueOf(q.mWifiCount));
-
         String val = String.format(mObservationAndSize, q.mReportCount, formatKb(q.mBytes));
         mQueuedObservationsView.setText(val);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -48,7 +48,9 @@ public class MetricsView {
             mQueuedObservationsView,
             mQueuedCellsView,
             mQueuedWifisView,
-            mThisSessionObservationsView;
+            mThisSessionObservationsView,
+            mThisSessionUniqueCellsView,
+            mThisSessionUniqueAPsView;
 
     private final CheckBox mOnMapShowMLS;
 
@@ -94,6 +96,8 @@ public class MetricsView {
         mQueuedCellsView = (TextView) mView.findViewById(R.id.cells_queued_value);
         mQueuedWifisView = (TextView) mView.findViewById(R.id.wifis_queued_value);
         mThisSessionObservationsView = (TextView) mView.findViewById(R.id.this_session_observations_value);
+        mThisSessionUniqueCellsView = (TextView) mView.findViewById(R.id.cells_unique_value);
+        mThisSessionUniqueAPsView = (TextView) mView.findViewById(R.id.wifis_unique_value);
 
         mUploadButton = (ImageButton) mView.findViewById(R.id.upload_observations_button);
         mUploadButton.setEnabled(false);
@@ -193,6 +197,9 @@ public class MetricsView {
     }
 
     private void updateThisSessionStats() {
+        mThisSessionUniqueCellsView.setText(String.valueOf(sThisSessionUniqueCellCount));
+        mThisSessionUniqueAPsView.setText(String.valueOf(sThisSessionUniqueWifiCount));
+
         if (sThisSessionObservationsCount < 1) {
             mThisSessionObservationsView.setText("0");
             return;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -244,12 +244,9 @@ public class MetricsView {
 
         try {
             Properties props = dataStorageManager.readSyncStats();
-            String value;
-            value = props.getProperty(DataStorageContract.Stats.KEY_CELLS_SENT, "0");
-            value = props.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0");
-            value = props.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0");
+            String sent = props.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0");
             String bytes = props.getProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "0");
-            value = String.format(mObservationAndSize, Integer.parseInt(value), formatKb(Long.parseLong(bytes)));
+            String value = String.format(mObservationAndSize, Integer.parseInt(sent), formatKb(Long.parseLong(bytes)));
             mAllTimeObservationsSentView.setText(value);
 
             mLastUploadTime = Long.parseLong(props.getProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "0"));

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
@@ -33,4 +33,6 @@ public interface IReporter {
     public void shutdown();
 
     public void flush();
+
+    public int getObservationCount();
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
@@ -35,4 +35,8 @@ public interface IReporter {
     public void flush();
 
     public int getObservationCount();
+
+    public int getUniqueAPCount();
+
+    public int getUniqueCellCount();
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/IReporter.java
@@ -6,8 +6,6 @@ package org.mozilla.mozstumbler.service.stumblerthread;
 
 import android.content.Context;
 
-import org.json.JSONObject;
-
 /**
  * This is the public interface for the Reporter class.  
  * All methods here are properly synchronized as the reporter
@@ -35,6 +33,4 @@ public interface IReporter {
     public void shutdown();
 
     public void flush();
-
-    public JSONObject getPreviousBundleJSON();
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -46,6 +46,7 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     private int mPhoneType;
 
     private StumblerBundle mBundle;
+    private int mObservationCount = 0;
 
     public Reporter() {}
 
@@ -232,10 +233,16 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
             i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
             LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
+
+            mObservationCount++;
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }
 
         mBundle = null;
+    }
+
+    public int getObservationCount() {
+        return mObservationCount;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -46,13 +46,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     private int mPhoneType;
 
     private StumblerBundle mBundle;
-    private JSONObject mPreviousBundleJSON;
 
     public Reporter() {}
-
-    public synchronized JSONObject getPreviousBundleJSON() {
-        return mPreviousBundleJSON;
-    }
 
     public synchronized void startup(Context context) {
         if (mIsStarted) {
@@ -230,17 +225,15 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             return;
         }
 
-        mPreviousBundleJSON = mlsObj;
-
         AppGlobals.guiLogInfo("MLS record: " + mlsObj.toString());
-
-        Intent i = new Intent(ACTION_NEW_BUNDLE);
-        i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
-        i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
-        LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
         try {
             DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);
+
+            Intent i = new Intent(ACTION_NEW_BUNDLE);
+            i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
+            i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
+            LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -26,8 +26,10 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellI
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellScanner;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class Reporter extends BroadcastReceiver implements IReporter {
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Reporter.class.getSimpleName();
@@ -47,6 +49,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
     private StumblerBundle mBundle;
     private int mObservationCount = 0;
+    private final Set<String> mUniqueAPs = new HashSet<String>();
+    private final Set<String> mUniqueCells = new HashSet<String>();
 
     public Reporter() {}
 
@@ -237,6 +241,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
             mObservationCount++;
+            mUniqueAPs.addAll(mBundle.getWifiData().keySet());
+            mUniqueCells.addAll(mBundle.getCellData().keySet());
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }
@@ -246,5 +252,13 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
     public int getObservationCount() {
         return mObservationCount;
+    }
+
+    public int getUniqueAPCount() {
+        return mUniqueAPs.size();
+    }
+
+    public int getUniqueCellCount() {
+        return mUniqueCells.size();
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -248,15 +248,15 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         mBundle = null;
     }
 
-    public int getObservationCount() {
+    public synchronized int getObservationCount() {
         return mObservationCount;
     }
 
-    public int getUniqueAPCount() {
+    public synchronized int getUniqueAPCount() {
         return mUniqueAPs.size();
     }
 
-    public int getUniqueCellCount() {
+    public synchronized int getUniqueCellCount() {
         return mUniqueCells.size();
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -26,8 +26,10 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellI
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellScanner;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class Reporter extends BroadcastReceiver implements IReporter {
     private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Reporter.class.getSimpleName();
@@ -47,6 +49,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
     private StumblerBundle mBundle;
     private int mObservationCount = 0;
+    private final Set<String> mUniqueAPs = new HashSet<String>();
+    private final Set<String> mUniqueCells = new HashSet<String>();
 
     public Reporter() {}
 
@@ -235,6 +239,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
             mObservationCount++;
+            mUniqueAPs.addAll(mBundle.getWifiData().keySet());
+            mUniqueCells.addAll(mBundle.getCellData().keySet());
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }
@@ -244,5 +250,13 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
     public int getObservationCount() {
         return mObservationCount;
+    }
+
+    public int getUniqueAPCount() {
+        return mUniqueAPs.size();
+    }
+
+    public int getUniqueCellCount() {
+        return mUniqueCells.size();
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -250,15 +250,15 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         mBundle = null;
     }
 
-    public int getObservationCount() {
+    public synchronized int getObservationCount() {
         return mObservationCount;
     }
 
-    public int getUniqueAPCount() {
+    public synchronized int getUniqueAPCount() {
         return mUniqueAPs.size();
     }
 
-    public int getUniqueCellCount() {
+    public synchronized int getUniqueCellCount() {
         return mUniqueCells.size();
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -46,6 +46,7 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     private int mPhoneType;
 
     private StumblerBundle mBundle;
+    private int mObservationCount = 0;
 
     public Reporter() {}
 
@@ -234,10 +235,16 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
             i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
             LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
+
+            mObservationCount++;
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }
 
         mBundle = null;
+    }
+
+    public int getObservationCount() {
+        return mObservationCount;
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -46,13 +46,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     private int mPhoneType;
 
     private StumblerBundle mBundle;
-    private JSONObject mPreviousBundleJSON;
 
     public Reporter() {}
-
-    public synchronized JSONObject getPreviousBundleJSON() {
-        return mPreviousBundleJSON;
-    }
 
     public synchronized void startup(Context context) {
         if (mIsStarted) {
@@ -228,17 +223,15 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             return;
         }
 
-        mPreviousBundleJSON = mlsObj;
-
         AppGlobals.guiLogInfo("MLS record: " + mlsObj.toString());
-
-        Intent i = new Intent(ACTION_NEW_BUNDLE);
-        i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
-        i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
-        LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
         try {
             DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);
+
+            Intent i = new Intent(ACTION_NEW_BUNDLE);
+            i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
+            i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
+            LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
         } catch (IOException e) {
             Log.w(LOG_TAG, e.toString());
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -9,7 +9,6 @@ import android.location.Location;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import org.json.JSONObject;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.WifiBlockListInterface;
@@ -85,7 +84,7 @@ public class StumblerService extends PersistentIntentService
         return mScanManager.getWifiStatus();
     }
 
-    public synchronized int getAPCount() {
+    public synchronized int getUniqueAPCount() {
         return mScanManager.getAPCount();
     }
 
@@ -93,8 +92,8 @@ public class StumblerService extends PersistentIntentService
         return mScanManager.getVisibleAPCount();
     }
 
-    public synchronized int getCellInfoCount() {
-        return mScanManager.getCellInfoCount();
+    public synchronized int getVisibleCellInfoCount() {
+        return mScanManager.getVisibleCellInfoCount();
     }
 
     // Previously this was done in onCreate(). Moved out of that so that in the passive standalone service
@@ -217,9 +216,4 @@ public class StumblerService extends PersistentIntentService
             UploadAlarmReceiver.scheduleAlarm(this, FREQUENCY_IN_SEC_OF_UPLOAD_IN_ACTIVE_MODE, true /* repeating */);
         }
     }
-
-    public JSONObject getLastReportedBundle() {
-        return mReporter.getPreviousBundleJSON();
-    }
-
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -89,7 +89,7 @@ public class StumblerService extends PersistentIntentService
     }
 
     public synchronized int getUniqueAPCount() {
-        return mScanManager.getAPCount();
+        return mReporter.getUniqueAPCount();
     }
 
     public synchronized int getVisibleAPCount() {
@@ -98,6 +98,10 @@ public class StumblerService extends PersistentIntentService
 
     public synchronized int getVisibleCellInfoCount() {
         return mScanManager.getVisibleCellInfoCount();
+    }
+
+    public synchronized int getUniqueCellCount() {
+        return mReporter.getUniqueCellCount();
     }
 
     // Previously this was done in onCreate(). Moved out of that so that in the passive standalone service

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -80,6 +80,10 @@ public class StumblerService extends PersistentIntentService
         return mScanManager.getLocation();
     }
 
+    public synchronized int getObservationCount() {
+        return mReporter.getObservationCount();
+    }
+
     public synchronized int getWifiStatus() {
         return mScanManager.getWifiStatus();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -162,10 +162,6 @@ public class ScanManager {
         return mIsScanning;
     }
 
-    public int getAPCount() {
-        return (mWifiScanner == null) ? 0 : mWifiScanner.getAPCount();
-    }
-
     public int getVisibleAPCount() {
         return (mWifiScanner == null) ? 0 : mWifiScanner.getVisibleAPCount();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -160,8 +160,8 @@ public class ScanManager {
         return (mWifiScanner == null) ? 0 : mWifiScanner.getStatus();
     }
 
-    public int getCellInfoCount() {
-        return (mCellScanner == null) ? 0 : mCellScanner.getCellInfoCount();
+    public int getVisibleCellInfoCount() {
+        return (mCellScanner == null) ? 0 : mCellScanner.getVisibleCellInfoCount();
     }
 
     public int getLocationCount() {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -148,10 +148,6 @@ public class ScanManager {
         return mIsScanning;
     }
 
-    public int getAPCount() {
-        return (mWifiScanner == null) ? 0 : mWifiScanner.getAPCount();
-    }
-
     public int getVisibleAPCount() {
         return (mWifiScanner == null) ? 0 : mWifiScanner.getVisibleAPCount();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -174,8 +174,8 @@ public class ScanManager {
         return (mWifiScanner == null) ? 0 : mWifiScanner.getStatus();
     }
 
-    public int getCellInfoCount() {
-        return (mCellScanner == null) ? 0 : mCellScanner.getCellInfoCount();
+    public int getVisibleCellInfoCount() {
+        return (mCellScanner == null) ? 0 : mCellScanner.getVisibleCellInfoCount();
     }
 
     public int getLocationCount() {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -22,10 +22,7 @@ import org.mozilla.mozstumbler.service.stumblerthread.blocklist.SSIDBlockList;
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.WifiBlockListInterface;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,7 +44,6 @@ public class WifiScanner extends BroadcastReceiver {
     private final Context mContext;
     private WifiLock mWifiLock;
     private Timer mWifiScanTimer;
-    private final Set<String> mAPs = Collections.synchronizedSet(new HashSet<String>());
     private AtomicInteger mVisibleAPs = new AtomicInteger();
 
     public WifiScanner(Context c) {
@@ -115,7 +111,6 @@ public class WifiScanner extends BroadcastReceiver {
                 scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
                 if (shouldLog(scanResult)) {
                     scanResults.add(scanResult);
-                    mAPs.add(scanResult.BSSID);
                 }
             }
             mVisibleAPs.set(scanResults.size());
@@ -126,10 +121,6 @@ public class WifiScanner extends BroadcastReceiver {
     public static void setWifiBlockList(WifiBlockListInterface blockList) {
         BSSIDBlockList.setFilterList(blockList.getBssidOuiList());
         SSIDBlockList.setFilterLists(blockList.getSsidPrefixList(), blockList.getSsidSuffixList());
-    }
-
-    public int getAPCount() {
-        return mAPs.size();
     }
 
     public int getVisibleAPCount() {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -12,10 +12,10 @@ import android.os.Handler;
 import android.os.Message;
 import android.support.v4.content.LocalBroadcastManager;
 import android.telephony.TelephonyManager;
-import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
+import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -24,8 +24,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
-import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 
 public class CellScanner {
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".CellScanner.";
@@ -38,7 +36,7 @@ public class CellScanner {
 
     private final Context mContext;
     private Timer mCellScanTimer;
-    private final Set<String> mCells = new HashSet<String>();
+    private final Set<String> mVisibleCells = new HashSet<String>();
     private final ReportFlushedReceiver mReportFlushedReceiver = new ReportFlushedReceiver();
     private final AtomicBoolean mReportWasFlushed = new AtomicBoolean();
     private Handler mBroadcastScannedHandler;
@@ -132,11 +130,11 @@ public class CellScanner {
     }
 
     private synchronized void clearCells() {
-        mCells.clear();
+        mVisibleCells.clear();
     }
 
     private synchronized void addToCells(String cell) {
-        mCells.add(cell);
+        mVisibleCells.add(cell);
     }
 
     public synchronized void stop() {
@@ -151,8 +149,8 @@ public class CellScanner {
         mCellScannerImplementation.stop();
     }
 
-    public synchronized int getCellInfoCount() {
-        return mCells.size();
+    public synchronized int getVisibleCellInfoCount() {
+        return mVisibleCells.size();
     }
 
     private class ReportFlushedReceiver extends BroadcastReceiver {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -11,10 +11,10 @@ import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Message;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
+import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -23,8 +23,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
-import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 
 public class CellScanner {
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".CellScanner.";
@@ -37,7 +35,7 @@ public class CellScanner {
 
     private final Context mContext;
     private Timer mCellScanTimer;
-    private final Set<String> mCells = new HashSet<String>();
+    private final Set<String> mVisibleCells = new HashSet<String>();
     private final ReportFlushedReceiver mReportFlushedReceiver = new ReportFlushedReceiver();
     private final AtomicBoolean mReportWasFlushed = new AtomicBoolean();
     private Handler mBroadcastScannedHandler;
@@ -124,11 +122,11 @@ public class CellScanner {
     }
 
     private synchronized void clearCells() {
-        mCells.clear();
+        mVisibleCells.clear();
     }
 
     private synchronized void addToCells(String cell) {
-        mCells.add(cell);
+        mVisibleCells.add(cell);
     }
 
     public synchronized void stop() {
@@ -143,8 +141,8 @@ public class CellScanner {
         mCellScannerImplementation.stop();
     }
 
-    public synchronized int getCellInfoCount() {
-        return mCells.size();
+    public synchronized int getVisibleCellInfoCount() {
+        return mVisibleCells.size();
     }
 
     private class ReportFlushedReceiver extends BroadcastReceiver {

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -109,6 +109,14 @@
                         tools:text="50" />
                 </TableRow>
 
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="5dp"
+                    android:background="@android:color/darker_gray">
+
+                    <View android:layout_height="1dp" />
+                </TableRow>
+
                 <TableRow>
 
                     <TextView
@@ -163,52 +171,6 @@
                 <TableRow>
 
                     <TextView
-                        android:id="@+id/cells_sent_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_cell_towers_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/cells_sent_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/wifis_sent_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_wifis_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/wifis_sent_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="500" />
-                </TableRow>
-
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="5dp"
-                    android:background="@android:color/darker_gray">
-
-                    <View android:layout_height="1dp" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
                         android:id="@+id/queued_header"
                         android:layout_gravity="start"
                         android:layout_span="2"
@@ -234,42 +196,6 @@
                         android:id="@+id/observations_queued_value"
                         android:layout_gravity="start"
                         android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/cells_queued_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_cell_towers_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/cells_queued_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="10" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/wifis_queued_title"
-                        android:layout_gravity="start"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_wifis_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/wifis_queued_value"
-                        android:layout_gravity="start"
                         android:textSize="@dimen/font_size_for_metrics"
                         tools:text="50" />
                 </TableRow>

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -96,6 +96,7 @@
                     <TextView
                         android:id="@+id/wifis_unqiue_title"
                         android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
                         android:paddingEnd="3dp"
                         android:paddingRight="3dp"
                         android:text="@string/metrics_observations_wifis_title"
@@ -104,8 +105,9 @@
                     <TextView
                         android:id="@+id/wifis_unique_value"
                         android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
                         android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
+                        tools:text="100" />
                 </TableRow>
 
                 <TableRow

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -76,6 +76,42 @@
                 <TableRow>
 
                     <TextView
+                        android:id="@+id/cells_unique_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_cell_towers_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/cells_unique_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="10" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/wifis_unqiue_title"
+                        android:layout_gravity="start"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_wifis_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/wifis_unique_value"
+                        android:layout_gravity="start"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
                         android:id="@+id/sent_header"
                         android:layout_gravity="start"
                         android:layout_span="2"

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -97,6 +97,7 @@
                     <TextView
                         android:id="@+id/wifis_unqiue_title"
                         android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
                         android:paddingEnd="3dp"
                         android:paddingRight="3dp"
                         android:text="@string/metrics_observations_wifis_title"
@@ -105,8 +106,9 @@
                     <TextView
                         android:id="@+id/wifis_unique_value"
                         android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
                         android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
+                        tools:text="100" />
                 </TableRow>
 
                 <TableRow

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -108,6 +108,14 @@
                         tools:text="50" />
                 </TableRow>
 
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="5dp"
+                    android:background="@android:color/darker_gray">
+
+                    <View android:layout_height="1dp" />
+                </TableRow>
+
                 <TableRow>
 
                     <TextView
@@ -162,52 +170,6 @@
                 <TableRow>
 
                     <TextView
-                        android:id="@+id/cells_sent_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_cell_towers_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/cells_sent_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/wifis_sent_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_wifis_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/wifis_sent_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="500" />
-                </TableRow>
-
-                <TableRow
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="5dp"
-                    android:background="@android:color/darker_gray">
-
-                    <View android:layout_height="1dp" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
                         android:id="@+id/queued_header"
                         android:layout_gravity="start"
                         android:layout_span="2"
@@ -233,42 +195,6 @@
                         android:id="@+id/observations_queued_value"
                         android:layout_gravity="start"
                         android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="50" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/cells_queued_title"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_cell_towers_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/cells_queued_value"
-                        android:layout_gravity="start"
-                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
-                        android:textSize="@dimen/font_size_for_metrics"
-                        tools:text="10" />
-                </TableRow>
-
-                <TableRow>
-
-                    <TextView
-                        android:id="@+id/wifis_queued_title"
-                        android:layout_gravity="start"
-                        android:paddingEnd="3dp"
-                        android:paddingRight="3dp"
-                        android:text="@string/metrics_observations_wifis_title"
-                        android:textSize="@dimen/font_size_for_metrics" />
-
-                    <TextView
-                        android:id="@+id/wifis_queued_value"
-                        android:layout_gravity="start"
                         android:textSize="@dimen/font_size_for_metrics"
                         tools:text="50" />
                 </TableRow>

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -75,6 +75,42 @@
                 <TableRow>
 
                     <TextView
+                        android:id="@+id/cells_unique_title"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_cell_towers_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/cells_unique_value"
+                        android:layout_gravity="start"
+                        android:paddingBottom="@dimen/padding_below_for_metrics_titles"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="10" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                        android:id="@+id/wifis_unqiue_title"
+                        android:layout_gravity="start"
+                        android:paddingEnd="3dp"
+                        android:paddingRight="3dp"
+                        android:text="@string/metrics_observations_wifis_title"
+                        android:textSize="@dimen/font_size_for_metrics" />
+
+                    <TextView
+                        android:id="@+id/wifis_unique_value"
+                        android:layout_gravity="start"
+                        android:textSize="@dimen/font_size_for_metrics"
+                        tools:text="50" />
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
                         android:id="@+id/sent_header"
                         android:layout_gravity="start"
                         android:layout_span="2"

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -38,7 +38,7 @@
     </plurals>
     <plurals name="time_diff_hours">
         <item quantity="one">hace una hora</item>
-        <item quantity="other">hace %d houras</item>
+        <item quantity="other">hace %d horas</item>
     </plurals>
     <plurals name="time_diff_days">
         <item quantity="one">hace un día</item>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -26,6 +26,24 @@
     <string name="about_legal_flaticons">Los iconos de GPS, torre celular, Wi-Fi, y binoculares están hechos por Freepik de http://flaticon.com bajo la licencia: https://creativecommons.org/licenses/by-nd/3.0</string>
     <string name="upload_observations_sent_title">Sesiones anteriores</string>
     <string name="metrics_observations_last_upload_time_title">Última fecha de envío:</string>
+    <string name="metrics_observations_last_upload_time_never">nunca</string>
+    <!-- http://developer.android.com/guide/topics/resources/string-resource.html#Plurals -->
+    <plurals name="time_diff_seconds">
+        <item quantity="one">justo ahora</item>
+        <item quantity="other">hace un momento</item>
+    </plurals>
+    <plurals name="time_diff_minutes">
+        <item quantity="one">hace un minuto</item>
+        <item quantity="other">hace %d minutos</item>
+    </plurals>
+    <plurals name="time_diff_hours">
+        <item quantity="one">hace una hora</item>
+        <item quantity="other">hace %d houras</item>
+    </plurals>
+    <plurals name="time_diff_days">
+        <item quantity="one">hace un día</item>
+        <item quantity="other">hace %d días</item>
+    </plurals>
     <string name="metrics_observations_title">Reportes:</string>
     <string name="metrics_observations_wifis_title">Redes Wi-Fi:</string>
     <string name="metrics_observations_cell_towers_title">Redes celulares:</string>
@@ -44,7 +62,8 @@
     <string name="kml_file_save">Guardar archivo KML</string>
     <string name="kml_file_description">Guardar/Cargar los reportes (ubicaciones, datos wi-fi+celulares) para debugear.</string>
     <string name="kml_file_saved_name">Archivo guardado:</string>
-    <string name="keep_screen_on_title">Mantener la pantalla encendida mientras se esta en el mapa</string>
+    <string name="keep_screen_on_title">Mantener la pantalla encendida mientras escaneas</string>
+    <string name="keep_screen_on_summary">Mantendrá la pantalla encendia mientras escaneas y la aplicación está en primer plano.</string>
     <string name="delete_all">Borrar todos</string>
     <string name="are_you_sure">¿Estás seguro?</string>
     <string name="loading_kml">Cargando el KML</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="about_mapbox">Learn more at http://www.mapbox.com</string>
     <string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string>
     <string name="about_legal_flaticons">GPS, cell tower, Wi-Fi, and binoculars icons made by Freepik from http://www.flaticon.com under license: https://creativecommons.org/licenses/by-nd/3.0</string>
-    <string name="upload_observations_sent_title">Already sent</string>
+    <string name="upload_observations_sent_title">Previous Sessions</string>
     <string name="metrics_observations_last_upload_time_title">Last upload:</string>
     <string name="metrics_observations_last_upload_time_never">never</string>
     <!-- http://developer.android.com/guide/topics/resources/string-resource.html#Plurals -->

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="about_mapbox">Learn more at http://www.mapbox.com</string>
     <string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string>
     <string name="about_legal_flaticons">GPS, cell tower, Wi-Fi, and binoculars icons made by Freepik from http://www.flaticon.com under license: https://creativecommons.org/licenses/by-nd/3.0</string>
-    <string name="upload_observations_sent_title">Previous sessions</string>
+    <string name="upload_observations_sent_title">Already sent</string>
     <string name="metrics_observations_last_upload_time_title">Last upload:</string>
     <string name="metrics_observations_last_upload_time_never">never</string>
     <!-- http://developer.android.com/guide/topics/resources/string-resource.html#Plurals -->

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="about_mapbox">Learn more at http://www.mapbox.com</string>
     <string name="about_legal_aosp">Some iconography in this app is reproduced from work created and shared by the Android Open Source Project and used according to terms described in the Creative Commons 2.5 Attribution License.</string>
     <string name="about_legal_flaticons">GPS, cell tower, Wi-Fi, and binoculars icons made by Freepik from http://www.flaticon.com under license: https://creativecommons.org/licenses/by-nd/3.0</string>
-    <string name="upload_observations_sent_title">Previous Sessions</string>
+    <string name="upload_observations_sent_title">Previous sessions</string>
     <string name="metrics_observations_last_upload_time_title">Last upload:</string>
     <string name="metrics_observations_last_upload_time_never">never</string>
     <!-- http://developer.android.com/guide/topics/resources/string-resource.html#Plurals -->


### PR DESCRIPTION
This PR is a bit larger, I am looking forward to get your feedback.
I read a German article about the Mozilla Stumbler release, and the author wrote that he had stumbled over 900 wifis in a really small area, so I remembered #1019.

It's best to check each commit separately:
- first commit does some cleanup and renames some variables, no functional change.
- second commit makes the `Reporter` count the observations, instead of the `MainApp`
- third commit counts the unique networks in the `Reporter`, I guess it fixes #132
- fourth commits displays the unique network stats in the metrics (see first screenshot)
- last commit removes the other network counts (see final screenshot)

This was one of my tests to see that the code works. I did five scans on the same position (6 cells, 7 wifis visible), only two of the scans had wifi enabled:
![screenshot_2014-11-07-00-15-45](https://cloud.githubusercontent.com/assets/3845150/4946052/1b78a6d8-660f-11e4-8dd3-e8d9bdbab090.png)

This is the final version:
![screenshot_2014-11-07-00-25-24](https://cloud.githubusercontent.com/assets/3845150/4946069/4f5858ae-660f-11e4-8d27-7e380c78b8fb.png)
