### PR TITLE
MapLocationListener: wrap requestLocUpdates to catch and ignore exceptions

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -13,6 +13,7 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.widget.Toast;
 
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 
 import java.lang.ref.WeakReference;
@@ -120,11 +121,16 @@ class MapLocationListener  {
             return;
         }
 
-        if (isEnabled && !listener.mIsActive) {
-            mLocationManager.requestLocationUpdates(listener.mType, listener.mFreqMs, 0, listener);
-        } else if (!isEnabled && listener.mIsActive) {
-            mLocationManager.removeUpdates(listener);
+        try {
+            if (isEnabled && !listener.mIsActive) {
+                mLocationManager.requestLocationUpdates(listener.mType, listener.mFreqMs, 0, listener);
+            } else if (!isEnabled && listener.mIsActive) {
+                mLocationManager.removeUpdates(listener);
+            }
+        } catch (IllegalArgumentException ex) {
+            AppGlobals.guiLogError("enableLocationListener failed");
         }
+
         listener.mIsActive = isEnabled;
     }
 


### PR DESCRIPTION
Arguably, one can check if particular location providers are available (instead of catching the exception as I did here). 
This is only useful if the code then takes further useful actions based on this info. We have no interest in handling this case beyond not crashing and putting an error in the log. Why is the network provider unavailable anyway? What is the mojo on the device required to reproduce this? I tried airplane mode, restricting geolocation to GPS only.  Neither triggered this.
Issue #1311
