### PR TITLE
On first start use last known location

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -145,41 +145,44 @@ public final class MapFragment extends android.support.v4.app.Fragment
         sGPSColor = getResources().getColor(R.color.gps_track);
 
         mFirstLocationFix = true;
-        int zoomLevel = DEFAULT_ZOOM;
+        int zoomLevel;
         GeoPoint lastLoc = null;
         if (savedInstanceState != null) {
-            mFirstLocationFix = false;
             zoomLevel = savedInstanceState.getInt(ZOOM_KEY, DEFAULT_ZOOM);
             if (savedInstanceState.containsKey(LAT_KEY) && savedInstanceState.containsKey(LON_KEY)) {
+                mFirstLocationFix = false;
                 final double latitude = savedInstanceState.getDouble(LAT_KEY);
                 final double longitude = savedInstanceState.getDouble(LON_KEY);
                 lastLoc = new GeoPoint(latitude, longitude);
             }
         } else {
             lastLoc = ClientPrefs.getInstance().getLastMapCenter();
-            if (lastLoc != null) {
-                zoomLevel = DEFAULT_ZOOM_AFTER_FIX;
+            zoomLevel = DEFAULT_ZOOM_AFTER_FIX;
+            if (new GeoPoint(0, 0).equals(lastLoc)) {
+                lastLoc = null;
             }
         }
 
-        final GeoPoint loc = lastLoc;
-        final int zoom = zoomLevel;
-        mMap.getController().setZoom(zoom);
-        mMap.getController().setCenter(loc);
-        mMap.setMinZoomLevel(AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel());
+        if (lastLoc != null) {
+            final GeoPoint loc = lastLoc;
+            final int zoom = zoomLevel;
+            mMap.getController().setZoom(zoom);
+            mMap.getController().setCenter(loc);
 
-        mMap.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                // https://github.com/osmdroid/osmdroid/issues/22
-                // These need a fully constructed map, which on first load seems to take a while.
-                // Post with no delay does not work for me, adding an arbitrary
-                // delay of 300 ms should be plenty.
-                Log.d(LOG_TAG, "ZOOM " + zoom);
-                mMap.getController().setZoom(zoom);
-                mMap.getController().setCenter(loc);
-            }
-        }, 300);
+            mMap.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    // https://github.com/osmdroid/osmdroid/issues/22
+                    // These need a fully constructed map, which on first load seems to take a while.
+                    // Post with no delay does not work for me, adding an arbitrary
+                    // delay of 300 ms should be plenty.
+                    Log.d(LOG_TAG, "postDelayed ZOOM " + zoom);
+                    mMap.getController().setZoom(zoom);
+                    mMap.getController().setCenter(loc);
+                }
+            }, 300);
+        }
+        mMap.setMinZoomLevel(AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel());
 
         Log.d(LOG_TAG, "onCreate");
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -12,6 +12,8 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
 
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 
 import java.lang.ref.WeakReference;
@@ -19,6 +21,7 @@ import java.lang.ref.WeakReference;
 class MapLocationListener  {
     private final WeakReference<MapFragment> mMapActivity;
     private LocationManager mLocationManager;
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MapLocationListener.class.getSimpleName());
 
     interface ReceivedLocationCallback {
         void receivedLocation();
@@ -97,6 +100,7 @@ class MapLocationListener  {
             lastLoc = mLocationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
         }
         if (lastLoc != null && mMapActivity.get() != null) {
+            Log.d(LOG_TAG, "set last known location");
             mMapActivity.get().setUserPositionAt(lastLoc);
         }
 


### PR DESCRIPTION
The last know location is set by `MapLocationListener` when calling `MapFragment.onResume()`.
