### PR TITLE
Minor improvement regarding enabling GPS in MapLocationListener

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -108,11 +108,11 @@ class MapLocationListener  {
             mMapActivity.get().setUserPositionAt(lastLoc);
         }
 
-        enableLocationListener(true, mNetworkLocationListener);
-        enableLocationListener(true, mGpsLocationListener);
-
         if (mapFragment.getApplication().isIsScanningPausedDueToNoMotion()) {
             pauseGpsUpdates(true);
+        } else {
+            enableLocationListener(true, mNetworkLocationListener);
+            enableLocationListener(true, mGpsLocationListener);
         }
     }
 


### PR DESCRIPTION
To be improved: you can see the GPS icon blinking once when scanning is paused and the app comes to the foreground (`MapFragment.onResume`).

In `MapLocationListener` there is this code:

```
enableLocationListener(true, mNetworkLocationListener);
enableLocationListener(true, mGpsLocationListener);

if (mapFragment.getApplication().isIsScanningPausedDueToNoMotion()) {
    pauseGpsUpdates(true);
}
```

If scanning is paused, the result of what this does is this:

```
enableLocationListener(true, mNetworkLocationListener);
enableLocationListener(true, mGpsLocationListener);
// then in pauseGpsUpdates:
enableLocationListener(false, mGpsLocationListener);
enableLocationListener(true, mNetworkLocationListener);
```

The updated code in this PR only runs one of the two paths.
