### PR TITLE
Always clear cells after flush

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -99,12 +99,12 @@ public class CellScanner {
                 ArrayList<CellInfo> cells = (sTestingModeCellInfoArray != null)? sTestingModeCellInfoArray :
                         new ArrayList<CellInfo>(mCellScannerImplementation.getCellInfo());
 
-                if (cells.isEmpty()) {
-                    return;
-                }
-
                 if (mReportWasFlushed.getAndSet(false)) {
                     clearCells();
+                }
+
+                if (cells.isEmpty()) {
+                    return;
                 }
 
                 for (CellInfo cell : cells) {


### PR DESCRIPTION
If there are no cells in the current scan and there was a bundle flush, clear cells before returning early.
Otherwise number of cells will never be zero.
