### PR TITLE
Add metrics to notification

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -187,7 +187,7 @@ dependencies {
     // libraries, because they support a wide range of Android versions and
     // provide APIs for recommended user interface patterns.
 
-    compile "com.android.support:support-v4:19.1.+"
+    compile "com.android.support:support-v4:21.0.+"
     compile 'com.android.support:appcompat-v7:19.1.0'
 
     compile('org.simpleframework:simple-xml:2.7.1') {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -219,8 +219,7 @@ public class MainApp extends Application
             return;
         }
         NotificationUtil nm = new NotificationUtil(this.getApplicationContext());
-        Notification notification = nm.buildNotification(getText(R.string.service_name).toString(),
-                getText(R.string.service_scanning).toString(), getString(R.string.stop_scanning).toString());
+        Notification notification = nm.buildNotification(getString(R.string.service_name), getString(R.string.stop_scanning));
         mStumblerService.startForeground(NotificationUtil.NOTIFICATION_ID, notification);
         mStumblerService.startScanning();
         if (mMainActivity.get() != null) {
@@ -415,11 +414,7 @@ public class MainApp extends Application
         AppGlobals.guiLogInfo("Is motionless: " + mIsScanningPausedDueToNoMotion);
 
         NotificationUtil util = new NotificationUtil(this.getApplicationContext());
-        if (mIsScanningPausedDueToNoMotion) {
-            util.updateSubtitle(getString(R.string.map_scanning_paused_no_motion));
-        } else {
-            util.updateSubtitle(getString(R.string.service_scanning));
-        }
+        util.setPaused(mIsScanningPausedDueToNoMotion);
 
         if (mMainActivity.get() != null) {
             mMainActivity.get().isPausedDueToNoMotion(mIsScanningPausedDueToNoMotion);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -264,7 +264,8 @@ public class MainDrawerActivity
 
         int observationCount = service.getObservationCount();
         mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
-        mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(), service.getUniqueAPCount());
+        mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(),
+                service.getUniqueAPCount(), getApp().isScanningOrPaused());
 
         mMetricsView.update();
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -260,12 +260,12 @@ public class MetricsView {
         updateUploadButtonEnabled();
     }
 
-    public void setObservationCount(int observations, int cells, int wifis, boolean scanning) {
+    public void setObservationCount(int observations, int cells, int wifis, boolean isActive) {
         sThisSessionObservationsCount = observations;
         sThisSessionUniqueCellCount = cells;
         sThisSessionUniqueWifiCount = wifis;
 
         NotificationUtil util = new NotificationUtil(mView.getContext().getApplicationContext());
-        util.updateMetrics(observations, cells, wifis, mLastUploadTime, scanning);
+        util.updateMetrics(observations, cells, wifis, mLastUploadTime, isActive);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -20,6 +20,7 @@ import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.DateTimeUtils;
 import org.mozilla.mozstumbler.client.subactivities.PreferencesScreen;
+import org.mozilla.mozstumbler.client.util.NotificationUtil;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageContract;
@@ -220,7 +221,7 @@ public class MetricsView {
 
     private void updateLastUploadedLabel() {
         Context context = mView.getContext();
-        String value = (String) context.getText(R.string.metrics_observations_last_upload_time_never);
+        String value = context.getString(R.string.metrics_observations_last_upload_time_never);
         if (mLastUploadTime > 0) {
             if (Locale.getDefault().getLanguage().equals("en")) {
                 value = DateTimeUtils.prettyPrintTimeDiff(mLastUploadTime, context.getResources());
@@ -265,9 +266,12 @@ public class MetricsView {
         updateUploadButtonEnabled();
     }
 
-    public void setObservationCount(int observations, int cells, int wifis) {
+    public void setObservationCount(int observations, int cells, int wifis, boolean scanning) {
         sThisSessionObservationsCount = observations;
         sThisSessionUniqueCellCount = cells;
         sThisSessionUniqueWifiCount = wifis;
+
+        NotificationUtil util = new NotificationUtil(mView.getContext().getApplicationContext());
+        util.updateMetrics(observations, cells, wifis, mLastUploadTime, scanning);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
@@ -5,9 +5,11 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 
 import org.mozilla.mozstumbler.R;
+import org.mozilla.mozstumbler.client.DateTimeUtils;
 import org.mozilla.mozstumbler.client.MainApp;
 import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 
@@ -15,6 +17,8 @@ public class NotificationUtil {
     private final Context mContext;
     public static final int NOTIFICATION_ID = 1;
     private static String sTitle, sSubtitle, sStopTitle;
+    private static int sObservations, sCells, sWifis;
+    private static long sUploadTime;
 
     public NotificationUtil(Context context) {
         mContext = context;
@@ -29,16 +33,33 @@ public class NotificationUtil {
                 notificationIntent,
                 PendingIntent.FLAG_CANCEL_CURRENT);
 
+        String subText = mContext.getString(R.string.metrics_notification_subtext);
+        String bigText = sSubtitle + "\n" + mContext.getString(R.string.metrics_notification_bigtext);
+
+        String uploadtime = mContext.getString(R.string.metrics_observations_last_upload_time_never);
+        if (sUploadTime > 0) {
+            uploadtime = DateTimeUtils.formatTimeForLocale(sUploadTime);
+        }
+
         return new NotificationCompat.Builder(mContext)
                 .setSmallIcon(R.drawable.ic_status_scanning)
                 .setContentTitle(sTitle)
                 .setContentText(sSubtitle)
+                .setSubText(String.format(subText, sObservations, sCells, sWifis))
                 .setContentIntent(contentIntent)
                 .setOngoing(true)
                 .setPriority(NotificationCompat.PRIORITY_LOW)
-                .addAction(R.drawable.ic_action_cancel, sStopTitle
-                        , turnOffIntent)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(String.format(bigText, sObservations, sCells, sWifis, uploadtime)))
+                .addAction(R.drawable.ic_action_cancel, sStopTitle, turnOffIntent)
                 .build();
+    }
+
+    private void update() {
+        Notification notification = build();
+        NotificationManager nm = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+        nm.notify(NOTIFICATION_ID, notification);
     }
 
     public Notification buildNotification(String title, String subtitle, String stopTitle) {
@@ -50,8 +71,19 @@ public class NotificationUtil {
 
     public void updateSubtitle(String s) {
         sSubtitle = s;
-        Notification notification = build();
-        NotificationManager nm = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-        nm.notify(NOTIFICATION_ID, notification);
+        update();
+    }
+
+    public void updateMetrics(int observations, int cells, int wifis, long uploadtime, boolean scanning) {
+        sObservations = observations;
+        sCells = cells;
+        sWifis = wifis;
+        sUploadTime = uploadtime;
+
+        if (scanning) {
+            if (Build.VERSION.SDK_INT >= 16) {
+                update();
+            }
+        }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
@@ -16,9 +16,11 @@ import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 public class NotificationUtil {
     private final Context mContext;
     public static final int NOTIFICATION_ID = 1;
-    private static String sTitle, sSubtitle, sStopTitle;
+    private static final long UPDATE_FREQUENCY = 60 * 1000;
+    private static String sTitle, sStopTitle;
     private static int sObservations, sCells, sWifis;
-    private static long sUploadTime;
+    private static long sUploadTime, sDisplayTime, sLastUpdateTime;
+    private static boolean sIsPaused;
 
     public NotificationUtil(Context context) {
         mContext = context;
@@ -33,25 +35,36 @@ public class NotificationUtil {
                 notificationIntent,
                 PendingIntent.FLAG_CANCEL_CURRENT);
 
-        String subText = mContext.getString(R.string.metrics_notification_subtext);
-        String bigText = sSubtitle + "\n" + mContext.getString(R.string.metrics_notification_bigtext);
+        String stateShort, stateFull;
+        if (sIsPaused) {
+            stateShort = mContext.getString(R.string.notification_paused_short);
+            stateFull = mContext.getString(R.string.map_scanning_paused_no_motion);
+        } else {
+            stateShort = mContext.getString(R.string.notification_scanning_short);
+            stateFull = mContext.getString(R.string.service_scanning);
+        }
+        String text = mContext.getString(R.string.metrics_notification_text);
+        String bigText = mContext.getString(R.string.metrics_notification_bigtext);
 
         String uploadtime = mContext.getString(R.string.metrics_observations_last_upload_time_never);
         if (sUploadTime > 0) {
             uploadtime = DateTimeUtils.formatTimeForLocale(sUploadTime);
         }
 
+        sLastUpdateTime = System.currentTimeMillis();
+
         return new NotificationCompat.Builder(mContext)
                 .setSmallIcon(R.drawable.ic_status_scanning)
                 .setContentTitle(sTitle)
-                .setContentText(sSubtitle)
-                .setSubText(String.format(subText, sObservations, sCells, sWifis))
+                .setContentText(String.format(text, stateShort, sObservations, sCells, sWifis))
+                .setWhen(sDisplayTime)
                 .setContentIntent(contentIntent)
                 .setOngoing(true)
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setStyle(new NotificationCompat.BigTextStyle()
-                        .bigText(String.format(bigText, sObservations, sCells, sWifis, uploadtime)))
+                        .bigText(stateFull + "\n" +
+                                String.format(bigText, sObservations, sCells, sWifis, uploadtime)))
                 .addAction(R.drawable.ic_action_cancel, sStopTitle, turnOffIntent)
                 .build();
     }
@@ -62,28 +75,30 @@ public class NotificationUtil {
         nm.notify(NOTIFICATION_ID, notification);
     }
 
-    public Notification buildNotification(String title, String subtitle, String stopTitle) {
+    public Notification buildNotification(String title, String stopTitle) {
         sTitle = title;
-        sSubtitle = subtitle;
         sStopTitle = stopTitle;
+        sIsPaused = false;
+        sDisplayTime = System.currentTimeMillis();
         return build();
     }
 
-    public void updateSubtitle(String s) {
-        sSubtitle = s;
+    public void setPaused(boolean isPaused) {
+        sIsPaused = isPaused;
+        sDisplayTime = System.currentTimeMillis();
         update();
     }
 
-    public void updateMetrics(int observations, int cells, int wifis, long uploadtime, boolean scanning) {
+    public void updateMetrics(int observations, int cells, int wifis, long uploadtime, boolean isActive) {
         sObservations = observations;
         sCells = cells;
         sWifis = wifis;
         sUploadTime = uploadtime;
 
-        if (scanning) {
-            if (Build.VERSION.SDK_INT >= 16) {
-                update();
-            }
+        long diffLastUpdate = System.currentTimeMillis() - sLastUpdateTime;
+        boolean isUpdateAnimated = Build.VERSION.SDK_INT < 21;
+        if (isActive && (!isUpdateAnimated || diffLastUpdate > UPDATE_FREQUENCY)) {
+            update();
         }
     }
 }

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -43,6 +43,8 @@
         <item quantity="one">vor einem Tag</item>
         <item quantity="other">vor %d Tagen</item>
     </plurals>
+    <string name="metrics_notification_subtext">Metriken (Berichte, Funkzellen, WLAN): %1$d, %2$d, %3$d</string>
+    <string name="metrics_notification_bigtext">Berichte: %1$d\nFunkzellen: %2$d\nWLAN-Netzwerke: %3$d\nLetzter Upload: %4$s</string>
     <string name="metrics_observations_title">Berichte:</string>
     <string name="metrics_observations_wifis_title">WLAN-Netzwerke:</string>
     <string name="metrics_observations_cell_towers_title">Funkzellen:</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -9,6 +9,8 @@
     <string name="view_leaderboard">Bestenliste ansehen</string>
     <string name="service_name">Mozilla Stumbler</string>
     <string name="service_scanning">Scanne WLAN und Mobilfunknetze</string>
+    <string name="notification_scanning_short">Scanne.</string>
+    <string name="notification_paused_short">Pausiert.</string>
     <string name="enter_nickname">Namen eingeben (optional)</string>
     <string name="enter_nickname_title">Name: %1$s</string>
     <string name="enter_nickname_longtext">Dieser Name wird in der Bestenliste erscheinen.</string>
@@ -43,7 +45,7 @@
         <item quantity="one">vor einem Tag</item>
         <item quantity="other">vor %d Tagen</item>
     </plurals>
-    <string name="metrics_notification_subtext">Metriken (Berichte, Funkzellen, WLAN): %1$d, %2$d, %3$d</string>
+    <string name="metrics_notification_text">%1$s (Metriken: %2$d, %3$d, %4$d)</string>
     <string name="metrics_notification_bigtext">Berichte: %1$d\nFunkzellen: %2$d\nWLAN-Netzwerke: %3$d\nLetzter Upload: %4$s</string>
     <string name="metrics_observations_title">Berichte:</string>
     <string name="metrics_observations_wifis_title">WLAN-Netzwerke:</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="view_leaderboard">View Leaderboard</string>
     <string name="service_name">Mozilla Stumbler</string>
     <string name="service_scanning">Scanning for Wi-Fi and Cellular networks</string>
+    <string name="notification_scanning_short">Scanning.</string>
+    <string name="notification_paused_short">Paused.</string>
     <string name="enter_nickname">Enter Nickname (optional)</string>
     <string name="enter_nickname_title">Nickname: %1$s</string>
     <string name="enter_nickname_longtext">Your nickname will appear on the leaderboard.</string>
@@ -47,7 +49,8 @@
         <item quantity="one">one day ago</item>
         <item quantity="other">%d days ago</item>
     </plurals>
-    <string name="metrics_notification_subtext">Metrics (reports, cells, Wi-Fi): %1$d, %2$d, %3$d</string>
+    <!-- metrics_notification_text: %1$s refers to notification_scanning_short / notification_paused_short -->
+    <string name="metrics_notification_text">%1$s (Metrics: %2$d, %3$d, %4$d)</string>
     <string name="metrics_notification_bigtext">Reports: %1$d\nCell networks: %2$d\nWi-Fi networks: %3$d\nLast upload: %4$s</string>
     <string name="metrics_observations_title">Reports:</string>
     <string name="metrics_observations_wifis_title">Wi-Fi networks:</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
         <item quantity="one">one day ago</item>
         <item quantity="other">%d days ago</item>
     </plurals>
+    <string name="metrics_notification_subtext">Metrics (reports, cells, Wi-Fi): %1$d, %2$d, %3$d</string>
+    <string name="metrics_notification_bigtext">Reports: %1$d\nCell networks: %2$d\nWi-Fi networks: %3$d\nLast upload: %4$s</string>
     <string name="metrics_observations_title">Reports:</string>
     <string name="metrics_observations_wifis_title">Wi-Fi networks:</string>
     <string name="metrics_observations_cell_towers_title">Cell networks:</string>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 21 22:18:32 CET 2014
+#Fri Sep 19 09:56:12 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 19 09:56:12 EDT 2014
+#Fri Nov 21 22:18:32 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
This adresses #476. `Notification.BigTextStyle` was only added in API level 16. I think the notification text can only be one line though, which is a bit too short.

@garvankeeley 

> Keep in mind this code recreates the notification every time the message changes, which has the effect in the UI of the row deleting (with animation) and creating a new row, so the update should be rate limited.

There is no animation during an update on Android 5. I did not investiage yet how other devices (>= API 16) do this though.

Pulled down notification on Android 5 lock screen:
![notification](https://cloud.githubusercontent.com/assets/3845150/5151651/b1323116-71e1-11e4-9531-26a3ef50d0a9.png)
