### PR TITLE
Revert change for 1362, which was no API check before grabbing Sig. Motion Sensor

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -52,11 +52,11 @@ public class MotionSensor {
         }
 
         mStopSignificantMotionSensor = false;
-        //if (Build.VERSION.SDK_INT >= 18) -> this doesn't seem to be working in Indian ROMs
-        AppGlobals.guiLogInfo("Build version: " + Build.VERSION.SDK_INT);
-        mSignificantMotionSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION);
-        if (mSignificantMotionSensor != null) {
-           AppGlobals.guiLogInfo("Device has significant motion sensor.");
+        if (Build.VERSION.SDK_INT >= 18) {
+           mSignificantMotionSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION);
+           if (mSignificantMotionSensor != null) {
+               AppGlobals.guiLogInfo("Device has significant motion sensor.");
+           }
         }
 
         // If no TYPE_SIGNIFICANT_MOTION is available, use alternate means to sense motion


### PR DESCRIPTION
This change was experimental, and did not yield fruit.
Issue #1362
Revert "(Build.VERSION.SDK_INT >= 18) -> this doesn't seem to be working in Indian ROMs"

This reverts commit a345d4170031de14673e195a75f4d0d9594f46bd.
