### PR TITLE
Android SDK automatic installation support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ MozStumbler
 
 # Building a debug version from command line #
 
+The build system is smart enough to automatically download and install
+all the parts of the Android SDK for you.  If you cannot build, you
+can either try to fix your Android dev enviroment to fit the
+android/build.gradle requirements - or you can simply remove
+ANDROID_HOME, and all traces of your Android SDK from your PATH.
+
 ```
 make
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,14 +18,12 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.+'
-
         classpath 'org.robolectric:robolectric-gradle-plugin:0.12.+'
-
-        // Gradle download task is from: https://github.com/michel-kraemer/gradle-download-task
-        classpath 'de.undercouch:gradle-download-task:1.0'
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
 
+apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 apply plugin: 'robolectric'
 


### PR DESCRIPTION
Fix for #1162 - Android SDK is automatically installed if you haven't configured Android SDK already.
