### PR TITLE
Features/1268 json crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test: unittest
 
 
 unittest:
-	./gradlew assembleUnittest
+	./gradlew assembleGithubUnittest
 
 debug:
 	./gradlew assembleGithubDebug

--- a/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -27,6 +27,10 @@ public class AppGlobals {
     /* Location constructor requires a named origin, these are created in the app. */
     public static final String LOCATION_ORIGIN_INTERNAL = "internal";
 
+    public static String makeLogTag(Class<?> cls) {
+        return makeLogTag(cls.getSimpleName());
+    }
+
     public enum ActiveOrPassiveStumbling { ACTIVE_STUMBLING, PASSIVE_STUMBLING }
 
     /* In passive mode, only scan this many times for each gps. */

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -182,10 +182,6 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             return;
         }
 
-        if (AppGlobals.isDebug) {
-            Log.d(LOG_TAG, "Received a MLS bundle" + mlsObj.toString());
-        }
-
         if (wifiCount + cellCount < 1) {
             mBundle = null;
             return;

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -44,7 +44,7 @@ public class DataStorageManager {
 
     // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
     // After this size is reached, data is persisted to disk, mCurrentReports is cleared.
-    private static final int MAX_REPORTS_IN_MEMORY = 50;
+    public static final int MAX_REPORTS_IN_MEMORY = 50;
 
     // Used to cap the amount of data stored. When this limit is hit, no more data is saved to disk
     // until the data is uploaded, or and data exceeds DEFAULT_MAX_WEEKS_DATA_ON_DISK.
@@ -60,7 +60,7 @@ public class DataStorageManager {
     // Set to the default value specified above.
     private final int mMaxWeeksStored;
 
-    private final ReportBatchBuilder mCurrentReports = new ReportBatchBuilder();
+    final ReportBatchBuilder mCurrentReports = new ReportBatchBuilder();
     private final File mReportsDir;
     private final File mStatsFile;
     private final StorageIsEmptyTracker mTracker;
@@ -183,7 +183,7 @@ public class DataStorageManager {
         }
     }
 
-    private static class ReportBatchBuilder {
+    static class ReportBatchBuilder {
         public final ArrayList<String> reports = new ArrayList<String>();
         public int wifiCount;
         public int cellCount;
@@ -447,7 +447,7 @@ public class DataStorageManager {
         mCurrentReports.wifiCount += wifiCount;
         mCurrentReports.cellCount += cellCount;
 
-        if (mCurrentReports.reports.size() >= MAX_REPORTS_IN_MEMORY) {
+        if (mCurrentReports.reports.size() == MAX_REPORTS_IN_MEMORY) {
             // save to disk
             saveCurrentReportsToDisk();
         } else {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -43,7 +43,7 @@ public class DataStorageManager {
     private static final String LOG_TAG = AppGlobals.makeLogTag(DataStorageManager.class.getSimpleName());
 
     // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
-    // After this size is reached, data is persisted to disk, mCurrentReports is cleared.
+    // Once this size is reached, data is persisted to disk, mCurrentReports is cleared.
     public static final int MAX_REPORTS_IN_MEMORY = 50;
 
     // Used to cap the amount of data stored. When this limit is hit, no more data is saved to disk
@@ -181,12 +181,6 @@ public class DataStorageManager {
             this.wifiCount = wifiCount;
             this.cellCount = cellCount;
         }
-    }
-
-    static class ReportBatchBuilder {
-        public final ArrayList<String> reports = new ArrayList<String>();
-        public int wifiCount;
-        public int cellCount;
     }
 
     private static class ReportBatchIterator {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -1,12 +1,57 @@
 package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.core.logging.Log;
+
 import java.util.ArrayList;
 
 /**
 * Created by victorng on 14-11-20.
 */
-class ReportBatchBuilder {
-    public final ArrayList<String> reports = new ArrayList<String>();
+public class ReportBatchBuilder {
+    // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
+    // Once this size is reached, data is persisted to disk, mCurrentReports is cleared.
+    public static final int MAX_REPORTS_IN_MEMORY = 50;
+    private static final String LOG_TAG = AppGlobals.makeLogTag(ReportBatchBuilder.class);
+    private final ArrayList<String> reports = new ArrayList<String>();
     public int wifiCount;
     public int cellCount;
+
+    public int reportsCount() {
+        return reports.size();
+    }
+
+    String finalizeReports() {
+        final String kPrefix = "{\"items\":[";
+        final String kSuffix = "]}";
+        final StringBuilder sb = new StringBuilder(kPrefix);
+        String sep = "";
+        final String separator = ",";
+        if (reports != null) {
+            for(String s: reports) {
+                sb.append(sep).append(s);
+                sep = separator;
+            }
+        }
+
+        final String result = sb.append(kSuffix).toString();
+        return result;
+    }
+
+    public void clearReports() {
+        reports.clear();
+    }
+
+    public void addReport(String report) {
+        if (reports.size() == MAX_REPORTS_IN_MEMORY) {
+            // This can happen in the event that serializing reports to disk fails
+            // and the reports list is never cleared.
+            return;
+        }
+        reports.add(report);
+    }
+
+    public boolean maxReportsReached() {
+        return reportsCount() == MAX_REPORTS_IN_MEMORY;
+    }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -1,0 +1,12 @@
+package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+import java.util.ArrayList;
+
+/**
+* Created by victorng on 14-11-20.
+*/
+class ReportBatchBuilder {
+    public final ArrayList<String> reports = new ArrayList<String>();
+    public int wifiCount;
+    public int cellCount;
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -64,7 +64,8 @@ public class WifiScanner extends BroadcastReceiver {
         if (manager == null) {
             return null;
         }
-        return getWifiManager().getScanResults();
+
+        return manager.getScanResults();
     }
 
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -110,7 +110,12 @@ public class WifiScanner extends BroadcastReceiver {
             final ArrayList<ScanResult> scanResults = new ArrayList<ScanResult>();
             for (ScanResult scanResult : scanResultList) {
                 scanResult.BSSID = BSSIDBlockList.canonicalizeBSSID(scanResult.BSSID);
+
                 if (shouldLog(scanResult)) {
+                    // Once we've checked that we want this scan result, we can safely discard
+                    // the SSID and capabilities.
+                    scanResult.SSID = "";
+                    scanResult.capabilities = "";
                     scanResults.add(scanResult);
                 }
             }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
@@ -23,8 +23,8 @@ public class CellInfo implements Parcelable {
 
     public static final String RADIO_GSM = "gsm";
     public static final String RADIO_CDMA = "cdma";
-    public static final String RADIO_WCDMA = "wcdma";
 
+    public static final String CELL_RADIO_UNKNOWN = "";
     public static final String CELL_RADIO_GSM = "gsm";
     public static final String CELL_RADIO_UMTS = "umts";
     public static final String CELL_RADIO_CDMA = "cdma";
@@ -48,19 +48,6 @@ public class CellInfo implements Parcelable {
     public CellInfo(int phoneType) {
         reset();
         setRadio(phoneType);
-    }
-
-    private CellInfo(Parcel in) {
-        mRadio = in.readString();
-        mCellRadio = in.readString();
-        mMcc = in.readInt();
-        mMnc = in.readInt();
-        mCid = in.readInt();
-        mLac = in.readInt();
-        mSignal = in.readInt();
-        mAsu = in.readInt();
-        mTa = in.readInt();
-        mPsc = in.readInt();
     }
 
     public boolean isCellRadioValid() {
@@ -161,6 +148,24 @@ public class CellInfo implements Parcelable {
         mRadio = getRadioTypeName(phoneType);
     }
 
+    void setNeighboringCellInfo(NeighboringCellInfo nci, String networkOperator) {
+        final int lac, cid, psc, rssi;
+
+        reset();
+        mCellRadio = getCellRadioTypeName(nci.getNetworkType());
+        setNetworkOperator(networkOperator);
+
+        lac = nci.getLac();
+        cid = nci.getCid();
+        psc = nci.getPsc();
+        rssi = nci.getRssi();
+
+        if (lac >= 0) mLac = lac;
+        if (cid >= 0) mCid = cid;
+        if (psc >= 0) mPsc = psc;
+        if (rssi != NeighboringCellInfo.UNKNOWN_RSSI) mAsu = rssi;
+    }
+
     void setCellLocation(CellLocation cl,
                          int networkType,
                          String networkOperator,
@@ -206,24 +211,6 @@ public class CellInfo implements Parcelable {
         } else {
             throw new IllegalArgumentException("Unexpected CellLocation type: " + cl.getClass().getName());
         }
-    }
-
-    void setNeighboringCellInfo(NeighboringCellInfo nci, String networkOperator) {
-        final int lac, cid, psc, rssi;
-
-        reset();
-        mCellRadio = getCellRadioTypeName(nci.getNetworkType());
-        setNetworkOperator(networkOperator);
-
-        lac = nci.getLac();
-        cid = nci.getCid();
-        psc = nci.getPsc();
-        rssi = nci.getRssi();
-
-        if (lac >= 0) mLac = lac;
-        if (cid >= 0) mCid = cid;
-        if (psc >= 0) mPsc = psc;
-        if (rssi != NeighboringCellInfo.UNKNOWN_RSSI) mAsu = rssi;
     }
 
     void setGsmCellInfo(int mcc, int mnc, int lac, int cid, int asu) {
@@ -282,6 +269,7 @@ public class CellInfo implements Parcelable {
     }
 
     static String getCellRadioTypeName(int networkType) {
+        Log.d(LOG_TAG, "getCellRadioTypeName("+networkType+")");
         switch (networkType) {
             // If the network is either GSM or any high-data-rate variant of it, the radio
             // field should be specified as `gsm`. This includes `GSM`, `EDGE` and `GPRS`.
@@ -315,7 +303,7 @@ public class CellInfo implements Parcelable {
 
             default:
                 Log.e(LOG_TAG, "", new IllegalArgumentException("Unexpected network type: " + networkType));
-                return String.valueOf(networkType);
+                return CELL_RADIO_UNKNOWN;
         }
     }
 

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
@@ -7,13 +7,9 @@ import android.location.Location;
 import android.net.wifi.ScanResult;
 import android.telephony.TelephonyManager;
 
-import junit.framework.Assert;
-import junit.framework.AssertionFailedError;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
@@ -26,7 +22,6 @@ import org.robolectric.RobolectricTestRunner;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Map;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -97,7 +92,7 @@ public class ReporterTest {
         ArrayList<CellInfo> cellIdList = new ArrayList<CellInfo>();
 
         for (int offset = 0; offset< StumblerBundle.MAX_CELLS_PER_LOCATION-1; offset++) {
-            CellInfo cell = makeCellInfo(1, 1, 2000+offset, 1600199+offset, 19);
+            CellInfo cell = createCellInfo(1, 1, 2000 + offset, 1600199 + offset, 19);
             cellIdList.add(cell);
         }
 
@@ -107,8 +102,8 @@ public class ReporterTest {
                 rp.mBundle.getUnmodifiableCellData().size());
 
         cellIdList.clear();
-        CellInfo cell  = makeCellInfo(1, 1, 2000+StumblerBundle.MAX_CELLS_PER_LOCATION+1,
-                1600199+StumblerBundle.MAX_CELLS_PER_LOCATION+1, 19);
+        CellInfo cell  = createCellInfo(1, 1, 2000 + StumblerBundle.MAX_CELLS_PER_LOCATION + 1,
+                1600199 + StumblerBundle.MAX_CELLS_PER_LOCATION + 1, 19);
         cellIdList.add(cell);
         cellIntent = getCellIntent(cellIdList);
         // This will force a flush and the bundle should go to null
@@ -140,7 +135,7 @@ public class ReporterTest {
         return i;
     }
 
-    CellInfo makeCellInfo(int mcc, int mnc, int lac, int cid, int asu) {
+    public static CellInfo createCellInfo(int mcc, int mnc, int lac, int cid, int asu) {
         CellInfo cell = new CellInfo(TelephonyManager.PHONE_TYPE_GSM);
         Method method = getMethod(CellInfo.class, "setGsmCellInfo");
         assert (method != null);
@@ -152,7 +147,7 @@ public class ReporterTest {
         return cell;
     }
 
-    Method getMethod(Class<?> c, String name) {
+    static Method getMethod(Class<?> c, String name) {
         Method[] methods = c.getDeclaredMethods();
         for (Method m : methods) {
             if (m.getName().contains(name)) {
@@ -163,7 +158,7 @@ public class ReporterTest {
         return null;
     }
 
-    ScanResult createScanResult(String BSSID, String caps, int level, int frequency,
+    public static ScanResult createScanResult(String BSSID, String caps, int level, int frequency,
                                         long tsf) {
         Class<?> c = null;
         try {

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -152,7 +152,7 @@ public class DataStorageManagerTest {
                 Log.e(LOG_TAG, "Bombed out on " + (locCount + 1) + " adding after " + dm.mCurrentReports.reports.size() + " records", ioEx);
             }
 
-            Log.d(LOG_TAG, "Total number of reports: " + dm.mCurrentReports.reports.size());
+            assertTrue(dm.mCurrentReports.reports.size() < DataStorageManager.MAX_REPORTS_IN_MEMORY);
 
             // I think we can basically reproduce this if DataStorageManager.mBundle is set
             // then we call flush() and eat the FileNotFoundException

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -1,0 +1,162 @@
+package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.net.wifi.ScanResult;
+import android.telephony.TelephonyManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.core.logging.Log;
+import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
+import org.mozilla.mozstumbler.service.stumblerthread.ReporterTest;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mozilla.mozstumbler.service.stumblerthread.ReporterTest.createCellInfo;
+import static org.mozilla.mozstumbler.service.stumblerthread.ReporterTest.createScanResult;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class DataStorageManagerTest {
+
+    private String LOG_TAG = AppGlobals.makeLogTag(DataStorageManagerTest.class);
+
+    public class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+        public void notifyStorageStateEmpty(boolean isEmpty) {
+        }
+    }
+    private DataStorageManager dm;
+    private Reporter rp;
+    private Context ctx;
+
+    private Application getApplicationContext() {
+        return Robolectric.application;
+    }
+
+    private Intent getLocationIntent() {
+        Location location = new Location("mock");
+        location.setLongitude(20);
+        location.setLatitude(30);
+        Intent i = new Intent(GPSScanner.ACTION_GPS_UPDATED);
+        i.putExtra(Intent.EXTRA_SUBJECT, GPSScanner.SUBJECT_NEW_LOCATION);
+        i.putExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION, location);
+        i.putExtra(GPSScanner.ACTION_ARG_TIME, System.currentTimeMillis());
+        return i;
+    }
+
+    @Before
+    public void setUp() {
+        ctx = getApplicationContext();
+
+        StorageTracker tracker = new StorageTracker();
+
+        long maxBytes = 20000;
+        int maxWeeks = 10;
+
+        // The DM is required to handle the flush() operation in the Reporter.
+        dm = DataStorageManager.createGlobalInstance(ctx, tracker, maxBytes, maxWeeks);
+
+        // Reports are muddled because of the ReporterTest cases for some reason.
+        while (dm.mCurrentReports.reports.size() > 0) {
+            dm.mCurrentReports.reports.remove(0);
+        }
+
+        rp = new Reporter();
+
+        // The Reporter class needs a reference to a context
+        rp.startup(ctx);
+        assertEquals(0, dm.mCurrentReports.reports.size());
+    }
+
+    @Test
+    public void testMaxReportsLength() throws JSONException {
+        StumblerBundle bundle;
+
+        assertEquals(0, dm.mCurrentReports.reports.size());
+        for (int locCount = 0; locCount < DataStorageManager.MAX_REPORTS_IN_MEMORY-1; locCount++) {
+            Location loc = new Location("mock");
+            loc.setLatitude(42+(locCount*0.1));
+            loc.setLongitude(45+(locCount*0.1));
+
+            bundle = new StumblerBundle(loc, TelephonyManager.PHONE_TYPE_GSM);
+
+            for (int offset = 0; offset< StumblerBundle.MAX_WIFIS_PER_LOCATION*20; offset++) {
+                String bssid = Long.toHexString(offset | 0xabcd00000000L);
+                ScanResult scan = createScanResult(bssid, "caps", 3, 11, 10);
+                bundle.addWifiData(bssid, scan);
+            }
+
+            for (int offset = 0; offset< StumblerBundle.MAX_CELLS_PER_LOCATION*20; offset++) {
+                CellInfo cell = createCellInfo(1, 1, 2000 + offset, 1600199 + offset, 19);
+                String key = cell.getCellIdentity();
+                bundle.addCellData(key, cell);
+            }
+
+            JSONObject mlsObj = bundle.toMLSJSON();
+            int wifiCount = mlsObj.getInt(DataStorageContract.ReportsColumns.WIFI_COUNT);
+            int cellCount = mlsObj.getInt(DataStorageContract.ReportsColumns.CELL_COUNT);
+            try {
+                dm.insert(mlsObj.toString(), wifiCount, cellCount);
+            } catch (IOException ioEx) {
+                Log.e(LOG_TAG, "Bombed out on " +(locCount+1)+" adding after "+ dm.mCurrentReports.reports.size()+ " records", ioEx);
+            }
+        }
+        assertEquals(DataStorageManager.MAX_REPORTS_IN_MEMORY-1, dm.mCurrentReports.reports.size());
+
+
+        for (int locCount = DataStorageManager.MAX_REPORTS_IN_MEMORY;
+             locCount < DataStorageManager.MAX_REPORTS_IN_MEMORY+100;
+             locCount++) {
+            Location loc = new Location("mock");
+            loc.setLatitude(42+(locCount*0.1));
+            loc.setLongitude(45+(locCount*0.1));
+
+            bundle = new StumblerBundle(loc, TelephonyManager.PHONE_TYPE_GSM);
+
+            for (int offset = 0; offset < StumblerBundle.MAX_WIFIS_PER_LOCATION * 20; offset++) {
+                String bssid = Long.toHexString(offset | 0xabcd00000000L);
+                ScanResult scan = createScanResult(bssid, "caps", 3, 11, 10);
+                bundle.addWifiData(bssid, scan);
+            }
+
+            for (int offset = 0; offset < StumblerBundle.MAX_CELLS_PER_LOCATION * 20; offset++) {
+                CellInfo cell = createCellInfo(1, 1, 2000 + offset, 1600199 + offset, 19);
+                String key = cell.getCellIdentity();
+                bundle.addCellData(key, cell);
+            }
+
+            JSONObject mlsObj = bundle.toMLSJSON();
+            int wifiCount = mlsObj.getInt(DataStorageContract.ReportsColumns.WIFI_COUNT);
+            int cellCount = mlsObj.getInt(DataStorageContract.ReportsColumns.CELL_COUNT);
+            try {
+                dm.insert(mlsObj.toString(), wifiCount, cellCount);
+            } catch (FileNotFoundException fex) {
+                // This is ok
+            } catch (IOException ioEx) {
+                Log.e(LOG_TAG, "Bombed out on " + (locCount + 1) + " adding after " + dm.mCurrentReports.reports.size() + " records", ioEx);
+            }
+
+            Log.d(LOG_TAG, "Total number of reports: " + dm.mCurrentReports.reports.size());
+
+            // I think we can basically reproduce this if DataStorageManager.mBundle is set
+            // then we call flush() and eat the FileNotFoundException
+        }
+    }
+
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -114,7 +114,6 @@ public class DataStorageManagerTest {
             try {
                 dm.insert(mlsObj.toString(), wifiCount, cellCount);
             } catch (IOException ioEx) {
-                Log.e(LOG_TAG, "Bombed out on " +(locCount+1)+" adding after "+ dm.mCurrentReports.reports.size()+ " records", ioEx);
             }
         }
         assertEquals(DataStorageManager.MAX_REPORTS_IN_MEMORY-1, dm.mCurrentReports.reports.size());
@@ -149,7 +148,6 @@ public class DataStorageManagerTest {
             } catch (FileNotFoundException fex) {
                 // This is ok
             } catch (IOException ioEx) {
-                Log.e(LOG_TAG, "Bombed out on " + (locCount + 1) + " adding after " + dm.mCurrentReports.reports.size() + " records", ioEx);
             }
 
             assertTrue(dm.mCurrentReports.reports.size() < DataStorageManager.MAX_REPORTS_IN_MEMORY);

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfoTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfoTest.java
@@ -1,0 +1,82 @@
+package org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner;
+
+
+import android.os.Build;
+import android.telephony.CellLocation;
+import android.telephony.TelephonyManager;
+import android.telephony.gsm.GsmCellLocation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.core.logging.Log;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Created by victorng on 14-11-19.
+ */
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class CellInfoTest {
+
+    private static final String LOG_TAG = AppGlobals.makeLogTag(CellInfoTest.class);
+
+    // Only two fields in the CellInfo struct are strings.  This just makes sure that all
+    // values will map to known values or the empty string.
+
+    @Test
+    public void testCellInfoRadioType() {
+        // The only two fields in CellInfo which have unrestricted length are
+        // mCellRadio and mRadio.  Both of those should only allow setting string
+        // values from known lists.
+
+        int GARBAGE_PHONE_TYPE = 1600000000;
+        CellInfo cellInfo;
+
+        cellInfo = new CellInfo(GARBAGE_PHONE_TYPE);
+        assertEquals(cellInfo.getRadio(), "");
+
+        cellInfo = new CellInfo(TelephonyManager.PHONE_TYPE_NONE);
+        assertEquals(cellInfo.getRadio(), "");
+
+        cellInfo = new CellInfo(TelephonyManager.PHONE_TYPE_CDMA);
+        assertEquals(cellInfo.getRadio(), "cdma");
+
+        cellInfo = new CellInfo(TelephonyManager.PHONE_TYPE_NONE);
+        assertEquals(cellInfo.getRadio(), "");
+
+        cellInfo = new CellInfo(TelephonyManager.PHONE_TYPE_SIP);
+        assertEquals(cellInfo.getRadio(), "");
+    }
+
+    @Test
+    public void testCellInfoCellRadioType() {
+        int GARBAGE_PHONE_TYPE = 1600000000;
+        CellInfo cellInfo;
+
+        cellInfo = new CellInfo(GARBAGE_PHONE_TYPE);
+        GsmCellLocation gcl = new GsmCellLocation();
+        gcl.setLacAndCid(1, 2);
+
+        int[] netTypes;
+
+        netTypes = new int[]{TelephonyManager.NETWORK_TYPE_UNKNOWN, 32432789};
+        for (int networkType : netTypes) {
+            cellInfo.setCellLocation(gcl, networkType, "123456", 5, 5);
+            assertEquals("", cellInfo.getCellRadio());
+        }
+
+        netTypes = new int[]{TelephonyManager.NETWORK_TYPE_EVDO_0};
+        for (int networkType : netTypes) {
+            cellInfo.setCellLocation(gcl, networkType, "123456", 5, 5);
+            assertEquals(CellInfo.CELL_RADIO_CDMA, cellInfo.getCellRadio());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This should fix #1268 and fix our OOM errors.

I believe this was caused by some bad error checking on out of storage.  This patch will ensure that we don't grow without bound, but it doesn't do anything to clean up storage if we run out of diskspace.

This puts a hard limit on the number of StumblerBundle instances that can be inside of a single ReportBatchBuilder instance.

Tests added checking the underlying StumblerBundle and string lengths are in ReporterTest, while checks against the total number of StumblerBundle instances are contained in DataStorageManagerTest.
