### PR TITLE
Use different application ID for debug builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,6 +98,8 @@ android {
     buildTypes {
         debug {
             jniDebuggable true
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
 
             // set this to false if you want your debug builds to have
             // standard unlabelled tiles.


### PR DESCRIPTION
@crankycoder This fixes #1201 (or at least this is what I had in mind when I filed that issue).
It allows to install clean debug app versions (including version downgrades) while keeping the release version and all its data separately.
