### PR TITLE
Update metrics on Reporter.ACTION_NEW_BUNDLE, not when cell/wifi counts change

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -6,7 +6,7 @@ package org.mozilla.mozstumbler.client;
 
 public interface IMainActivity {
     // Thread-safe way to update the main UI.
-    public void updateUiOnMainThread();
+    public void updateUiOnMainThread(boolean updateMetrics);
 
     // Call from main thread only
     public void setUploadState(boolean isUploadingObservations);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -239,7 +239,8 @@ public class MainDrawerActivity
                 return super.onOptionsItemSelected(item);
         }
     }
-    public void updateUiOnMainThread() {
+
+    public void updateUiOnMainThread(final boolean updateMetrics) {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -248,12 +249,12 @@ public class MainDrawerActivity
                 }
 
                 updateStartStopMenuItemState();
-                updateNumberDisplay();
+                updateNumberDisplay(updateMetrics);
             }
         });
     }
 
-    private void updateNumberDisplay() {
+    private void updateNumberDisplay(boolean updateMetrics) {
         ClientStumblerService service = getApp().getService();
         if (service == null) {
             return;
@@ -264,9 +265,11 @@ public class MainDrawerActivity
 
         int observationCount = service.getObservationCount();
         mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
-        mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(), service.getUniqueAPCount());
 
-        mMetricsView.update();
+        if (updateMetrics) {
+            mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(), service.getUniqueAPCount());
+            mMetricsView.update();
+        }
     }
 
     @Override


### PR DESCRIPTION
I noticed that UI updates always update all metrics. The UI is updated whenever a `ACTION_WIFIS_SCANNED` or `ACTION_CELLS_SCANNED` intent occurs, which is about once per second.
The current call stack looks like this:
- update the stats displayed in the map in `MainDrawerActivity.updateNumberDisplay()`
- always call `MetricsView.update()` _(this was improved)_
- call `MetricsView.updateQueuedStats()`
- call `DataStorageManager.getQueuedCounts()`

The last method for example calls `Zipper.zipData()` and has this comment:

> Some data is calculated on-demand, don't abuse this function

This PR changes the code to only update metrics stats if a bundle was flushed.
The UI updates could be differentiated a bit more even.
