### PR TITLE
Added OSM copyright string #1264

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -524,9 +524,9 @@ public final class MapFragment extends android.support.v4.app.Fragment
     private void showCopyright() {
         TextView copyrightArea = (TextView) mRootView.findViewById(R.id.copyright_area);
         if (BuildConfig.TILE_SERVER_URL == null) {
-            copyrightArea.setText("Tiles Courtesy of MapQuest\n© OpenStreetMap contributors");
+            copyrightArea.setText(getActivity().getString(R.string.map_copyright_fdroid));
         } else {
-            copyrightArea.setText("© MapBox © OpenStreetMap contributors");
+            copyrightArea.setText(getActivity().getString(R.string.map_copyright_moz));
         }
     }
 

--- a/android/src/main/res/layout/activity_map.xml
+++ b/android/src/main/res/layout/activity_map.xml
@@ -169,6 +169,7 @@
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true" />
 
+	<!-- The copyright text is set at java\org\mozilla\mozstumbler\client\mapview\MapFragment.java showCopyright() -->
     <TextView
         android:id="@+id/copyright_area"
         android:textColor="@android:color/black"

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -86,6 +86,8 @@
     <string name="first_run_welcome_to_mozstumbler">Willkommen bei Mozilla Stumbler</string>
     <string name="map_unavailable">Die Karte kann nicht angezeigt werden, da kein SD-Kartenspeicher vorhanden ist.\nSie können aber immer noch Daten sammeln.</string>
     <string name="map_offline_mode">Die Karte kann ohne eine verfügbare Internetverbindung nicht aktualisiert werden.\nSie können aber immer noch Daten sammeln.</string>
+	<string name="map_copyright_fdroid">Kacheln bereitgestellt durch MapQuest\n© OpenStreetMap-Mitwirkende</string>
+	<string name="map_copyright_moz">© MapBox © OpenStreetMap-Mitwirkende</string>
     <string name="action_developer">Entwickler</string>
     <string name="developer_title">Entwickler</string>
     <string name="enable_option_show_mls_on_map">MLS Ortungsabfragen aktivieren</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="first_run_welcome_to_mozstumbler">Welcome to Mozilla Stumbler</string>
     <string name="map_unavailable">The map is not available for display, as there is no SD card storage.\nYou can still collect data.</string>
     <string name="map_offline_mode">The map will not update without an Internet connection,\nhowever you are still able to collect data.</string>
+	<string name="map_copyright_fdroid">Tiles Courtesy of MapQuest\n© OpenStreetMap contributors</string>
+	<string name="map_copyright_moz">© MapBox © OpenStreetMap contributors</string>
     <string name="action_developer">Developer</string>
     <string name="developer_title">Developer</string>
     <string name="enable_option_show_mls_on_map">Enable MLS location queries</string>


### PR DESCRIPTION
Moved strings from code to the English and German strings.xml files.
Added a comment to the layout file of the map about where to find the
code that sets the strings.

Was quite a hassle to find that string...
Should have used the windows search from the beginning instead of looking through each .xml file ^^
(ended up being hidden in the mapfragment)

Pls the check the code, since I never wrote apps myself for Android it is likely that I made a mistake.
(I'm not sure whether I can set the @string stuff in the mapfragment and whether it is good style and I'm not sure whether I can use a "-" in the string's name (for F-Droid))
