### PR TITLE
Hide map zoom buttons when opening metrics sidebar

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -498,6 +498,10 @@ public final class MapFragment extends android.support.v4.app.Fragment
         setHighBandwidthMap(hasWifi);
     }
 
+    public void setZoomButtonsVisible(boolean visible) {
+        mMap.setZoomButtonsVisible(visible);
+    }
+
     @SuppressLint("NewApi")
     public void dimToolbar() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -78,6 +78,11 @@ public class MainDrawerActivity
         ) {
 
             @Override
+            public void onDrawerSlide(View drawerView, float slideOffset) {
+                mMapFragment.setZoomButtonsVisible(false);
+            }
+
+            @Override
             public void onDrawerClosed(View view) {}
 
             @Override

--- a/android/src/main/java/org/mozilla/osmdroid/views/MapView.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/MapView.java
@@ -1094,6 +1094,10 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
         this.mZoomController.setZoomOutEnabled(canZoomOut());
     }
 
+    public void setZoomButtonsVisible(final boolean visible) {
+        this.mZoomController.setVisible(visible);
+    }
+
     public void setBuiltInZoomControls(final boolean on) {
         this.mEnableZoomController = on;
         this.checkZoomButtons();


### PR DESCRIPTION
This fixes #976. The zoom buttons will fade out as soon the sidebar slides in.
There might be another better approach, because the zoom buttons still appear, but at least it's an improvement.
