### PR TITLE
Features/1294 rebased sensor tests

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -42,6 +42,8 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellS
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploadParam;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
+import org.mozilla.mozstumbler.svclocator.ServiceConfig;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.osmdroid.tileprovider.constants.TileFilePath;
 
 import java.io.File;
@@ -116,6 +118,10 @@ public class MainApp extends Application
         super.onCreate();
         // The following line triggers the initialization of ACRA
         ACRA.init(this);
+
+        // Bootstrap the service locator with the default list of services
+        ServiceLocator rootLocator = ServiceLocator.newRoot(ServiceConfig.defaultServiceConfig());
+        ServiceLocator.setRootInstance(rootLocator);
 
         // This must be called after init to get a copy of the
         // original ACRA.log instance so that we can toggle the logger on

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
@@ -24,7 +24,7 @@ import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.MainApp;
 import org.mozilla.mozstumbler.client.serialize.KMLFragment;
 import org.mozilla.mozstumbler.service.AppGlobals;
-import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.DetectUnchangingLocation;
+import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.LocationChangeSensor;
 import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.MotionSensor;
 import org.mozilla.mozstumbler.service.utils.BatteryCheckReceiver;
 
@@ -60,7 +60,7 @@ public class DeveloperActivity extends ActionBarActivity {
                             a.hashCode();
                             break;
                         case 1:
-                            DetectUnchangingLocation.debugSendLocationUnchanging();
+                            LocationChangeSensor.debugSendLocationUnchanging();
                             break;
                         case 2:
                             MotionSensor.debugMotionDetected();

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
@@ -32,7 +32,6 @@ public class LegacyMotionSensor {
     // I'm assuming 30 iterations is good enough to get convergence.
     private static int iterations_for_convergence = 30;
     private final float alpha = (float) 0.8;
-    private static final float converged_accel_epsilon = (float) 0.3;
 
     public LegacyMotionSensor(Context ctx)
     {
@@ -61,6 +60,11 @@ public class LegacyMotionSensor {
                     gravity[2] * gravity[2]);
 
             if (iterations_for_convergence > 0) {
+                // We don't use an epsilon to detect convergence because imperically
+                // devices don't seem to comply to the 0.05m/s^2 error that Google
+                // specifies.  The Motorola XT1032 seems to get ~10.10 m/s^s for gravity
+                // when it's tilted to stand on it's edge.  When laid flat,
+                // it gets pretty close with 9.89m/s^2 which is still far from 9.81m/s^2
                 iterations_for_convergence--;
                 return;
             }
@@ -75,7 +79,6 @@ public class LegacyMotionSensor {
         float z = linear_acceleration[2];
 
         final float accel = FloatMath.sqrt(x * x + y * y + z * z);
-        Log.d(LOG_TAG, "Got acceleration of " + accel);
 
         // I found this to be a very low threshold, slight movements of the device are greater than 1.0.
         // False positives are fine, what we don't want is devices that can't be woken up easily.

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -13,7 +13,7 @@ import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
-import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.DetectUnchangingLocation;
+import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.LocationChangeSensor;
 import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.MotionSensor;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.WifiBlockListInterface;
@@ -38,7 +38,7 @@ public class ScanManager {
     private BatteryCheckReceiver mPassiveModeBatteryChecker;
     private enum PassiveModeBatteryState { OK, LOW, IGNORE_BATTERY_STATE }
     private PassiveModeBatteryState mPassiveModeBatteryState;
-    private DetectUnchangingLocation mDetectUnchangingLocation;
+    private LocationChangeSensor mLocationChangeSensor;
     private MotionSensor mMotionSensor;
     private boolean mIsMotionlessPausedState;
 
@@ -120,10 +120,10 @@ public class ScanManager {
 
         mIsMotionlessPausedState = false;
 
-        if (mDetectUnchangingLocation == null) {
-            mDetectUnchangingLocation = new DetectUnchangingLocation(mContext, mDetectUserIdleReceiver);
+        if (mLocationChangeSensor == null) {
+            mLocationChangeSensor = new LocationChangeSensor(mContext, mDetectUserIdleReceiver);
         }
-        mDetectUnchangingLocation.start();
+        mLocationChangeSensor.start();
 
         if (mMotionSensor == null) {
             mMotionSensor = new MotionSensor(mContext, mDetectMotionReceiver);
@@ -159,7 +159,7 @@ public class ScanManager {
         }
 
         mIsMotionlessPausedState = false;
-        mDetectUnchangingLocation.stop();
+        mLocationChangeSensor.stop();
         mMotionSensor.stop();
 
         mGPSScanner.stop();
@@ -228,7 +228,7 @@ public class ScanManager {
             startScanning(context);
             mMotionSensor.stop();
 
-            mDetectUnchangingLocation.quickCheckForFalsePositiveAfterMotionSensorMovement();
+            mLocationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement();
 
             Intent sendIntent = new Intent(ACTION_SCAN_PAUSED_USER_MOTIONLESS);
             sendIntent.putExtra(ACTION_EXTRA_IS_PAUSED, mIsMotionlessPausedState);

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.svclocator;
+
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.SystemClock;
+import org.mozilla.osmdroid.api.IGeoPoint;
+
+import java.util.HashMap;
+
+public class ServiceConfig extends HashMap<Class<?>, Object> {
+
+    private static final long serialVersionUID = 1111111111L;
+
+    public static ServiceConfig defaultServiceConfig() {
+
+        ServiceConfig result = new ServiceConfig();
+
+        result.put(ISystemClock.class, new SystemClock());
+
+        return result;
+    }
+
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceLocator.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceLocator.java
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.svclocator;
+
+import java.util.HashMap;
+
+public class ServiceLocator {
+
+    private ServiceConfig svcMap = new ServiceConfig();
+    private ServiceLocator parentLocator = null;
+
+    private static ServiceLocator instance = null;
+
+
+    public static synchronized ServiceLocator newRoot(ServiceConfig newMap) {
+        ServiceLocator svcLocator = new ServiceLocator(null);
+        svcLocator.svcMap = newMap;
+        return svcLocator;
+    }
+
+    public static synchronized void setRootInstance(ServiceLocator root) {
+        instance = root;
+    }
+
+    public static synchronized ServiceLocator getInstance() {
+        return instance;
+    }
+
+    public ServiceLocator(ServiceLocator parent) {
+        parentLocator = parent;
+    }
+
+    public Object getService(Class<?> svcInterface) {
+        Object result = null;
+
+        if (svcMap.containsKey(svcInterface)) {
+            return svcMap.get(svcInterface);
+        }
+
+        if (parentLocator != null) {
+            result = parentLocator.getService(svcInterface);
+        }
+        return result;
+    }
+
+    public void putService(Class<?> svcInterface, Object obj) {
+        svcMap.put(svcInterface, obj);
+    }
+
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/ISystemClock.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/ISystemClock.java
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.svclocator.services;
+
+/*
+ This interface provides interfaces to time related methods.
+
+ */
+public interface ISystemClock {
+
+    // Implementations should provide an implementation of System.currentTimeMillis
+    public long currentTimeMillis();
+
+
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/MockSystemClock.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/MockSystemClock.java
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.svclocator.services;
+
+public class MockSystemClock implements ISystemClock {
+
+    private long currentTime;
+
+    public void setCurrentTime(long currentTime) {
+        this.currentTime = currentTime;
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return currentTime;
+    }
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/SystemClock.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/SystemClock.java
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.svclocator.services;
+
+public class SystemClock implements ISystemClock {
+
+    @Override
+    public long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
@@ -56,7 +56,7 @@ public class ReporterTest {
         // The Reporter class needs a reference to a context
         rp.startup(ctx);
 
-        Intent gpsUpdated = getLocationIntent();
+        Intent gpsUpdated = getLocationIntent(0, 0);
         rp.onReceive(ctx, gpsUpdated);
         assertTrue(null != rp.getGPSLocation());
     }
@@ -188,10 +188,17 @@ public class ReporterTest {
         return scan;
     }
 
-    private Intent getLocationIntent() {
+    public static Intent getLocationIntent(double lat, double lon) {
+
+        if (lat == 0) {
+            lat = 20;
+        }
+        if (lon == 0) {
+            lon = 30;
+        }
         Location location = new Location("mock");
-        location.setLongitude(20);
-        location.setLatitude(30);
+        location.setLongitude(lat);
+        location.setLatitude(lon);
         Intent i = new Intent(GPSScanner.ACTION_GPS_UPDATED);
         i.putExtra(Intent.EXTRA_SUBJECT, GPSScanner.SUBJECT_NEW_LOCATION);
         i.putExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION, location);

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/CustomShadowLocationManager.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/CustomShadowLocationManager.java
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.service.stumblerthread.motiondetection;
+
+import android.location.LocationManager;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowLocationManager;
+
+@Implements(LocationManager.class)
+public class CustomShadowLocationManager extends ShadowLocationManager {
+
+    @Implementation
+    public android.location.LocationProvider getProvider(java.lang.String name) {
+        return null;
+    }
+
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/CustomShadowWifiManager.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/CustomShadowWifiManager.java
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.service.stumblerthread.motiondetection;
+
+import android.net.wifi.WifiManager;
+import android.os.Build;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowWifiManager;
+
+@Implements(WifiManager.class)
+public class CustomShadowWifiManager extends ShadowWifiManager {
+
+    @Implementation
+    public boolean isWifiEnabled() {
+        return true;
+    }
+
+    @Implementation
+    public boolean isScanAlwaysAvailable() {
+        return true;
+    }
+
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.mozstumbler.service.stumblerthread.motiondetection;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.location.Location;
+import android.support.v4.content.LocalBroadcastManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.Prefs;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.MockSystemClock;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.LinkedList;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mozilla.mozstumbler.service.stumblerthread.ReporterTest.getLocationIntent;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class LocationChangeSensorTest {
+
+    private static final String LOG_TAG = AppGlobals.makeLogTag(LocationChangeSensorTest.class);
+    private LocationChangeSensor locationChangeSensor;
+
+    private LinkedList<Intent> receivedIntent = new LinkedList<Intent>();
+
+    // After DetectUnchangingLocation reports the user is not moving, and the scanning pauses,
+    // then use MotionSensor to determine when to wake up and start scanning again.
+    private final BroadcastReceiver callbackReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            // Just capture the intent for testing
+            receivedIntent.add(intent);
+        }
+    };
+    private Context ctx;
+    private MockSystemClock clock;
+
+    @Before
+    public void setup() {
+        ctx = Robolectric.application;
+
+        ServiceLocator rootLocator = new ServiceLocator(null);
+
+        clock = new MockSystemClock();
+        rootLocator.putService(ISystemClock.class, clock);
+        ServiceLocator.setRootInstance(rootLocator);
+        clock.setCurrentTime(0);
+        receivedIntent.clear();
+
+        // Register a listener for each of the intents that are used by motion detection
+
+        // TODO: move the intents into a single location for the package so that we know where to
+        // find them all.
+        LocalBroadcastManager.getInstance(ctx).registerReceiver(callbackReceiver,
+                new IntentFilter(MotionSensor.ACTION_USER_MOTION_DETECTED));
+        LocalBroadcastManager.getInstance(ctx).registerReceiver(callbackReceiver,
+                new IntentFilter(LocationChangeSensor.ACTION_LOCATION_NOT_CHANGING));
+
+        locationChangeSensor = new LocationChangeSensor(
+                ctx,
+                callbackReceiver);
+
+        // Set the minimum change distance to be very large
+        Prefs.getInstance().setMotionChangeDistanceMeters(10000);
+        //
+        // start the sensor
+        locationChangeSensor.start();
+    }
+
+    @Test
+    public void testStartMotionDetectionAfterFirstGPSLock() {
+        // Motion detection should start only after the first GPS lock is acquired.
+
+        // Note that this is not the same as having 'start()' called.   This means that
+        // we are waiting for mPrefMotionChangeTimeWindowMs for the next GPS signal or else
+        // we go to sleep.
+
+        assertFalse(locationChangeSensor.checkTimeScheduled);
+
+        Intent intent = getLocationIntent(0, 0);
+        locationChangeSensor.onReceive(ctx, intent);
+        assertTrue(locationChangeSensor.checkTimeScheduled);
+    }
+
+    @Test
+    public void testNotFirstGPSFix_MovedDistance() {
+        Intent intent;
+        Location expectedPosition;
+        // The second GPS fix must have movement > mPrefMotionChangeDistanceMeters
+        // for the saved location to be updated.
+
+        // If the second GPS fix is too soon, the accelerometers are registering movement
+        // but the person hasn't actually moved geographically.  Keep the scanners on
+        // and schedule the next timeout check to see if the user just stops moving around.
+
+        assertFalse(locationChangeSensor.checkTimeScheduled);
+
+        intent = getLocationIntent(20, 30);
+        expectedPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
+        locationChangeSensor.onReceive(ctx, intent);
+        assertEquals(expectedPosition, locationChangeSensor.mLastLocation);
+
+        intent = getLocationIntent(21, 30);
+        locationChangeSensor.onReceive(ctx, intent);
+
+        // The new recorded position should be 21, 30
+        expectedPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
+        assertEquals(expectedPosition, locationChangeSensor.mLastLocation);
+    }
+
+    @Test
+    public void testNotFirstGPSFix_LongWaitForSecondFix() {
+        // If the second fix that comes in arrives late (> time window for movement pref),
+        // then we assume the user isn't actually moving.
+        // Send off a ACTION_LOCATION_NOT_CHANGING intent.
+
+        // The callback receiver passed in the constructor to the DetectUnchangingLocationTest
+        // should get the ACTION_LOCATION_NOT_CHANGING intent
+        Intent intent;
+        Location expectedPosition;
+
+
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        assertFalse(locationChangeSensor.checkTimeScheduled);
+
+        intent = getLocationIntent(20, 30);
+        expectedPosition = intent.getParcelableExtra(GPSScanner.NEW_LOCATION_ARG_LOCATION);
+        locationChangeSensor.onReceive(ctx, intent);
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        assertEquals(expectedPosition, locationChangeSensor.mLastLocation);
+
+        intent = getLocationIntent(20.01, 30.01);
+
+        // Muck about with the time and move to the end of time
+        clock.setCurrentTime(Long.MAX_VALUE);
+        locationChangeSensor.onReceive(ctx, intent);
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        // The new recorded position should not be changed!
+        assertEquals(expectedPosition, locationChangeSensor.mLastLocation);
+
+        boolean foundIntent = false;
+
+        for (Intent capturedIntent: receivedIntent) {
+            if (capturedIntent.getAction().equals(LocationChangeSensor.ACTION_LOCATION_NOT_CHANGING)) {
+                foundIntent = true;
+            }
+        }
+        assertTrue(foundIntent);
+    }
+
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,76 @@
+Testing
+=======
+
+Testing for the Mozilla Stumbler is handled through several tools that
+work together.
+
+We use roboelectric to run fast unit tests within a regular JVM.  This
+is not 100% problem free, but it allows your tests to run fast.
+
+We use a Service Locator pattern
+(http://martinfowler.com/articles/injection.html#UsingAServiceLocator)
+to inject dependencies at runtime.
+
+We are currently investigating the use of robotium to instrument the
+full client application to get more realistic tests that run on a real
+Android VM where good tests cannot be written using robolectric.
+
+
+Robolectric for dummies
+-----------------------
+
+Testing in Android is just hard.  The standard test tools run slowly
+so we use robolectric to run tests quickly on a regular JVM. This lets
+your tests run in seconds instead of minutes. 
+
+Robolectric provides `Shadow` classes for all Android classes in the
+`android.*` namespace.  A `Shadow` can be though of as a
+mock implementation of the equivalent Android class. 
+
+Robolectric tests run within JUnit4.  You need to provide extra
+annotations to tell Robolectric to run with a custom test runner, a
+target SDK and any custom shadow you may have.
+
+Limitations
+-----------
+
+Roboelectric 2.4 only supports up to Android API level 18 
+(Jelly Bean MR2).
+
+Shadow classes explicitly implements stubs to methods that will be
+shadowed.  In some cases, you will need to fork and extend the
+roboelectric project and install your own robolectric JAR file.  In
+that case, you will need to also update your android/build.gradle file
+to use `mavenLocal()` as a depdendency repository after doing a `mvn
+install` for your custom robolectric build.
+
+In many cases, you will want to customize the behavior of an Android
+class.  Typically, the solution to this is that you will want to
+subclass a `Shadow` implementation, and then annotate your test so
+that your custom shadow is used.
+
+Examples
+--------
+
+A good basic example can be found in LogActivityTest at:
+
+TODO: update this link to the primary Mozilla Stumbler repository:
+
+https://github.com/crankycoder/MozStumbler/blob/features/1294-motion-sensor-tests/android/src/test/java/org/mozilla/mozstumbler/client/subactivities/LogActivityTest.java#L31
+
+You will find an example there of loading a custom shadow to provide
+specialized behavior as well as the standard annotations you will need
+for your tests to run.
+
+
+After your tests are run, you will get an HTML report.  If you run the
+testGithubUnittest target, your HTML output will appear in :
+
+`android/build/test-report/github/unittest/index.html`
+
+Android Studio integration
+--------------------------
+
+TODO: Get instructions from here :
+
+http://blog.blundell-apps.com/how-to-run-robolectric-junit-tests-in-android-studio/


### PR DESCRIPTION
This closes off #1294 to add basic tests around the sensor code.

This adds basic roboelectric test coverage to the CellScanner and WifiScanner classes.

The primary goal of this is to get some concrete examples of using roboelectric and custom shadow classes to exercise the stumbler code.

Some preliminary documentation has been added into docs/testing.md, but it's still best to look at the example code to see how to write tests. 

We still need to get robotium tests for things where roboelectric's mocking system isn't sufficient and we need a real Android VM to test on.
