### PR TITLE
Sync Fennec code with stumbler github

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -4,12 +4,13 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import org.mozilla.mozstumbler.BuildConfig;
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.osmdroid.api.IGeoPoint;
 import org.mozilla.osmdroid.util.GeoPoint;
 
 public class ClientPrefs extends Prefs {
-    private static final String LOG_TAG = ClientPrefs.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ClientPrefs.class.getSimpleName());
     private static final String LAT_PREF = "lat";
     private static final String LON_PREF = "lon";
     private static final String IS_FIRST_RUN = "is_first_run";

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -19,7 +19,7 @@ import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageMa
 //    as possible on the Android process kill list.
 // -- Binding functions are commented in this class as being unused in the stand-alone service mode.
 public class ClientStumblerService extends StumblerService {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + StumblerService.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(StumblerService.class.getSimpleName());
     private final IBinder mBinder = new StumblerBinder();
 
     // Service binding is not used in stand-alone passive mode.

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class MainApp extends Application
         implements AsyncUploader.AsyncUploaderListener {
     public static final AtomicBoolean isUploading = new AtomicBoolean();
-    private final String LOG_TAG = AppGlobals.LOG_PREFIX + MainApp.class.getSimpleName();
+    private final String LOG_TAG = AppGlobals.makeLogTag(MainApp.class.getSimpleName());
     private ClientStumblerService mStumblerService;
     private ServiceConnection mConnection;
     private ServiceBroadcastReceiver mReceiver;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -18,6 +18,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.mozstumbler.client.mapview.ObservationPoint;
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
@@ -29,7 +30,7 @@ import java.util.LinkedList;
 
 public class ObservedLocationsReceiver extends BroadcastReceiver {
 
-    private static final String LOG_TAG = ObservedLocationsReceiver.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ObservedLocationsReceiver.class.getSimpleName());
     private WeakReference<MapFragment> mMapActivity = new WeakReference<MapFragment>(null);
     private final LinkedList<ObservationPoint> mCollectionPoints = new LinkedList<ObservationPoint>();
     private final LinkedList<ObservationPoint> mQueuedForMLS = new LinkedList<ObservationPoint>();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/TurnOffReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/TurnOffReceiver.java
@@ -17,7 +17,7 @@ import org.mozilla.mozstumbler.service.core.logging.Log;
  * stumbler, and [X] Stop Scanning will appear.
  */
 public final class TurnOffReceiver extends BroadcastReceiver {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + TurnOffReceiver.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(TurnOffReceiver.class.getSimpleName());
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Updater {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Updater.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(Updater.class.getSimpleName());
     private static final String LATEST_URL = "https://github.com/mozilla/MozStumbler/releases/latest";
     private static final String APK_URL_FORMAT = "https://github.com/mozilla/MozStumbler/releases/download/v%s/MozStumbler-v%s.apk";
     private final IHttpUtil httpClient;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/cellscanner/ScreenMonitor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/cellscanner/ScreenMonitor.java
@@ -20,7 +20,7 @@ import org.mozilla.mozstumbler.service.AppGlobals;
  * https://code.google.com/p/android/issues/detail?id=10931
  */
 public class ScreenMonitor {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + "ScreenOffWorkaround";
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ScreenMonitor.class.getName());
 
     private static final String PREFS_FILE = ScreenMonitor.class.getSimpleName();
     private static final String LOCATION_UPDATES_COUNT_PREF = "location_updates_count";

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 This class provides MLS locations by calling HTTP methods against the MLS.
  */
 public class MLSLocationGetter extends AsyncTask<String, Void, Location> {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MLSLocationGetter.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MLSLocationGetter.class.getSimpleName());
     private static final String RESPONSE_OK_TEXT = "ok";
     private ILocationService mls;
     private MLSLocationGetterCallback mCallback;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -66,7 +66,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
 
     public enum NoMapAvailableMessage { eHideNoMapMessage, eNoMapDueToNoAccessibleStorage, eNoMapDueToNoInternet }
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MapFragment.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MapFragment.class.getSimpleName());
 
     private static final String COVERAGE_REDIRECT_URL = "https://location.services.mozilla.com/map.json";
     private static int sGPSColor;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -14,6 +14,7 @@ import android.graphics.RectF;
 import android.os.SystemClock;
 
 import org.mozilla.mozstumbler.client.ObservedLocationsReceiver;
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.osmdroid.util.GeoPoint;
 import org.mozilla.osmdroid.views.MapView;
 import org.mozilla.osmdroid.views.Projection;
@@ -28,7 +29,7 @@ import java.util.LinkedList;
 import java.util.ListIterator;
 
 class ObservationPointsOverlay extends Overlay {
-    private static final String LOG_TAG = ObservationPointsOverlay.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ObservationPointsOverlay.class.getSimpleName());
     private final Paint mRedPaint = new Paint();
     private final Paint mGreenPaint = new Paint();
     private final Paint mCellPaint = new Paint();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -38,7 +38,7 @@ public class MetricsView {
         public void setShowMLS(boolean isOn);
     }
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MetricsView.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MetricsView.class.getSimpleName());
 
     private final TextView
             mLastUpdateTimeView,

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/KMLFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/KMLFragment.java
@@ -39,7 +39,7 @@ import java.util.LinkedList;
 public class KMLFragment extends Fragment
     implements ObservationPointSerializer.IListener {
 
-    private final String LOG_TAG = AppGlobals.LOG_PREFIX + KMLFragment.class.getSimpleName();
+    private final String LOG_TAG = AppGlobals.makeLogTag(KMLFragment.class.getSimpleName());
 
     private LinkedList<ObservationPoint> mPointsToWrite;
     private WeakReference<ProgressDialog> mProgressDialog;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
@@ -26,6 +26,7 @@ import com.ekito.simpleKML.model.TimeStamp;
 
 import org.joda.time.DateTime;
 import org.mozilla.mozstumbler.client.mapview.ObservationPoint;
+import org.mozilla.mozstumbler.service.AppGlobals;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -46,7 +47,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
         public void onError();
     }
 
-    private static final String LOG_TAG = ObservationPointSerializer.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ObservationPointSerializer.class.getSimpleName());
     private static final String GPS_NAME = "GPS";
     private static final String MLS_NAME = "MLS";
     private static final String ICON_RED_CIRCLE = "http://maps.google.com/mapfiles/kml/shapes/placemark_circle_highlight.png";

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
@@ -29,7 +29,7 @@ import org.mozilla.mozstumbler.service.core.logging.MockAcraLog;
 
 public class DeveloperActivity extends ActionBarActivity {
 
-    private final String LOG_TAG = AppGlobals.LOG_PREFIX + DeveloperActivity.class.getSimpleName();
+    private final String LOG_TAG = AppGlobals.makeLogTag(DeveloperActivity.class.getSimpleName());
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,7 +71,7 @@ public class DeveloperActivity extends ActionBarActivity {
 
     // For misc developer options
     public static class DeveloperOptions extends Fragment {
-        private final String LOG_TAG = AppGlobals.LOG_PREFIX + DeveloperOptions.class.getSimpleName();
+        private final String LOG_TAG = AppGlobals.makeLogTag(DeveloperOptions.class.getSimpleName());
 
         private View mRootView;
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -9,7 +9,7 @@ import java.util.Date;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class AppGlobals {
-    public static final String LOG_PREFIX = "Stumbler:";
+    public static final String LOG_PREFIX = "Stumbler_";
 
     /* All intent actions start with this string. Only locally broadcasted. */
     public static final String ACTION_NAMESPACE = "org.mozilla.mozstumbler.intent.action";
@@ -64,5 +64,16 @@ public class AppGlobals {
             guiLogMessageBuffer.add(noTruncateFlag + ts + "<font color='" + color +"'>" + msg + "</font>");
         }
     }
+
+    public static String makeLogTag(String name) {
+        final int maxLen = 23 - LOG_PREFIX.length();
+        if (name.length() > maxLen) {
+                name = name.substring(name.length() - maxLen, name.length());
+            }
+        return LOG_PREFIX + name;
+    }
+
+    public static final String ACTION_TEST_SETTING_ENABLED = "stumbler-test-setting-enabled";
+    public static final String ACTION_TEST_SETTING_DISABLED = "stumbler-test-setting-disabled";
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
@@ -13,7 +13,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 public class Prefs {
-    private static final String LOG_TAG = Prefs.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(Prefs.class.getSimpleName());
     private static final String NICKNAME_PREF = "nickname";
     private static final String EMAIL_PREF = "email";
     private static final String USER_AGENT_PREF = "user-agent";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class HTTPResponse implements IResponse {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + HTTPResponse.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(HTTPResponse.class.getSimpleName());
 
     private final int statusCode;
     private final byte[] bodyBytes;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 public class HttpUtil implements IHttpUtil {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + HttpUtil.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(HttpUtil.class.getSimpleName());
     private static final String USER_AGENT_HEADER = "User-Agent";
     private final String userAgent;
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/MLS.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/MLS.java
@@ -14,7 +14,7 @@ public class MLS implements ILocationService {
     private static final String SEARCH_URL = "https://location.services.mozilla.com/v1/search";
     private static final String SUBMIT_URL = "https://location.services.mozilla.com/v1/submit";
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MLS.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MLS.class.getSimpleName());
 
     public static final String NICKNAME_HEADER = "X-Nickname";
     public static final String EMAIL_HEADER = "X-Email";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 public final class Reporter extends BroadcastReceiver implements IReporter {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Reporter.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(Reporter.class.getSimpleName());
     public static final String ACTION_FLUSH_TO_BUNDLE = AppGlobals.ACTION_NAMESPACE + ".FLUSH";
     public static final String ACTION_NEW_BUNDLE = AppGlobals.ACTION_NAMESPACE + ".NEW_BUNDLE";
     public static final String NEW_BUNDLE_ARG_BUNDLE = "bundle";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -126,6 +126,8 @@ public class StumblerService extends PersistentIntentService
     public void onDestroy() {
         super.onDestroy();
 
+        UploadAlarmReceiver.cancelAlarm(this, !mScanManager.isPassiveMode());
+
         if (!isScanning()) {
             return;
         }
@@ -180,7 +182,11 @@ public class StumblerService extends PersistentIntentService
             return;
         }
 
-        if (!DataStorageManager.getInstance().isDirEmpty()) {
+        boolean hasFilesWaiting = !DataStorageManager.getInstance().isDirEmpty();
+        if (AppGlobals.isDebug) {
+            Log.d(LOG_TAG, "Files waiting:" + hasFilesWaiting);
+        }
+        if (hasFilesWaiting) {
             // non-empty on startup, schedule an upload
             // This is the only upload trigger in Firefox mode
             // Firefox triggers this ~4 seconds after startup (after Gecko is loaded), add a small delay to avoid

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 //
 public class StumblerService extends PersistentIntentService
         implements DataStorageManager.StorageIsEmptyTracker {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + StumblerService.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(StumblerService.class.getSimpleName());
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE;
     public static final String ACTION_START_PASSIVE = ACTION_BASE + ".START_PASSIVE";
     public static final String ACTION_EXTRA_MOZ_API_KEY = ACTION_BASE + ".MOZKEY";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/blocklist/BSSIDBlockList.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/blocklist/BSSIDBlockList.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 public final class BSSIDBlockList {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + BSSIDBlockList.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(BSSIDBlockList.class.getSimpleName());
     private static final String NULL_BSSID = "000000000000";
     private static final String WILDCARD_BSSID = "ffffffffffff";
     private static final Pattern BSSID_PATTERN = Pattern.compile("([0-9a-f]{12})");

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -40,7 +40,7 @@ import java.util.TimerTask;
  * when the service is destroyed.
  */
 public class DataStorageManager {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + DataStorageManager.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(DataStorageManager.class.getSimpleName());
 
     // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
     // After this size is reached, data is persisted to disk, mCurrentReports is cleared.

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -31,7 +31,7 @@ public class GPSScanner implements LocationListener {
     public static final String NEW_LOCATION_ARG_LOCATION = "location";
     public static final int MIN_SAT_USED_IN_FIX = 3;
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + GPSScanner.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(GPSScanner.class.getSimpleName());
     private static final long ACTIVE_MODE_GPS_MIN_UPDATE_TIME_MS = 2000;
     private static final float ACTIVE_MODE_GPS_MIN_UPDATE_DISTANCE_M = 30;
     private static final long PASSIVE_GPS_MIN_UPDATE_FREQ_MS = 3000;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -24,7 +24,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 public class ScanManager {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + ScanManager.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ScanManager.class.getSimpleName());
     private Timer mPassiveModeFlushTimer;
     private Context mContext;
     private boolean mIsScanning;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/StumblerFilter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/StumblerFilter.java
@@ -16,7 +16,7 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 
  */
 public final class StumblerFilter {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + StumblerFilter.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(StumblerFilter.class.getSimpleName());
     private static final double MAX_ALTITUDE = 8848;      // Mount Everest's altitude in meters
     private static final double MIN_ALTITUDE = -418;      // Dead Sea's altitude in meters
     private static final float MAX_SPEED = 340.29f;   // Mach 1 in meters/second

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -37,7 +37,7 @@ public class WifiScanner extends BroadcastReceiver {
     public static final int STATUS_ACTIVE = 1;
     public static final int STATUS_WIFI_DISABLED = -1;
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + WifiScanner.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(WifiScanner.class.getSimpleName());
     private static final long WIFI_MIN_UPDATE_TIME = 5000; // milliseconds
 
     private boolean mStarted;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
@@ -19,7 +19,7 @@ import org.json.JSONObject;
 import org.mozilla.mozstumbler.service.AppGlobals;
 
 public class CellInfo implements Parcelable {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + CellInfo.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(CellInfo.class.getSimpleName());
 
     public static final String RADIO_GSM = "gsm";
     public static final String RADIO_CDMA = "cdma";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -47,7 +47,7 @@ public class CellScanner {
     public interface CellScannerImpl {
         void start();
         boolean isStarted();
-        boolean isSupported();
+        boolean isSupportedOnThisDevice();
         void stop();
         List<CellInfo> getCellInfo();
     }
@@ -58,7 +58,7 @@ public class CellScanner {
     }
 
     public void start(final ActiveOrPassiveStumbling stumblingMode) {
-        if (!mCellScannerImplementation.isSupported()) {
+        if (!mCellScannerImplementation.isSupportedOnThisDevice()) {
             return;
         }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -31,7 +31,7 @@ public class CellScanner {
     public static final String ACTION_CELLS_SCANNED_ARG_CELLS = "cells";
     public static final String ACTION_CELLS_SCANNED_ARG_TIME = AppGlobals.ACTION_ARG_TIME;
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + CellScanner.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(CellScanner.class.getSimpleName());
     private static final long CELL_MIN_UPDATE_TIME = 1000; // milliseconds
 
     private final Context mContext;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScannerImplementation.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScannerImplementation.java
@@ -62,8 +62,11 @@ public class CellScannerImplementation implements CellScanner.CellScannerImpl {
         mContext = context;
     }
 
-    public boolean isSupported() {
-        TelephonyManager telephonyManager = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+    public boolean isSupportedOnThisDevice() {
+        TelephonyManager telephonyManager = mTelephonyManager;
+        if (telephonyManager == null) {
+            telephonyManager = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+        }
         return telephonyManager != null &&
            (telephonyManager.getPhoneType() == TelephonyManager.PHONE_TYPE_CDMA ||
             telephonyManager.getPhoneType() == TelephonyManager.PHONE_TYPE_GSM);
@@ -76,7 +79,7 @@ public class CellScannerImplementation implements CellScanner.CellScannerImpl {
 
     @Override
     public synchronized void start() {
-        if (mIsStarted || !isSupported()) {
+        if (mIsStarted || !isSupportedOnThisDevice()) {
             return;
         }
         mIsStarted = true;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScannerImplementation.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScannerImplementation.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class CellScannerImplementation implements CellScanner.CellScannerImpl {
 
-    protected static String LOG_TAG = AppGlobals.LOG_PREFIX + CellScannerImplementation.class.getSimpleName();
+    protected static String LOG_TAG = AppGlobals.makeLogTag(CellScannerImplementation.class.getSimpleName());
     protected GetAllCellInfoScannerImpl mGetAllInfoCellScanner;
     protected TelephonyManager mTelephonyManager;
     protected boolean mIsStarted;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -47,7 +47,7 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
     }
 
     private static AsyncUploaderListener sAsyncListener;
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + AsyncUploader.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(AsyncUploader.class.getSimpleName());
     public static final AtomicLong sTotalBytesUploadedThisSession = new AtomicLong();
     public static final AtomicBoolean isUploading = new AtomicBoolean();
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
@@ -30,7 +30,7 @@ import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 // - triggered from the main thread
 // - actual work is done the upload thread (AsyncUploader)
 public class UploadAlarmReceiver extends BroadcastReceiver {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + UploadAlarmReceiver.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(UploadAlarmReceiver.class.getSimpleName());
     private static final String EXTRA_IS_REPEATING = "is_repeating";
     private static boolean sIsAlreadyScheduled;
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/LocationAdapter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/LocationAdapter.java
@@ -16,7 +16,7 @@ import org.mozilla.mozstumbler.service.AppGlobals;
  */
 public class LocationAdapter {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + LocationAdapter.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(LocationAdapter.class.getSimpleName());
 
     private static final String JSON_LATITUDE = "lat";
     private static final String JSON_LONGITUDE = "lon";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -11,7 +11,7 @@ import android.util.Log;
 import org.mozilla.mozstumbler.service.AppGlobals;
 
 public final class NetworkInfo {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + NetworkInfo.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(NetworkInfo.class.getSimpleName());
 
     ConnectivityManager mConnectivityManager;
     static NetworkInfo sInstance;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/ShaUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/ShaUtil.java
@@ -12,7 +12,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class ShaUtil {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + ShaUtil.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ShaUtil.class.getSimpleName());
 
     public static String sha1_hex_digest(String email) {
         String result = "";

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/Zipper.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/Zipper.java
@@ -18,7 +18,7 @@ import java.util.zip.GZIPOutputStream;
 
 public class Zipper {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + Zipper.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(Zipper.class.getSimpleName());
 
     public enum ZippedState {
         eNotZipped,

--- a/android/src/main/java/org/mozilla/osmdroid/DefaultResourceProxyImpl.java
+++ b/android/src/main/java/org/mozilla/osmdroid/DefaultResourceProxyImpl.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Field;
  */
 public class DefaultResourceProxyImpl implements ResourceProxy, MapViewConstants {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + DefaultResourceProxyImpl.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(DefaultResourceProxyImpl.class.getSimpleName());
 
     private Resources mResources;
     private DisplayMetrics mDisplayMetrics;

--- a/android/src/main/java/org/mozilla/osmdroid/contributor/GpxToPHPUploader.java
+++ b/android/src/main/java/org/mozilla/osmdroid/contributor/GpxToPHPUploader.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 
 public class GpxToPHPUploader {
 
-	private static final String LOG_TAG = AppGlobals.LOG_PREFIX + GpxToPHPUploader.class.getSimpleName();
+	private static final String LOG_TAG = AppGlobals.makeLogTag(GpxToPHPUploader.class.getSimpleName());
 
 	protected static final String UPLOADSCRIPT_URL = "http://www.PLACEYOURDOMAINHERE.com/anyfolder/gpxuploader/upload.php";
 

--- a/android/src/main/java/org/mozilla/osmdroid/events/DelayedMapListener.java
+++ b/android/src/main/java/org/mozilla/osmdroid/events/DelayedMapListener.java
@@ -15,7 +15,7 @@ import org.mozilla.mozstumbler.service.core.logging.Log;
  */
 public class DelayedMapListener implements MapListener {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + DelayedMapListener.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(DelayedMapListener.class.getSimpleName());
 
     /**
      * Default listening delay

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/BetterMapTileProviderArray.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/BetterMapTileProviderArray.java
@@ -31,7 +31,7 @@ public class BetterMapTileProviderArray extends MapTileProviderBase {
 
     protected final Map<MapTile, MapTileRequestState> mWorking = Collections.synchronizedMap(new HashMap<MapTile, MapTileRequestState>());
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + BetterMapTileProviderArray.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(BetterMapTileProviderArray.class.getSimpleName());
 
     protected final List<MapTileModuleProviderBase> mTileProviderList;
 

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/BetterTileProvider.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/BetterTileProvider.java
@@ -20,7 +20,7 @@ import org.mozilla.osmdroid.tileprovider.util.SimpleRegisterReceiver;
  */
 public class BetterTileProvider extends BetterMapTileProviderArray implements IMapTileProviderCallback {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + BetterTileProvider.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(BetterTileProvider.class.getSimpleName());
 
     public BetterTileProvider(final Context pContext) {
         // @TODO vng - this needs to be deleted as we are getting the

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/LRUMapTileCache.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/LRUMapTileCache.java
@@ -28,7 +28,7 @@ import java.util.LinkedHashMap;
 public class LRUMapTileCache {
     private int mCapacity = 0;
     private InnerLRUMapTileCache innerCache;
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + LRUMapTileCache.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(LRUMapTileCache.class.getSimpleName());
 
     public LRUMapTileCache(int capacity) {
         ensureCapacity(capacity);

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/MapTileProviderBase.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 public abstract class MapTileProviderBase implements IMapTileProviderCallback,
         OSMConstants {
 
-	private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MapTileProviderBase.class.getSimpleName();
+	private static final String LOG_TAG = AppGlobals.makeLogTag(MapTileProviderBase.class.getSimpleName());
 
 	protected final MapTileCache mTileCache;
 	protected Handler mTileRequestCompleteHandler;

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -81,7 +81,7 @@ public abstract class MapTileModuleProviderBase implements OSMConstants {
 
 	private final ExecutorService mExecutor;
 
-	private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MapTileModuleProviderBase.class.getSimpleName();
+	private static final String LOG_TAG = AppGlobals.makeLogTag(MapTileModuleProviderBase.class.getSimpleName());
 
 	protected final Object mQueueLockObject = new Object();
 	protected final HashMap<MapTile, MapTileRequestState> mWorking;

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SmartFSProvider.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SmartFSProvider.java
@@ -40,7 +40,7 @@ public class SmartFSProvider extends MapTileModuleProviderBase {
     // Constants
     // ===========================================================
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + SmartFSProvider.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(SmartFSProvider.class.getSimpleName());
 
     /**
      * whether the sdcard is mounted read/write

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
@@ -42,7 +42,7 @@ public class TileDownloaderDelegate {
     private static final int HTTP404_CACHE_SIZE = 2000;
     Map<String, Long> HTTP404_CACHE = Collections.synchronizedMap(new LruCache<String, Long>(HTTP404_CACHE_SIZE));
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + TileDownloaderDelegate.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(TileDownloaderDelegate.class.getSimpleName());
 
     public TileDownloaderDelegate(INetworkAvailablityCheck pNetworkAvailablityCheck,
                                   TileIOFacade tw) {

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileIOFacade.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileIOFacade.java
@@ -39,7 +39,7 @@ public class TileIOFacade  {
     // Constants
     // ===========================================================
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + TileIOFacade.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(TileIOFacade.class.getSimpleName());
 
     // ===========================================================
     // Fields

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -23,7 +23,7 @@ import java.util.Random;
 public abstract class BitmapTileSourceBase
         implements ITileSource, OSMConstants {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + BitmapTileSourceBase.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(BitmapTileSourceBase.class.getSimpleName());
 
     private static int globalOrdinal = 0;
 

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/CloudmadeTileSource.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/CloudmadeTileSource.java
@@ -8,7 +8,7 @@ import org.mozilla.osmdroid.tileprovider.util.CloudmadeUtil;
 
 public class CloudmadeTileSource extends OnlineTileSourceBase implements IStyledTileSource<Integer> {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + CloudmadeTileSource.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(CloudmadeTileSource.class.getSimpleName());
 
     private Integer mStyle = 1;
 

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/TileSourceFactory.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/TileSourceFactory.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 
 public class TileSourceFactory {
 
-    // private static final String LOG_TAG = AppGlobals.LOG_PREFIX + TileSourceFactory.class.getSimpleName();
+    // private static final String LOG_TAG = AppGlobals.makeLogTag(TileSourceFactory.class.getSimpleName());
 
     /**
      * Get the tile source with the specified name.

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/CloudmadeUtil.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/CloudmadeUtil.java
@@ -30,7 +30,7 @@ import java.io.InputStreamReader;
  */
 public class CloudmadeUtil implements OSMConstants {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + CloudmadeUtil.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(CloudmadeUtil.class.getSimpleName());
 
     /**
      * the meta data key in the manifest

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/ManifestUtil.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/ManifestUtil.java
@@ -12,7 +12,7 @@ import org.mozilla.mozstumbler.service.core.logging.Log;
  */
 public class ManifestUtil {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + ManifestUtil.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ManifestUtil.class.getSimpleName());
 
     /**
      * Retrieve a key from the manifest meta data, or empty string if not found.

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/StreamUtils.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/util/StreamUtils.java
@@ -15,7 +15,7 @@ public class StreamUtils {
     // Constants
     // ===========================================================
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + StreamUtils.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(StreamUtils.class.getSimpleName());
 
     public static final int IO_BUFFER_SIZE = 8 * 1024;
 

--- a/android/src/main/java/org/mozilla/osmdroid/views/MapView.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/MapView.java
@@ -65,7 +65,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
     // Constants
     // ===========================================================
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MapView.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MapView.class.getSimpleName());
 
     private static final double ZOOM_SENSITIVITY = 1.0;
     private static final double ZOOM_LOG_BASE_INV = 1.0 / Math.log(2.0 / ZOOM_SENSITIVITY);

--- a/android/src/main/java/org/mozilla/osmdroid/views/overlay/TilesOverlay.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/overlay/TilesOverlay.java
@@ -34,7 +34,7 @@ import org.mozilla.osmdroid.views.Projection;
 
 public class TilesOverlay extends Overlay implements IOverlayMenuProvider {
 
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + TilesOverlay.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(TilesOverlay.class.getSimpleName());
 
     public static final int MENU_MAP_MODE = getSafeMenuId();
     public static final int MENU_TILE_SOURCE_STARTING_ID = getSafeMenuIdSequence(TileSourceFactory

--- a/android/src/main/java/org/mozilla/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -39,7 +39,7 @@ import java.util.LinkedList;
  */
 public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer,
         IOverlayMenuProvider, Snappable {
-    private static final String LOG_TAG = AppGlobals.LOG_PREFIX + MyLocationNewOverlay.class.getSimpleName();
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MyLocationNewOverlay.class.getSimpleName());
 
     // ===========================================================
     // Constants


### PR DESCRIPTION
- In Fennec, we found that >23 char log tags are enforced for Log.isLoggable(). 
- Also, noticed the upload alarm wasn't canceled on destroy, more obvious in Fennec because it keeps starting and stopping the service in bursts.
- Still need to port all the logging changes from Fennec to here. Fennec logs no location info, no wifi scan details, no cell scan details.
