### PR TITLE
The passive service lives longer than the stumbler service, so upload should not be cancelled.

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -128,8 +128,6 @@ public class StumblerService extends PersistentIntentService
     public void onDestroy() {
         super.onDestroy();
 
-        UploadAlarmReceiver.cancelAlarm(this, !mScanManager.isPassiveMode());
-
         if (!isScanning()) {
             return;
         }


### PR DESCRIPTION
I committed a few days ago, and this approach is wrong.
