### PR TITLE
Update Gradle to version 1.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
-        classpath 'org.robolectric:robolectric-gradle-plugin:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'org.robolectric:robolectric-gradle-plugin:0.14.+'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
@@ -49,6 +49,8 @@ android {
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 18
+
+        applicationId "org.mozilla.mozstumbler"
 
         versionCode versionMajor * 1000000 + versionMinor * 10000 + versionPatch * 100
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
@@ -95,16 +97,15 @@ android {
 
     buildTypes {
         debug {
-            jniDebugBuild true
+            jniDebuggable true
 
             // set this to false if you want your debug builds to have
             // standard unlabelled tiles.
             buildConfigField "boolean", "LABEL_MAP_TILES", "false"
-
         }
 
         release {
-            runProguard true
+            minifyEnabled true
             proguardFile 'proguard.cfg'
             signingConfig signingConfigs.release
         }
@@ -114,37 +115,6 @@ android {
         unittest {
             buildConfigField "boolean", "ROBOLECTRIC", "true"
         }
-
-
-        applicationVariants.all { variant ->
-            variant.processManifest.doLast {
-                println("configuring AndroidManifest.xml");
-                copy {
-                    from("${buildDir}/intermediates/manifests") {
-                        include "${variant.dirName}/AndroidManifest.xml"
-                    }
-                    into("${buildDir}/intermediates/filtered_manifests")
-                }
-                def manifestFile = new
-                        File("${buildDir}/intermediates/filtered_manifests/${variant.dirName}/AndroidManifest.xml")
-                def content = manifestFile.getText()
-
-                def updatedContent = content.replaceAll("ANDROID_VERSIONNAME",
-                        defaultConfig.versionName).replaceAll("ANDROID_VERSIONCODE",
-                        Long.toString(defaultConfig.versionCode))
-
-                manifestFile.write(updatedContent)
-            }
-            // This is a bit confusing, we want to swap in the
-            // filtered AndroidManifest.xml file so that we don't
-            // modify the original AndroidManifest.xml. This prevents
-            // accidental commit of the mapbox key into source
-            // control, so we actually modify the pointer in gradle.
-            variant.processResources.manifestFile = new
-                    File("${buildDir}/intermediates/filtered_manifests/${variant.dirName}/AndroidManifest.xml")
-        }
-
-
 
     }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.mozilla.mozstumbler"
-    android:versionCode="ANDROID_VERSIONCODE"
-    android:versionName="ANDROID_VERSIONNAME" >
+    package="org.mozilla.mozstumbler" >
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/android/src/main/java/org/mozilla/mozstumbler/client/PackageUtils.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/PackageUtils.java
@@ -17,7 +17,7 @@ public final class PackageUtils {
     public static String getAppVersion(Context context) {
         PackageManager pm = context.getPackageManager();
         try {
-            return pm.getPackageInfo(BuildConfig.PACKAGE_NAME, 0).versionName;
+            return pm.getPackageInfo(BuildConfig.APPLICATION_ID, 0).versionName;
         } catch (NameNotFoundException e) {
             throw new IllegalArgumentException(e);
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:0.12.2'
+		classpath 'com.android.tools.build:gradle:1.0.0'
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 19 09:56:12 EDT 2014
+#Tue Dec 09 12:48:01 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
@crankycoder This fixes #1327 
The `versionCode` and `versionName` are set automatically from the `build.gradle` file, so I removed the custom code.
Regarding the `PackageUtils` change: for testing I modified the version and `applicationId` and checked if the app version was still displayed correctly. Everything seems fine.
Do you see any problems with this?
