### PR TITLE
#1201 use different application ID for debug builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,7 +99,6 @@ android {
         debug {
             jniDebuggable true
             applicationIdSuffix ".debug"
-            versionNameSuffix "-debug"
 
             // set this to false if you want your debug builds to have
             // standard unlabelled tiles.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,6 +98,8 @@ android {
     buildTypes {
         debug {
             jniDebuggable true
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
 
             // set this to false if you want your debug builds to have
             // standard unlabelled tiles.

--- a/android/src/debug/res/values/strings.xml
+++ b/android/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Debug Stumbler</string>
+</resources>


### PR DESCRIPTION
This is a minor update to #1339.

This patch will change the applicationId for debug builds as well as using "Debug Stumbler" as the app_name so that it's easy to identify release vs debug builds of the stumbler on your launcher.

I've removed the change to the versionName as I don't see any benefit to messing with versions when the applicationId is completely different anyway.
