### PR TITLE
Build System: parallel install of different app versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,6 +97,10 @@ android {
 
     buildTypes {
         debug {
+            // We add this suffix to the pakage name to be able to have production and dev version
+            // at same time
+            applicationIdSuffix '.debug'
+
             jniDebugBuild true
 
             // set this to false if you want your debug builds to have


### PR DESCRIPTION
# Overview

By adding ".debug" as applicationIdSuffix to the build type debug, what we do is to change the app package name for the debug build so we can have installed the debug and production version at same time.

This is a quick fix until the beta program is defined.
