### PR TITLE
Added "File a Bug" button

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -85,6 +85,15 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".client.navdrawer.MainDrawerActivity" />
         </activity>
+        <activity
+            android:name=".client.subactivities.FileBugActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:parentActivityName=".client.subactivities.PreferencesScreen" >
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".client.subactivities.PreferencesScreen" />
+        </activity>
 
         <service
             android:name=".client.ClientStumblerService"

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
@@ -1,0 +1,85 @@
+package org.mozilla.mozstumbler.client.subactivities;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.view.Menu;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.Toast;
+
+import org.acra.ACRA;
+import org.mozilla.mozstumbler.R;
+
+public class FileBugActivity extends ActionBarActivity {
+
+    private static final String SENDER_NAME = "Sender Name";
+    private static final String SENDER_EMAIL = "Sender Email";
+
+    private static final String BUG_TITLE_FIELD = "Bug Title";
+    private static final String BUG_TYPE_FIELD = "Bug Type";
+    private static final String BUG_DESCRIPTION_FIELD = "Bug Description";
+    private static final String BUG_REPRODUCTION_FIELD = "Bug Reproduction";
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_file_bug);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        return false;
+    }
+
+    public void sendReport(View button) {
+
+        EditText senderName = (EditText) findViewById(R.id.bug_report_sender_name);
+        EditText senderEmail = (EditText) findViewById(R.id.bug_report_sender_email);
+        EditText bugName = (EditText) findViewById(R.id.bug_report_name);
+        Spinner bugType = (Spinner) findViewById(R.id.bug_report_type);
+        EditText bugDescription = (EditText) findViewById(R.id.bug_report_description);
+        EditText bugReproduction = (EditText) findViewById(R.id.bug_report_reproduction);
+
+        if (verifyInput(bugName, bugDescription, bugReproduction)) {
+
+            // Set custom data fields
+            ACRA.getErrorReporter().putCustomData(SENDER_NAME, senderName.getText().toString());
+            ACRA.getErrorReporter().putCustomData(SENDER_EMAIL, senderEmail.getText().toString());
+            ACRA.getErrorReporter().putCustomData(BUG_TITLE_FIELD, bugName.getText().toString());
+            ACRA.getErrorReporter().putCustomData(BUG_TYPE_FIELD, bugType.getSelectedItem().toString());
+            ACRA.getErrorReporter().putCustomData(BUG_DESCRIPTION_FIELD, bugDescription.getText().toString());
+            ACRA.getErrorReporter().putCustomData(BUG_REPRODUCTION_FIELD, bugReproduction.getText().toString());
+
+            // Send the report (Stack trace will say "Requested by Developer"
+            // That should set apart manual reports from actual crashes
+            ACRA.getErrorReporter().handleException(null);
+
+            // Notify the user that the report was sent
+            Toast toast = Toast.makeText(this, "Bug Report Sent\n Thank you!", Toast.LENGTH_LONG);
+            toast.show();
+            this.finish();
+        }
+    }
+
+    // Making sure input isn't just blank spaces for required fields
+    private boolean verifyInput(EditText... args) {
+        boolean allValid = true;
+        for (EditText field : args) {
+            String input = field.getText().toString();
+            if (input.trim().length() == 0) {
+                field.setError("This field is required!");
+                allValid = false;
+            }
+        }
+        return allValid;
+    }
+
+}
+

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.mozstumbler.client.subactivities;
 
 import android.os.Bundle;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -17,6 +17,7 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
@@ -98,6 +99,15 @@ public class PreferencesScreen extends PreferenceActivity {
             @Override
             public boolean onPreferenceClick(Preference arg) {
                 ((MainApp) getApplication()).showDeveloperDialog(PreferencesScreen.this);
+                return true;
+            }
+        });
+
+        button = findPreference("file_bug");
+        button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference arg) {
+                startActivity(new Intent(PreferencesScreen.this, FileBugActivity.class));
                 return true;
             }
         });

--- a/android/src/main/res/layout/activity_file_bug.xml
+++ b/android/src/main/res/layout/activity_file_bug.xml
@@ -1,0 +1,163 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".client.subactivities.FileBugActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_below_for_bug_report_fields">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_sender_name" />
+
+            <EditText
+                android:id="@+id/bug_report_sender_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/file_bug_sender_name_hint"
+                android:inputType="textPersonName|textCapWords"
+                android:singleLine="true"
+                android:textSize="@dimen/font_size_for_bug_report_fields" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_below_for_bug_report_fields">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_sender_email" />
+
+            <EditText
+                android:id="@+id/bug_report_sender_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/file_bug_sender_email_hint"
+                android:inputType="textEmailAddress"
+                android:singleLine="true"
+                android:textSize="@dimen/font_size_for_bug_report_fields" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_below_for_bug_report_fields">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_name" />
+
+            <EditText
+                android:id="@+id/bug_report_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/file_bug_name_hint"
+                android:inputType="textCapWords"
+                android:singleLine="true"
+                android:textSize="@dimen/font_size_for_bug_report_fields" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_below_for_bug_report_fields">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_type" />
+
+            <Spinner
+                android:id="@+id/bug_report_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:entries="@array/file_bug_type_list"
+                android:prompt="@string/file_bug_type" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_below_for_bug_report_fields">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_description" />
+
+            <EditText
+                android:id="@+id/bug_report_description"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/edit_text_size_bug_report_fields"
+                android:gravity="top|left"
+                android:hint="@string/file_bug_description_hint"
+                android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
+                android:textSize="@dimen/font_size_for_bug_report_fields" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/file_bug_reproduction"/>
+
+            <EditText
+                android:id="@+id/bug_report_reproduction"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/edit_text_size_bug_report_fields"
+                android:gravity="top|left"
+                android:hint="@string/file_bug_reproduction_hint"
+                android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
+                android:textSize="@dimen/font_size_for_bug_report_fields" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingBottom="32dp"
+            android:paddingTop="32dp"
+            android:text="@string/file_bug_report_info"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textSize="13dp" />
+
+        <Button
+            android:id="@+id/bug_report_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="sendReport"
+            android:text="@string/file_bug_send" />
+
+    </LinearLayout>
+</ScrollView>

--- a/android/src/main/res/values/dimens.xml
+++ b/android/src/main/res/values/dimens.xml
@@ -8,5 +8,8 @@
     <dimen name="padding_above_for_metrics_titles">12dp</dimen>
     <dimen name="padding_below_for_metrics_titles">5dp</dimen>
     <dimen name="font_size_for_map_view_report_icon">18sp</dimen>
+    <dimen name="font_size_for_bug_report_fields">18sp</dimen>
+    <dimen name="edit_text_size_bug_report_fields">120dp</dimen>
+    <dimen name="padding_below_for_bug_report_fields">10dp</dimen>
 
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -60,6 +60,30 @@
     <string name="metrics_this_session">Current session</string>
     <string name="drawer_map_option_show_mls_locations">Show MLS locations</string>
     <string name="title_activity_log">Log</string>
+
+    <string name="action_file_bug">File a Bug</string>
+    <string name="file_bug_sender_name">Your Name:</string>
+    <string name="file_bug_sender_name_hint">Optional</string>
+    <string name="file_bug_sender_email">Your Email:</string>
+    <string name="file_bug_sender_email_hint">Optional</string>
+    <string name="file_bug_name">Bug Title:</string>
+    <string name="file_bug_name_hint">Descriptive title for the bug</string>
+    <string name="file_bug_description">Bug Description:</string>
+    <string name="file_bug_description_hint">Detailed information about the bug being reported (what happens, when it happens, etc.)</string>
+    <string name="file_bug_reproduction">Bug Reproduction:</string>
+    <string name="file_bug_reproduction_hint">Steps explaining how to reproduce the bug.</string>
+    <string name="file_bug_report_info">By sending this report, you will also send information regarding the current state of your device. This information will be used to narrow down the cause of the bug. Bug reports for bugs that result in a crash are sent automatically if the option if "Enable crash reporting" is enabled. If you encounter bugs that do not result in a crash, please report them through this form.</string>
+    <string name="file_bug_send">Send Bug Report</string>
+    <string name="file_bug_type">Bug Type:</string>
+    <string-array name="file_bug_type_list">
+        <item>Cosmetic</item>
+        <item>Performance</item>
+        <item>Compatibility</item>
+        <item>Functionality</item>
+        <item>Feature Request</item>
+        <item>Other</item>
+    </string-array>
+
     <string name="action_view_log">View Log</string>
     <string name="scroll_to_start">Scroll to Top</string>
     <string name="scroll_to_end">Scroll to End</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="file_bug_description_hint">Detailed information about the bug being reported (what happens, when it happens, etc.)</string>
     <string name="file_bug_reproduction">Bug Reproduction:</string>
     <string name="file_bug_reproduction_hint">Steps explaining how to reproduce the bug.</string>
-    <string name="file_bug_report_info">By sending this report, you will also send information regarding the current state of your device. This information will be used to narrow down the cause of the bug. Bug reports for bugs that result in a crash are sent automatically if the option if "Enable crash reporting" is enabled. If you encounter bugs that do not result in a crash, please report them through this form.</string>
+    <string name="file_bug_report_info">By sending this report, you will also send information regarding the current state of your device. This information will be used to narrow down the cause of the bug. Bug reports for bugs that result in a crash are sent automatically if the option \"Enable crash reporting\" is enabled. If you encounter bugs that do not result in a crash, please report them through this form.</string>
     <string name="file_bug_send">Send Bug Report</string>
     <string name="file_bug_type">Bug Type:</string>
     <string-array name="file_bug_type_list">

--- a/android/src/main/res/xml/stumbler_preferences.xml
+++ b/android/src/main/res/xml/stumbler_preferences.xml
@@ -55,6 +55,8 @@
         android:key="leaderboard_button"/>
     </PreferenceCategory>
 
+    <Preference android:title="@string/action_file_bug"
+        android:key="file_bug"/>
     <Preference android:title="@string/action_view_log"
         android:key="log_button"/>
     <Preference android:title="@string/action_about"


### PR DESCRIPTION
Attempting to address #1182 by adding a "File a Bug" button under the settings/preferences activity.

This spawns a new activity that prompts the user to fill in a title for the bug, the type of bug it is (from a preset list), description of the bug, and how to reproduce the bug. An optional name and email field are there just in case.

These reports appear as ACRA reports, though the stack trace will always read "Report requested by developer" and contain the user provided information in the CUSTOM field under the stack trace. Aside from that, all the other information in an ACRA report is available as normal. I hope that is a good enough distinction between manual bug reports and crashes.

Some screen shots of the bug report form: 

![device-2014-12-23-211915](https://cloud.githubusercontent.com/assets/5815344/5545241/ca7c5e88-8af2-11e4-92ce-8f00480e41be.png)

![device-2014-12-23-211928](https://cloud.githubusercontent.com/assets/5815344/5545246/d44d0278-8af2-11e4-80e4-5c54d05f917d.png)
