### PR TITLE
Changed prefs to getInstance(Context) and the less-safe getInstanceWithoutContext()

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -31,16 +31,16 @@ public class ClientPrefs extends Prefs {
         super(context);
     }
 
-    public static synchronized ClientPrefs createGlobalInstance(Context c) {
-        if (sInstance == null) {
+    public static synchronized ClientPrefs getInstance(Context c) {
+        if (sInstance == null || sInstance.getClass() != ClientPrefs.class) {
             sInstance = new ClientPrefs(c);
         }
         return (ClientPrefs) sInstance;
     }
 
-    public static synchronized ClientPrefs getInstance() {
-        if (sInstance != null && sInstance.getClass().isInstance(ClientPrefs.class)) {
-            throw new IllegalArgumentException("sInstance is improperly initialized");
+    public static synchronized ClientPrefs getInstanceWithoutContext() {
+        if (sInstance != null && sInstance.getClass() != ClientPrefs.class) {
+            return null;
         }
         return (ClientPrefs) sInstance;
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -30,7 +30,7 @@ public class ClientStumblerService extends StumblerService {
         private boolean waitForBatteryOkBeforeSendingNotification;
         @Override
         public void batteryCheckCallback(BatteryCheckReceiver receiver) {
-            int minBattery = ClientPrefs.getInstance().getMinBatteryPercent();
+            int minBattery = ClientPrefs.getInstance(ClientStumblerService.this).getMinBatteryPercent();
             boolean isLow = receiver.isBatteryNotChargingAndLessThan(minBattery);
             if (isLow && !waitForBatteryOkBeforeSendingNotification) {
                 waitForBatteryOkBeforeSendingNotification = true;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -86,8 +86,8 @@ public class MainApp extends Application
         }
     };
 
-    public ClientPrefs getPrefs() {
-        return ClientPrefs.getInstance();
+    public ClientPrefs getPrefs(Context c) {
+        return ClientPrefs.getInstance(c);
     }
 
     public ClientStumblerService getService() {
@@ -145,7 +145,9 @@ public class MainApp extends Application
             oldPrefs.renameTo(new File(dir, ClientPrefs.getPrefsFileNameForUpgrade()));
         }
 
-        Prefs prefs = ClientPrefs.createGlobalInstance(this);
+        // Doing this onCreate ensures that a ClientPrefs is instantiated for the whole app.
+        // Don't remove this.
+        ClientPrefs prefs = ClientPrefs.getInstance(this);
         prefs.setMozApiKey(BuildConfig.MOZILLA_API_KEY);
         String userAgent = System.getProperty("http.agent") + " " +
                 AppGlobals.appName + "/" + AppGlobals.appVersionName;
@@ -249,9 +251,9 @@ public class MainApp extends Application
 
         AsyncUploader uploader = new AsyncUploader();
         AsyncUploadParam param = new AsyncUploadParam(
-                ClientPrefs.getInstance().getUseWifiOnly(),
-                Prefs.getInstance().getNickname(),
-                Prefs.getInstance().getEmail());
+                ClientPrefs.getInstance(this).getUseWifiOnly(),
+                Prefs.getInstance(this).getNickname(),
+                Prefs.getInstance(this).getEmail());
 
         uploader.execute(param);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -68,8 +68,13 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
         @Override
         public void run() {
             synchronized (ObservedLocationsReceiver.this) {
+                ClientPrefs prefs = ClientPrefs.getInstanceWithoutContext();
+                if (prefs == null) {
+                    return;
+                }
                 mHandler.postDelayed(mFetchMLSRunnable, FREQ_FETCH_MLS_MS);
-                if (mQueuedForMLS.size() < 1 || !ClientPrefs.getInstance().getOnMapShowMLS()) {
+                if (mQueuedForMLS.size() < 1 ||
+                    !prefs.getOnMapShowMLS()) {
                     return;
                 }
                 int count = 0;
@@ -106,6 +111,11 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
 
     @Override
     public synchronized void onReceive(Context context, Intent intent) {
+        ClientPrefs prefs = ClientPrefs.getInstanceWithoutContext();
+        if (prefs == null) {
+            return;
+        }
+
         final String action = intent.getAction();
         if (!action.equals(Reporter.ACTION_NEW_BUNDLE)) {
             return;
@@ -126,7 +136,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             JSONObject jsonBundle = bundle.toMLSJSON();
             observation.setCounts(jsonBundle);
 
-            boolean getInfoForMLS = ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap();
+            boolean getInfoForMLS = prefs.isOptionEnabledToShowMLSOnMap();
             if (getInfoForMLS) {
                 observation.setMLSQuery(jsonBundle);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -37,8 +37,8 @@ public class Updater {
         httpClient = httpUtil;
     }
 
-    public boolean wifiExclusiveAndUnavailable() {
-        return !NetworkInfo.getInstance().isWifiAvailable() && ClientPrefs.getInstance().getUseWifiOnly();
+    public boolean wifiExclusiveAndUnavailable(Context c) {
+        return !NetworkInfo.getInstance().isWifiAvailable() && ClientPrefs.getInstance(c).getUseWifiOnly();
     }
 
 
@@ -50,7 +50,7 @@ public class Updater {
         }
 
         // No wifi available and require the use of wifi only means skip
-        if (wifiExclusiveAndUnavailable()) {
+        if (wifiExclusiveAndUnavailable(activity.getApplicationContext())) {
             return false;
         }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -156,7 +156,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
                 lastLoc = new GeoPoint(latitude, longitude);
             }
         } else {
-            lastLoc = ClientPrefs.getInstance().getLastMapCenter();
+            lastLoc = ClientPrefs.getInstance(mRootView.getContext()).getLastMapCenter();
             zoomLevel = DEFAULT_ZOOM_AFTER_FIX;
             if (new GeoPoint(0, 0).equals(lastLoc)) {
                 lastLoc = null;
@@ -246,8 +246,10 @@ public final class MapFragment extends android.support.v4.app.Fragment
             final Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
+                    final ClientPrefs.MapTileResolutionOptions resolution =
+                            ClientPrefs.getInstance(mRootView.getContext()).getMapTileResolutionType();
                     if (mCoverageTilesOverlayLowZoom != null ||  // checks if init() has already happened
-                        ClientPrefs.getInstance().getMapTileResolutionType() == ClientPrefs.MapTileResolutionOptions.NoMap) {
+                        resolution == ClientPrefs.MapTileResolutionOptions.NoMap) {
                         return;
                     }
                     initCoverageTiles(sCoverageUrl);
@@ -375,7 +377,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
     // we need an additional "LowZoom" overlay. So in low bandwidth mode, you will see
     // that based on the current zoom level of the map, we show "HighZoom" or "LowZoom" overlays.
     private void setHighBandwidthMap(boolean isHighBandwidth) {
-        final ClientPrefs prefs = ClientPrefs.getInstance();
+        final ClientPrefs prefs = ClientPrefs.getInstance(mRootView.getContext());
         if (prefs == null || getActivity() == null) {
             return;
         }
@@ -619,7 +621,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
 
         mHighLowBandwidthChecker = new HighLowBandwidthReceiver(this);
 
-        ClientPrefs prefs = ClientPrefs.createGlobalInstance(getActivity().getApplicationContext());
+        ClientPrefs prefs = ClientPrefs.getInstance(getActivity().getApplicationContext());
         setShowMLS(prefs.getOnMapShowMLS());
 
         mObservationPointsOverlay.zoomChanged(mMap);
@@ -628,7 +630,7 @@ public final class MapFragment extends android.support.v4.app.Fragment
 
     private void saveStateToPrefs() {
         IGeoPoint center = mMap.getMapCenter();
-        ClientPrefs.getInstance().setLastMapCenter(center);
+        ClientPrefs.getInstance(mRootView.getContext()).setLastMapCenter(center);
     }
 
     @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -54,8 +54,9 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
         if (mMLSQuery == null || pointMLS != null || mIsMLSLocationQueryRunning) {
             return;
         }
-        ClientPrefs prefs = ClientPrefs.getInstance();
-        if (prefs.getUseWifiOnly() && !NetworkInfo.getInstance().isWifiAvailable()) {
+        ClientPrefs prefs = ClientPrefs.getInstanceWithoutContext();
+        if (prefs == null ||
+           (prefs.getUseWifiOnly() && !NetworkInfo.getInstance().isWifiAvailable())) {
             return;
         }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -156,7 +156,7 @@ public class MainDrawerActivity
             return;
         }
         if (svc.isScanning()) {
-            keepScreenOn(ClientPrefs.getInstance().getKeepScreenOn());
+            keepScreenOn(ClientPrefs.getInstance(this).getKeepScreenOn());
         } else {
             keepScreenOn(false);
         }
@@ -197,7 +197,7 @@ public class MainDrawerActivity
         super.onPostResume();
         mMetricsView.update();
 
-        if (ClientPrefs.getInstance().isFirstRun()) {
+        if (ClientPrefs.getInstance(this).isFirstRun()) {
             FragmentManager fm = getSupportFragmentManager();
             FirstRunFragment.showInstance(fm);
         } else if (!MainApp.getAndSetHasBootedOnce()) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -77,7 +77,7 @@ public class MetricsView {
         mOnMapShowMLS.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ClientPrefs.getInstance().setOnMapShowMLS(mOnMapShowMLS.isChecked());
+                ClientPrefs.getInstance(mView.getContext()).setOnMapShowMLS(mOnMapShowMLS.isChecked());
                 if (mMapLayerToggleListener.get() != null) {
                     mMapLayerToggleListener.get().setShowMLS(mOnMapShowMLS.isChecked());
                 }
@@ -104,8 +104,8 @@ public class MetricsView {
                 // and have it handled by MainApp
                 AsyncUploader uploader = new AsyncUploader();
                 AsyncUploadParam param = new AsyncUploadParam(false /* useWifiOnly */,
-                    Prefs.getInstance().getNickname(),
-                    Prefs.getInstance().getEmail());
+                    Prefs.getInstance(mView.getContext()).getNickname(),
+                    Prefs.getInstance(mView.getContext()).getEmail());
                 uploader.execute(param);
 
                 setUploadButtonToSyncing(true);
@@ -129,7 +129,7 @@ public class MetricsView {
 
     public void setMapLayerToggleListener(IMapLayerToggleListener listener) {
         mMapLayerToggleListener = new WeakReference<IMapLayerToggleListener>(listener);
-        mOnMapShowMLS.setChecked(ClientPrefs.getInstance().getOnMapShowMLS());
+        mOnMapShowMLS.setChecked(ClientPrefs.getInstance(mView.getContext()).getOnMapShowMLS());
     }
 
 
@@ -180,7 +180,7 @@ public class MetricsView {
     }
 
     public void onOpened() {
-        if (ClientPrefs.getInstance().isOptionEnabledToShowMLSOnMap()) {
+        if (ClientPrefs.getInstance(mView.getContext()).isOptionEnabledToShowMLSOnMap()) {
             mOnMapShowMLS.setVisibility(View.VISIBLE);
         } else {
             mOnMapShowMLS.setVisibility(View.GONE);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
@@ -66,7 +66,7 @@ public class DeveloperActivity extends ActionBarActivity {
                             MotionSensor.debugMotionDetected();
                             break;
                         case 3:
-                            int pct = ClientPrefs.getInstance().getMinBatteryPercent();
+                            int pct = ClientPrefs.getInstance(DeveloperActivity.this).getMinBatteryPercent();
                             BatteryCheckReceiver.debugSendBattery(pct - 1);
                             break;
                         case 4:
@@ -92,12 +92,13 @@ public class DeveloperActivity extends ActionBarActivity {
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             mRootView = inflater.inflate(R.layout.fragment_developer_options, container, false);
 
+            final ClientPrefs prefs = ClientPrefs.getInstance(mRootView.getContext());
             final Spinner batterySpinner = (Spinner) mRootView.findViewById(R.id.spinnerBatteryPercent);
             final SpinnerAdapter spinnerAdapter = batterySpinner.getAdapter();
             assert(spinnerAdapter instanceof ArrayAdapter);
             @SuppressWarnings("unchecked")
             final ArrayAdapter<String> adapter = (ArrayAdapter<String>)spinnerAdapter;
-            final int percent = ClientPrefs.getInstance().getMinBatteryPercent();
+            final int percent = prefs.getMinBatteryPercent();
             final int spinnerPosition = adapter.getPosition(percent + "%");
             batterySpinner.setSelection(spinnerPosition);
 
@@ -106,7 +107,6 @@ public class DeveloperActivity extends ActionBarActivity {
                 public void onItemSelected(AdapterView<?> parent, View arg1, int position, long id) {
                     String item = parent.getItemAtPosition(position).toString().replace("%", "");
                     int percent = Integer.valueOf(item);
-                    ClientPrefs prefs = ClientPrefs.createGlobalInstance(getActivity().getApplicationContext());
                     prefs.setMinBatteryPercent(percent);
                 }
 
@@ -119,7 +119,7 @@ public class DeveloperActivity extends ActionBarActivity {
                     new ArrayAdapter<String>(this.getActivity(), android.R.layout.simple_spinner_item, distanceArray);
             final Spinner distanceSpinner = (Spinner) mRootView.findViewById(R.id.spinnerMotionDetectionDistanceMeters);
             distanceSpinner.setAdapter(distanceAdapter);
-            final int dist = ClientPrefs.getInstance().getMotionChangeDistanceMeters();
+            final int dist = prefs.getMotionChangeDistanceMeters();
             distanceSpinner.setSelection(findIndexOf(dist, distanceArray));
 
             distanceSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -137,7 +137,7 @@ public class DeveloperActivity extends ActionBarActivity {
                     new ArrayAdapter<String>(this.getActivity(), android.R.layout.simple_spinner_item, timeArray);
             final Spinner timeSpinner = (Spinner) mRootView.findViewById(R.id.spinnerMotionDetectionTimeSeconds);
             timeSpinner.setAdapter(timeAdapter);
-            final int time = ClientPrefs.getInstance().getMotionChangeTimeWindowSeconds();
+            final int time = prefs.getMotionChangeTimeWindowSeconds();
             timeSpinner.setSelection(findIndexOf(time, timeArray));
 
             timeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -157,7 +157,7 @@ public class DeveloperActivity extends ActionBarActivity {
         private void changeOfMotionDetectionDistanceOrTime(AdapterView<?> parent, int position, IsDistanceOrTime isDistanceOrTime) {
             String item = parent.getItemAtPosition(position).toString();
             int val = Integer.valueOf(item.substring(0, item.indexOf(" ")));
-            ClientPrefs prefs = ClientPrefs.createGlobalInstance(getActivity().getApplicationContext());
+            ClientPrefs prefs = ClientPrefs.getInstance(getActivity().getApplicationContext());
             if (isDistanceOrTime == IsDistanceOrTime.DISTANCE) {
                 prefs.setMotionChangeDistanceMeters(val);
             } else {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FirstRunFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FirstRunFragment.java
@@ -47,7 +47,7 @@ public class FirstRunFragment extends DialogFragment {
             @Override
             public void onClick(View v) {
                 ((MainApp) getActivity().getApplication()).startScanning();
-                ClientPrefs.getInstance().setFirstRun(false);
+                ClientPrefs.getInstance(getActivity()).setFirstRun(false);
 
                 Dialog d = getDialog();
                 if (d != null) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LeaderboardActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LeaderboardActivity.java
@@ -66,10 +66,7 @@ public class LeaderboardActivity extends ActionBarActivity {
         });
 
         setProgress(0);
-        ClientPrefs prefs = ClientPrefs.getInstance();
-        if (prefs == null) {
-            prefs = ClientPrefs.createGlobalInstance(this.getApplicationContext());
-        }
+        ClientPrefs prefs = ClientPrefs.getInstance(getApplicationContext());
         String nick = prefs.getNickname();
         String url = LEADERBOARD_URL;
         if (nick != null) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -34,11 +34,7 @@ public class PreferencesScreen extends PreferenceActivity {
     private ListPreference mMapTileDetail;
 
     private ClientPrefs getPrefs() {
-        ClientPrefs prefs = ClientPrefs.getInstance();
-        if (prefs == null) {
-            prefs = ClientPrefs.createGlobalInstance(getApplicationContext());
-        }
-        return prefs;
+        return ClientPrefs.getInstance(this);
     }
 
     @SuppressWarnings("deprecation")
@@ -57,7 +53,7 @@ public class PreferencesScreen extends PreferenceActivity {
         mEnableShowMLSLocations = (CheckBoxPreference) getPreferenceManager().findPreference(ClientPrefs.ENABLE_OPTION_TO_SHOW_MLS_ON_MAP);
         mCrashReportsOn = (CheckBoxPreference) getPreferenceManager().findPreference(ClientPrefs.CRASH_REPORTING);
         mMapTileDetail = (ListPreference) getPreferenceManager().findPreference(ClientPrefs.MAP_TILE_RESOLUTION_TYPE);
-        int valueIndex = ClientPrefs.getInstance().getMapTileResolutionType().ordinal();
+        int valueIndex = ClientPrefs.getInstance(this).getMapTileResolutionType().ordinal();
         mMapTileDetail.setValueIndex(valueIndex);
         updateMapDetailTitle(valueIndex);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
@@ -47,17 +47,16 @@ public class Prefs {
         }
     }
 
-    /* Prefs must be created on application startup or service startup. */
-    public static synchronized Prefs createGlobalInstance(Context c) {
-        if (sInstance == null) {
-            sInstance = new Prefs(c);
-        }
+    // Allows code without a context handle to grab the prefs. The caller must null check the return value.
+    public static Prefs getInstanceWithoutContext() {
         return sInstance;
     }
 
     /* Only access after CreatePrefsInstance(Context) has been called at startup. */
-    public static synchronized Prefs getInstance() {
-        assert(sInstance != null);
+    public static synchronized Prefs getInstance(Context c) {
+        if (sInstance == null) {
+            sInstance = new Prefs(c);
+        }
         return sInstance;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
@@ -6,9 +6,8 @@ package org.mozilla.mozstumbler.service.core.http;
 
 import android.os.Build;
 
-import org.apache.http.protocol.HTTP;
-import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.service.utils.Zipper;
 import org.mozilla.osmdroid.tileprovider.util.StreamUtils;
@@ -42,8 +41,10 @@ public class HttpUtil implements IHttpUtil {
     private final String userAgent;
 
     public HttpUtil() {
-        this(ClientPrefs.getInstance().getUserAgent());
+        this((Prefs.getInstanceWithoutContext() != null)?
+              Prefs.getInstanceWithoutContext().getUserAgent() : "user-agent-not-set-properly");
     }
+
     public HttpUtil(String ua){
         userAgent = ua;
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/http/MLS.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/http/MLS.java
@@ -23,7 +23,10 @@ public class MLS implements ILocationService {
     private String mozApiKey;
 
     public MLS(IHttpUtil httpUtil) {
-        mozApiKey = Prefs.getInstance().getMozApiKey();
+        Prefs p = Prefs.getInstanceWithoutContext();
+        if (p != null) {
+            mozApiKey = p.getMozApiKey();
+        }
         httpDelegate = httpUtil;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -5,6 +5,7 @@
 package org.mozilla.mozstumbler.service.stumblerthread;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.os.AsyncTask;
@@ -69,8 +70,8 @@ public class StumblerService extends PersistentIntentService
         mScanManager.setWifiBlockList(list);
     }
 
-    public synchronized Prefs getPrefs() {
-        return Prefs.getInstance();
+    public synchronized Prefs getPrefs(Context c) {
+        return Prefs.getInstance(c);
     }
 
     public synchronized int getLocationCount() {
@@ -109,7 +110,8 @@ public class StumblerService extends PersistentIntentService
     // use (i.e. Fennec), init() can be called from this class's dedicated thread.
     // Safe to call more than once, ensure added code complies with that intent.
     protected void init() {
-        Prefs.createGlobalInstance(this);
+        // Don't remove, ensures that a Prefs instance is available for internal classes that call Prefs.getInstanceWithoutContext()
+        Prefs.getInstance(this);
         NetworkInfo.createGlobalInstance(this);
         DataStorageManager.createGlobalInstance(this, this);
         mReporter.startup(this);
@@ -142,7 +144,7 @@ public class StumblerService extends PersistentIntentService
                 }
 
                 if (!sFirefoxStumblingEnabled.get()) {
-                    Prefs.getInstance().setFirefoxScanEnabled(false);
+                    Prefs.getInstance(StumblerService.this).setFirefoxScanEnabled(false);
                 }
 
                 if (DataStorageManager.getInstance() != null) {
@@ -174,7 +176,7 @@ public class StumblerService extends PersistentIntentService
             return;
         }
 
-        final boolean isScanEnabledInPrefs = Prefs.getInstance().getFirefoxScanEnabled();
+        final boolean isScanEnabledInPrefs = Prefs.getInstance(this).getFirefoxScanEnabled();
 
         if (!isScanEnabledInPrefs && intent.getBooleanExtra(ACTION_NOT_FROM_HOST_APP, false)) {
             stopSelf();
@@ -190,7 +192,7 @@ public class StumblerService extends PersistentIntentService
             // This is the only upload trigger in Firefox mode
             // Firefox triggers this ~4 seconds after startup (after Gecko is loaded), add a small delay to avoid
             // clustering with other operations that are triggered at this time.
-            final long lastAttemptedTime = Prefs.getInstance().getLastAttemptedUploadTime();
+            final long lastAttemptedTime = Prefs.getInstance(this).getLastAttemptedUploadTime();
             final long timeNow = System.currentTimeMillis();
 
             if (timeNow - lastAttemptedTime < PASSIVE_UPLOAD_FREQ_GUARD_MSEC) {
@@ -199,23 +201,23 @@ public class StumblerService extends PersistentIntentService
                     Log.d(LOG_TAG, "Upload attempt too frequent.");
                 }
             } else {
-                Prefs.getInstance().setLastAttemptedUploadTime(timeNow);
+                Prefs.getInstance(this).setLastAttemptedUploadTime(timeNow);
                 UploadAlarmReceiver.scheduleAlarm(this, DELAY_IN_SEC_BEFORE_STARTING_UPLOAD_IN_PASSIVE_MODE, false /* no repeat*/);
             }
         }
 
         if (!isScanEnabledInPrefs) {
-            Prefs.getInstance().setFirefoxScanEnabled(true);
+            Prefs.getInstance(this).setFirefoxScanEnabled(true);
         }
 
         String apiKey = intent.getStringExtra(ACTION_EXTRA_MOZ_API_KEY);
-        if (apiKey != null && !apiKey.equals(Prefs.getInstance().getMozApiKey())) {
-            Prefs.getInstance().setMozApiKey(apiKey);
+        if (apiKey != null && !apiKey.equals(Prefs.getInstance(this).getMozApiKey())) {
+            Prefs.getInstance(this).setMozApiKey(apiKey);
         }
 
         String userAgent = intent.getStringExtra(ACTION_EXTRA_USER_AGENT);
-        if (userAgent != null && !userAgent.equals(Prefs.getInstance().getUserAgent())) {
-            Prefs.getInstance().setUserAgent(userAgent);
+        if (userAgent != null && !userAgent.equals(Prefs.getInstance(this).getUserAgent())) {
+            Prefs.getInstance(this).setUserAgent(userAgent);
         }
 
         startScanning();

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
@@ -105,8 +105,14 @@ public class LocationChangeSensor extends BroadcastReceiver {
     public void start() {
         mLastLocation = null;
         mStartTimeMs = sysClock.currentTimeMillis();
-        mPrefMotionChangeDistanceMeters = Prefs.getInstance().getMotionChangeDistanceMeters();
-        mPrefMotionChangeTimeWindowMs = 1000 * Prefs.getInstance().getMotionChangeTimeWindowSeconds();
+
+        Prefs prefs = Prefs.getInstanceWithoutContext();
+        if (prefs == null) {
+            return;
+        }
+
+        mPrefMotionChangeDistanceMeters = prefs.getMotionChangeDistanceMeters();
+        mPrefMotionChangeTimeWindowMs = 1000 * prefs.getMotionChangeTimeWindowSeconds();
 
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(GPSScanner.ACTION_GPS_UPDATED);

--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
@@ -80,9 +80,9 @@ public class UploadAlarmReceiver extends BroadcastReceiver {
 
                 AsyncUploader uploader = new AsyncUploader();
                 AsyncUploadParam param = new AsyncUploadParam(
-                        Prefs.getInstance().getUseWifiOnly(),
-                        Prefs.getInstance().getNickname(),
-                        Prefs.getInstance().getEmail()
+                        Prefs.getInstance(this).getUseWifiOnly(),
+                        Prefs.getInstance(this).getNickname(),
+                        Prefs.getInstance(this).getEmail()
                 );
                 uploader.execute(param);
             }

--- a/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.mozstumbler.client;
 
+import android.content.Context;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +30,7 @@ public class UpdaterTest {
         }
 
         @Override
-        public boolean wifiExclusiveAndUnavailable() {
+        public boolean wifiExclusiveAndUnavailable(Context c) {
             return false;
         }
     }

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
@@ -78,7 +78,7 @@ public class LocationChangeSensorTest {
                 callbackReceiver);
 
         // Set the minimum change distance to be very large
-        Prefs.getInstance().setMotionChangeDistanceMeters(10000);
+        Prefs.getInstance(this).setMotionChangeDistanceMeters(10000);
         //
         // start the sensor
         locationChangeSensor.start();

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
@@ -77,7 +77,7 @@ public class LocationChangeSensorTest {
                 callbackReceiver);
 
         // Set the minimum change distance to be very large
-        Prefs.getInstance(this).setMotionChangeDistanceMeters(10000);
+        Prefs.getInstance(ctx).setMotionChangeDistanceMeters(10000);
         //
         // start the sensor
         locationChangeSensor.start();


### PR DESCRIPTION
Where possible getInstance(Context) should be used. The internal utility classes can use Prefs.getInstanceWithoutContext(), but must check the instance is not null. As part of the app instantiation, the Prefs instance is created, so there is no known reason that Prefs.getInstanceWithoutContext() would return null. 
