### PR TITLE
Listen for GPSScanner.SUBJECT_LOCATION_LOST

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -113,6 +113,8 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
                 flush();
                 mBundle = new StumblerBundle(newPosition, mPhoneType);
             }
+        } else if (subject.equals(GPSScanner.SUBJECT_LOCATION_LOST)) {
+            flush();
         }
     }
 


### PR DESCRIPTION
There is no listener for `GPSScanner.SUBJECT_LOCATION_LOST`. Is this ok?
