### PR TITLE
Large Text is on: show only GPS fixes label, hide visible

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -6,6 +6,7 @@ package org.mozilla.mozstumbler.client.mapview;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.location.Location;
@@ -191,6 +192,14 @@ public final class MapFragment extends android.support.v4.app.Fragment
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();
         observer.setMapActivity(this);
 
+        Configuration c = getResources().getConfiguration();
+        if (c.fontScale > 1) {
+            Log.d(LOG_TAG, "Large text is enabled: " + c.fontScale);
+            mRootView.findViewById(R.id.text_satellites_sep).setVisibility(View.GONE);
+            mRootView.findViewById(R.id.text_satellites_avail).setVisibility(View.GONE);
+        } else {
+            initTextView(R.id.text_satellites_avail, "00");
+        }
         initTextView(R.id.text_cells_visible, "000");
         initTextView(R.id.text_wifis_visible, "000");
         initTextView(R.id.text_observation_count, "00000");
@@ -687,9 +696,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
         Paint textPaint = textView.getPaint();
         int width = (int) Math.ceil(textPaint.measureText(bound));
         textView.setWidth(width);
-        android.widget.LinearLayout.LayoutParams params =
-                new android.widget.LinearLayout.LayoutParams(width, android.widget.LinearLayout.LayoutParams.MATCH_PARENT);
-        textView.setLayoutParams(params);
+        textView.getLayoutParams().width = width;
         textView.setText("0");
     }
 

--- a/android/src/main/res/layout/activity_map.xml
+++ b/android/src/main/res/layout/activity_map.xml
@@ -56,7 +56,7 @@
                     android:textColor="@android:color/black"
                     android:layout_width="14dp"
                     android:layout_height="match_parent"
-                    android:text="0"
+                    tools:text="21"
                     android:gravity="bottom"
                     android:layout_marginBottom="4sp"
                     android:textSize="12sp"


### PR DESCRIPTION
@garvankeeley There is a layout problem regarding the display of available GPS satellites if `Accessibility > Large text` is enabled.
This PR fully fixes the problem for #used satellites <= 9. When more satellites are in use, the number of available satellites is now cut off. I could not find another fix without breaking what was discussed in #1051.
Do you think this is an improvement? Any other ideas?
