### PR TITLE
Features/fdroid buildhost

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,15 +2,6 @@
 def versionMajor = 1
 def versionMinor = 4 // minor feature releases
 def versionPatch = 0 // This should be bumped for hot fixes
-def buildHost = ""
-try
-{
-    buildHost = InetAddress.localHost.hostName
-} catch (Exception ex) {
-    // Some machines are ridiculous.
-    buildHost = "localhost"
-}
-buildHost =  buildHost.replaceAll("[^a-zA-Z0-9_-]","")
 
 // Double check the versioning
 for (versionPart in [versionPatch, versionMinor, versionMajor]) {
@@ -62,7 +53,7 @@ android {
         targetSdkVersion 18
 
         versionCode versionMajor * 1000000 + versionMinor * 10000 + versionPatch * 100
-        versionName "${versionMajor}.${versionMinor}.${versionPatch}.${buildHost}"
+        versionName "${versionMajor}.${versionMinor}.${versionPatch}"
 
         buildConfigField "boolean", "ROBOLECTRIC", "false"
         buildConfigField "String", "MOZILLA_API_KEY", "\"\""

--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -102,10 +102,15 @@ public class Updater {
         return true;
     }
 
-    private String stripBuildHostName(String installedVersion) {
-        return installedVersion.substring(0,installedVersion.lastIndexOf("."));
+    String stripBuildHostName(String installedVersion) {
+        // Some versions had the old buildhost stuff in there, we need
+        // to strip out anything pase the 3rd integer part.
+        String[] parts = installedVersion.split("\\.");
+        if (parts.length < 3) {
+            throw new RuntimeException("Unexpected version string: [" + installedVersion + "] parts:" + parts.length);
+        }
+        return parts[0] + "." + parts[1] + "." + parts[2];
     }
-
 
     private boolean isVersionGreaterThan(String a, String b) {
         if (a == null) {

--- a/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
@@ -1,24 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.mozstumbler.client;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.http.MockHttpUtil;
-import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
-
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+
 @Config(emulateSdk = 18)
 @RunWith(RobolectricTestRunner.class)
-public class MainDrawerActivityTest {
+public class UpdaterTest {
+    class TestUpdater extends Updater {
+        public TestUpdater(IHttpUtil simpleHttp) {
+            super(simpleHttp);
+        }
+
+        @Override
+        public boolean wifiExclusiveAndUnavailable() {
+            return false;
+        }
+    }
 
     private MainDrawerActivity activity;
 
@@ -32,28 +45,23 @@ public class MainDrawerActivityTest {
         assertNotNull(activity);
     }
 
-
     @Test
     public void testUpdater() {
-
-        class TestUpdater extends Updater {
-            public TestUpdater(IHttpUtil simpleHttp) {
-                super(simpleHttp);
-            }
-
-            @Override
-            public boolean wifiExclusiveAndUnavailable() {
-                return false;
-            }
-        }
-
         IHttpUtil mockHttp = new MockHttpUtil();
-
-
         Updater upd = new TestUpdater(mockHttp);
         assertFalse(upd.checkForUpdates(activity, ""));
         assertFalse(upd.checkForUpdates(activity, null));
         assertTrue(upd.checkForUpdates(activity, "anything_else"));
+
+        assertEquals("1.3.0", upd.stripBuildHostName("1.3.0.Victors-MBPr"));
+        assertEquals("1.3.0", upd.stripBuildHostName("1.3.0"));
+
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testUpdaterThrowsExceptions() {
+        Updater upd = new TestUpdater(null);
+        upd.stripBuildHostName("1.0");
     }
 
 }


### PR DESCRIPTION
This reverts the buildhost addition to the versioning scheme.  It completely breaks the fdroid build and I can't figure out how to resolve it without breaking the version names for all other productFlavors.  I hate gradle.

@garvankeeley  I'm planning on cutting a 1.4.1 release for fdroid that will be 1.4.0 plus this patch.
