### PR TITLE
Set map tile source even when there is no internet connection

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -502,12 +502,8 @@ public final class MapFragment extends android.support.v4.app.Fragment
         final boolean hasNetwork = (info != null) && info.isConnected();
         final boolean hasWifi = (info != null) && (info.getType() == ConnectivityManager.TYPE_WIFI);
 
-        if (!hasNetwork) {
-            showMapNotAvailableMessage(NoMapAvailableMessage.eNoMapDueToNoInternet);
-            return;
-        }
-
-        showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
+        NoMapAvailableMessage message = hasNetwork ? NoMapAvailableMessage.eHideNoMapMessage : NoMapAvailableMessage.eNoMapDueToNoInternet;
+        showMapNotAvailableMessage(message);
         setHighBandwidthMap(hasWifi);
     }
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. open app, load low resolution map (or set to always show high resolution map)
2. disable network connections
3. change phone orientation or restart app

Result:
- map is not shown anymore

Expected:
- cached map should still be visible
