### PR TITLE
India testing: ignore Build.VERSION.SDK_INT for Sig. Motion Sensor

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -52,11 +52,11 @@ public class MotionSensor {
         }
 
         mStopSignificantMotionSensor = false;
-        if (Build.VERSION.SDK_INT >= 18) {
-           mSignificantMotionSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION);
-           if (mSignificantMotionSensor != null) {
-               AppGlobals.guiLogInfo("Device has significant motion sensor.");
-           }
+        //if (Build.VERSION.SDK_INT >= 18) -> this doesn't seem to be working in Indian ROMs
+        AppGlobals.guiLogInfo("Build version: " + Build.VERSION.SDK_INT);
+        mSignificantMotionSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION);
+        if (mSignificantMotionSensor != null) {
+           AppGlobals.guiLogInfo("Device has significant motion sensor.");
         }
 
         // If no TYPE_SIGNIFICANT_MOTION is available, use alternate means to sense motion


### PR DESCRIPTION
My current guess is that Build.VERSION.SDK_INT doesn't seem to be working in Indian ROMs.
This code is for a test build, and likely will be reverted after 1.5.5 build

related to https://github.com/mozilla/MozStumbler/issues/1362
