### PR TITLE
Motion Detect: had an extra wait period for first GPS fix. This logic is of no value.

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/DetectUnchangingLocation.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/DetectUnchangingLocation.java
@@ -29,7 +29,6 @@ public class DetectUnchangingLocation extends BroadcastReceiver {
     private final Context mContext;
     private Location mLastLocation;
     private final Handler mHandler = new Handler();
-    private final long INITIAL_DELAY_TO_WAIT_FOR_GPS_FIX_MS = 1000 * 60 * 5; // 5 mins
     private int mPrefMotionChangeDistanceMeters;
     private long mPrefMotionChangeTimeWindowMs;
     private long mStartTimeMs;
@@ -73,7 +72,7 @@ public class DetectUnchangingLocation extends BroadcastReceiver {
     boolean isTimeWindowForMovementExceeded() {
         if (mLastLocation == null) {
             final long timeWaited = System.currentTimeMillis() - mStartTimeMs;
-            final boolean expired = timeWaited > INITIAL_DELAY_TO_WAIT_FOR_GPS_FIX_MS;
+            final boolean expired = timeWaited > mPrefMotionChangeTimeWindowMs;
             AppGlobals.guiLogInfo("No loc., is gps wait exceeded:" + expired + " (" + timeWaited/1000.0 + "s)");
             return expired;
         }
@@ -93,7 +92,7 @@ public class DetectUnchangingLocation extends BroadcastReceiver {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);
         LocalBroadcastManager.getInstance(mContext).registerReceiver(this, intentFilter);
-        mHandler.postDelayed(mCheckTimeout, INITIAL_DELAY_TO_WAIT_FOR_GPS_FIX_MS);
+        mHandler.postDelayed(mCheckTimeout, mPrefMotionChangeTimeWindowMs);
     }
 
     public void stop() {


### PR DESCRIPTION
Removed this extra time window, and just use the existing time window,
called mPrefMotionChangeTimeWindowMs, in this code. The code is
cleaner with one time window (as it now has) instead of 2.

The reason the old code was not good, is that the extra time window to
wait for GPS fix is not any different than the existing motion change
time window, except that it was hard coded to 5 mins.

What would happen is that when scanning was started, and there is no GPS fix,
it would wait 5 mins before the motion detection logic would kick in.
This is confusing to anyone trying to understand the workings
of this code. It should be easy to grok based on the developer setting
(the setting for wait XXX seconds before pausing).

Not that we shouldn't have some logic to account for the fact the phone has not received a GPS fix: the case where the app pauses due to no location change (and stop the GPS), then the phone won't get a fix, and it could get stuck in a paused state. 
With the default 120s timeout, the only circumstance where the GPS won't get a fix when satellites are visible/fixable, is when it has no AGPS and no access to AGPS (for example, no functional SIM). This is case is exceedingly rare, and not handled. The user would be best to use Google Maps or similar to get a GPS lock, then switch to using the stumbler.
