### PR TITLE
Motion detect: The delay to wait for the gps was wrong,

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/DetectUnchangingLocation.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/DetectUnchangingLocation.java
@@ -66,7 +66,7 @@ public class DetectUnchangingLocation extends BroadcastReceiver {
 
     boolean isTimeWindowForMovementExceeded() {
         if (mLastLocation == null) {
-            return System.currentTimeMillis() - mStartTimeMs < INITIAL_DELAY_TO_WAIT_FOR_GPS_FIX_MS;
+            return System.currentTimeMillis() - mStartTimeMs > INITIAL_DELAY_TO_WAIT_FOR_GPS_FIX_MS;
         }
 
         return System.currentTimeMillis() - mPrefMotionChangeTimeWindowMs > mLastLocation.getTime();


### PR DESCRIPTION
t < initial-gps-delay, should be
t > initial-gps-delay then isTimeWindowForMovementExceeded() return true

(This delay is the time to wait for an initial gps fix after scanning has started, during this window, don't pause scanning)
