### PR TITLE
Added telemetry for Fennec.

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -81,5 +81,14 @@ public class AppGlobals {
 
     public static final String ACTION_TEST_SETTING_ENABLED = "stumbler-test-setting-enabled";
     public static final String ACTION_TEST_SETTING_DISABLED = "stumbler-test-setting-disabled";
+
+    public static final String TELEMETRY_TIME_BETWEEN_UPLOADS_SEC = "STUMBLER_TIME_BETWEEN_UPLOADS_SEC";
+    public static final String TELEMETRY_BYTES_UPLOADED_PER_SEC = "STUMBLER_BYTES_UPLOADED_PER_SEC";
+    public static final String TELEMETRY_TIME_BETWEEN_STARTS_SEC = "STUMBLER_TIME_BETWEEN_START_SEC";
+    public static final String TELEMETRY_BYTES_PER_UPLOAD = "STUMBLER_BYTES_PER_UPLOAD";
+    public static final String TELEMETRY_OBSERVATIONS_PER_UPLOAD = "STUMBLER_OBSERVATIONS_PER_UPLOAD";
+    public static final String TELEMETRY_CELLS_PER_UPLOAD = "STUMBLER_CELLS_PER_UPLOAD";
+    public static final String TELEMETRY_WIFIS_PER_UPLOAD = "STUMBLER_WIFIS_PER_UPLOAD";
+    public static final String TELEMETRY_OBSERVATIONS_PER_DAY = "STUMBLER_OBSERVATIONS_PER_DAY";
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageContract.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageContract.java
@@ -21,12 +21,13 @@ public final class DataStorageContract {
 
     public static class Stats {
         public static final String KEY_VERSION = "version_code";
-        public static final int VERSION_CODE = 1;
+        public static final int VERSION_CODE = 2;
         public static final String KEY_BYTES_SENT = "bytes_sent";
         public static final String KEY_LAST_UPLOAD_TIME = "last_upload_time";
         public static final String KEY_OBSERVATIONS_SENT = "observations_sent";
         public static final String KEY_WIFIS_SENT = "wifis_sent";
         public static final String KEY_CELLS_SENT = "cells_sent";
+        public static final String KEY_OBSERVATIONS_PER_DAY = "obs_per_day";
     }
 
     private DataStorageContract() {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -57,7 +57,6 @@ public class DataStorageManager {
     // Set to the default value specified above.
     private final int mMaxWeeksStored;
 
-
     final ReportBatchBuilder mCurrentReports = new ReportBatchBuilder();
     protected final File mReportsDir;
 
@@ -480,9 +479,5 @@ public class DataStorageManager {
 
     public synchronized void incrementSyncStats(long bytesSent, long reports, long cells, long wifis) throws IOException {
         mPersistedOnDiskUploadStats.incrementSyncStats(bytesSent, reports, cells, wifis);
-    }
-
-    public void writeSyncStats(long time, long bytesSent, long totalObs, long totalCells, long totalWifis) throws IOException {
-        mPersistedOnDiskUploadStats.writeSyncStats(time, bytesSent, totalObs, totalCells, totalWifis);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
@@ -1,14 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.mozilla.mozstumbler.service.utils.TelemetryWrapper;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 class PersistedStats {
     private final File mStatsFile;
@@ -39,14 +42,43 @@ class PersistedStats {
 
         final Properties properties = readSyncStats();
         final long time = System.currentTimeMillis();
+        final long lastUploadTime = Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "0"));
+        final long storedObsPerDay = Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_PER_DAY, "0"));
+        long observationsToday = reports;
+        if (lastUploadTime > 0) {
+            long dayLastUploaded = TimeUnit.MILLISECONDS.toDays(lastUploadTime);
+            long dayDiff = TimeUnit.MILLISECONDS.toDays(time) - dayLastUploaded;
+            if (dayDiff > 0) {
+                // send value of store obs per day
+                TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_OBSERVATIONS_PER_DAY,
+                        Long.valueOf(storedObsPerDay / dayDiff).intValue());
+            } else {
+                observationsToday += storedObsPerDay;
+            }
+        }
+
         writeSyncStats(time,
             Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "0")) + bytesSent,
             Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0")) + reports,
             Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_CELLS_SENT, "0")) + cells,
-            Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0")) + wifis);
+            Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0")) + wifis,
+            observationsToday);
+
+
+        final long lastUploadMs = Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "0"));
+        final int timeDiffSec = Long.valueOf((time - lastUploadMs) / 1000).intValue();
+        if (lastUploadMs > 0 && timeDiffSec > 0) {
+            TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_TIME_BETWEEN_UPLOADS_SEC, timeDiffSec);
+            TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_BYTES_UPLOADED_PER_SEC, Long.valueOf(bytesSent).intValue() / timeDiffSec);
+        }
+        TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_BYTES_PER_UPLOAD, Long.valueOf(bytesSent).intValue());
+        TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_OBSERVATIONS_PER_UPLOAD, Long.valueOf(reports).intValue());
+        TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_WIFIS_PER_UPLOAD, Long.valueOf(wifis).intValue());
+        TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_CELLS_PER_UPLOAD, Long.valueOf(cells).intValue());
     }
 
-    public synchronized void writeSyncStats(long time, long bytesSent, long totalObs, long totalCells, long totalWifis) throws IOException {
+    public synchronized void writeSyncStats(long time, long bytesSent, long totalObs,
+                                            long totalCells, long totalWifis, long obsPerDay) throws IOException {
         final FileOutputStream out = new FileOutputStream(mStatsFile);
         try {
             final Properties props = new Properties();
@@ -56,6 +88,7 @@ class PersistedStats {
             props.setProperty(DataStorageContract.Stats.KEY_CELLS_SENT, String.valueOf(totalCells));
             props.setProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, String.valueOf(totalWifis));
             props.setProperty(DataStorageContract.Stats.KEY_VERSION, String.valueOf(DataStorageContract.Stats.VERSION_CODE));
+            props.setProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_PER_DAY, String.valueOf(obsPerDay));
             props.store(out, null);
         } finally {
             out.close();

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -18,6 +18,7 @@ import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
+import org.mozilla.mozstumbler.service.utils.TelemetryWrapper;
 
 public class GPSScanner implements LocationListener {
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".GPSScanner.";
@@ -33,7 +34,7 @@ public class GPSScanner implements LocationListener {
     private static final float ACTIVE_MODE_GPS_MIN_UPDATE_DISTANCE_M = 30;
     private static final long PASSIVE_GPS_MIN_UPDATE_FREQ_MS = 3000;
     private static final float PASSIVE_GPS_MOVEMENT_MIN_DELTA_M = 30;
-
+    private long mTelemetry_lastStartedMs;
 
     private final StumblerFilter stumbleFilter = new StumblerFilter();
     private final Context mContext;
@@ -75,6 +76,13 @@ public class GPSScanner implements LocationListener {
             return;
         }
         locationManager.requestLocationUpdates(LocationManager.PASSIVE_PROVIDER, 0, 0, this);
+
+        final int timeDiffSec = Long.valueOf((System.currentTimeMillis() - mTelemetry_lastStartedMs) / 1000).intValue();
+        if (mTelemetry_lastStartedMs > 0 && timeDiffSec > 0) {
+            TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_TIME_BETWEEN_STARTS_SEC, timeDiffSec);
+        }
+        mTelemetry_lastStartedMs = System.currentTimeMillis();
+
     }
 
     private void startActiveMode() {

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/TelemetryWrapper.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/TelemetryWrapper.java
@@ -1,0 +1,41 @@
+package org.mozilla.mozstumbler.service.utils;
+
+import android.util.Log;
+import org.mozilla.mozstumbler.service.AppGlobals;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+// Currently this is only implemented for Fennec.
+public class TelemetryWrapper {
+    private static final String LOG_TAG = AppGlobals.makeLogTag(TelemetryWrapper.class.getSimpleName());
+    private static Method mAddToHistogram;
+
+    public static void addToHistogram(String key, int value) {
+        if (mAddToHistogram == null) {
+            try {
+                Class<?> telemetry = Class.forName("org.mozilla.gecko.Telemetry");
+                mAddToHistogram = telemetry.getMethod("addToHistogram", String.class, int.class);
+            } catch (ClassNotFoundException e) {
+                Log.d(LOG_TAG, "Class not found!");
+                return;
+            } catch (NoSuchMethodException e) {
+                Log.d(LOG_TAG, "Method not found!");
+                return;
+            }
+        }
+
+        if (mAddToHistogram != null) {
+            try {
+                mAddToHistogram.invoke(null, key, value);
+            }
+            catch (IllegalArgumentException e) {
+                Log.d(LOG_TAG, "Got exception invoking.");
+            } catch (InvocationTargetException e) {
+                Log.d(LOG_TAG, "Got exception invoking.");
+            } catch (IllegalAccessException e) {
+                Log.d(LOG_TAG, "Got exception invoking.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Required using reflection to grab the telemetry class in Fennec due to the partitioning of the build system; stumbler has no access to gecko.
