### PR TITLE
Fix: notifications are never removed

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -242,8 +242,9 @@ public class MainApp extends Application
 
         mIsScanningPausedDueToNoMotion = false;
 
-        mStumblerService.stopForeground(true);
         mStumblerService.stopScanning();
+        mStumblerService.stopForeground(true);
+
         if (mMainActivity.get() != null) {
             mMainActivity.get().updateUiOnMainThread(false);
             mMainActivity.get().stop();


### PR DESCRIPTION
Sometimes notifications are never removed.

I think the problematic call stack is this:
- stopForeground and remove notifications
- stopScanning
- flush bundle
- update metrics and notification (scanner appears to be active still)
- scan manager only then sets scanning state to stopped
