### PR TITLE
Upload/Settings row on drawer: needs visual separation #1212

### DIFF
--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -6,6 +6,7 @@
     android:orientation="vertical">
 
     <ScrollView
+        android:background="#FF1F201F"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="10">
@@ -324,10 +325,15 @@
 
     </ScrollView>
 
+    <View
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:background="#FF515351"/>
     <RelativeLayout
         android:id="@+id/metrics_buttons_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="#FF151415"
         android:layout_weight="1"
         android:gravity="bottom"
         android:padding="5dp">


### PR DESCRIPTION
# Overview

Added two different background colors for the scrollbar that contains the metrics and the bottom layout of the drawer that contains the upload and settings button.

Also, between the bottom container and the metrics was added a view of 1dp height and light gray background to make the separation even more notorious.

This change was made to close the #1212 issue based on #893 UI suggestion.
# Screenshots

![screenshot_2014-11-06-23-23-44](https://cloud.githubusercontent.com/assets/4610807/4947587/71623156-6626-11e4-9acf-e20707eb3637.png)
![screenshot_2014-11-06-23-23-34](https://cloud.githubusercontent.com/assets/4610807/4947588/7164a0ee-6626-11e4-8363-7764eb32bab4.png)
