### PR TITLE
Fix MapLocationListener pausing GPS

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -644,7 +644,10 @@ public final class MapFragment extends android.support.v4.app.Fragment
         Log.d(LOG_TAG, "onPause");
         saveStateToPrefs();
 
-        mMapLocationListener.removeListener();
+        if (mMapLocationListener != null) {
+            mMapLocationListener.removeListener();
+            mMapLocationListener = null;
+        }
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();
         observer.removeMapActivity();
         mHighLowBandwidthChecker.unregister(this.getApplication());
@@ -739,6 +742,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
         mRootView.findViewById(R.id.scanning_paused_message).setVisibility(View.INVISIBLE);
         if (mMapLocationListener != null ) {
             mMapLocationListener.removeListener();
+            mMapLocationListener = null;
         }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -142,6 +142,7 @@ class MapLocationListener  {
         mLocationManager.removeGpsStatusListener(mSatelliteListener);
         enableLocationListener(false, mGpsLocationListener);
         enableLocationListener(false, mNetworkLocationListener);
+        mLocationManager = null;
     }
 
     public void pauseGpsUpdates(boolean isGpsOff) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -142,7 +142,6 @@ class MapLocationListener  {
         mLocationManager.removeGpsStatusListener(mSatelliteListener);
         enableLocationListener(false, mGpsLocationListener);
         enableLocationListener(false, mNetworkLocationListener);
-        mLocationManager = null;
     }
 
     public void pauseGpsUpdates(boolean isGpsOff) {


### PR DESCRIPTION
@garvankeeley This might fix #1317

How to reproduce the bug:
- start using the app
- at any point: do not move so that the scanning is paused
- **make sure that the app is not visible when you start moving and scanning is resumed**
  - e.g. enabled lockscreen (I suppose this happens a lot), use another app, press home button
- after scanning was resumed: stop scanning, press home button

Result:
- GPS is still active

I think what happens here is this:
- hiding app: `MapFragment.onPause` calls `mMapLocationListener.removeListener`
- moving after pause: `MapFragment.showPausedDueToNoMotionMessage(false)` re-enables GPS
- app becomes visible: `MapFragment.onResume` creates a new `MapLocationListener`, the reference to the old `MapLocationListener` with the active GPS is lost

This PR makes sure that `pauseGpsUpdates` does not have any effect after `removeListener` was called.
