### PR TITLE
Adds mockito support for testing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,12 @@ android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
 
+    def gitHash = "git rev-parse --short HEAD".execute().text.trim()
+    def hasModifiedDeletedOrOtherFiles = !"git ls-files -mdo --exclude-standard".execute().text.trim().isEmpty()
+    def hasStagedFiles = !"git diff-index --no-ext-diff --name-only --cached HEAD".execute().text.trim().isEmpty()
+    def dirtyWorkingCopy = hasModifiedDeletedOrOtherFiles || hasStagedFiles 
+    def gitDescription = dirtyWorkingCopy ? "${gitHash}-dirty" : gitHash
+
     packagingOptions {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/NOTICE'
@@ -69,6 +75,9 @@ android {
         buildConfigField "String", "ACRA_URI", "\"http://ec2-54-172-135-65.compute-1.amazonaws.com/acra-stumbler/_design/acra-storage/_update/report\""
         buildConfigField "String", "ACRA_USER", "\"nospam\""
         buildConfigField "String", "ACRA_PASS", "\"4ok3bsWs509i\""
+
+        buildConfigField "String", "GIT_DESCRIPTION", "\"${gitDescription}\""
+        buildConfigField "String", "GIT_VERSION", "\"${versionName} ${gitDescription}\""
     }
 
     signingConfigs {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -194,8 +194,8 @@ dependencies {
 
     // This needs to be tweaked so that we don't include this on real
     // releases, but I'm tired and can't muster the gradle foo.
-    androidTestCompile "org.mockito:mockito-all:1.+"
-    testCompile        "org.mockito:mockito-all:1.+"
+    androidTestCompile "org.mockito:mockito-core:1.+"
+    testCompile        "org.mockito:mockito-core:1.+"
 
 
     compile 'com.crankycoder:SimpleKML:1.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -178,13 +178,18 @@ android {
 
 dependencies {
     androidTestCompile 'junit:junit:4.10'
-    androidTestCompile 'org.robolectric:robolectric:2.4'
+    testCompile        'junit:junit:4.10'
 
-    testCompile 'junit:junit:4.10'
-    testCompile 'org.robolectric:robolectric:2.4'
+    androidTestCompile 'org.robolectric:robolectric:2.4'
+    testCompile        'org.robolectric:robolectric:2.4'
+
+    // This needs to be tweaked so that we don't include this on real
+    // releases, but I'm tired and can't muster the gradle foo.
+    androidTestCompile "org.mockito:mockito-all:1.+"
+    testCompile        "org.mockito:mockito-all:1.+"
+
 
     compile 'com.crankycoder:SimpleKML:1.0'
-
     compile 'org.slf4j:slf4j-android:1.7.7'
 
     // https://developer.android.com/tools/support-library/features.html

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -117,21 +117,28 @@ public class MapFragment extends android.support.v4.app.Fragment
 
         mRootView = inflater.inflate(R.layout.activity_map, container, false);
 
+        doOnCreateView(savedInstanceState);
+
+        return mRootView;
+    }
+
+    /*
+      This method has been extracted from onCreateView so that it's easy to stub
+      it out when the class is under test.
+     */
+    void doOnCreateView(Bundle savedInstanceState) {
         AbstractMapOverlay.setDisplayBasedMinimumZoomLevel(getApplication());
         showMapNotAvailableMessage(NoMapAvailableMessage.eHideNoMapMessage);
 
         hideLowResMapMessage();
-
         initializeMapControls();
         initializeLastLocation(savedInstanceState);
         initializeMapOverlays();
         initializeVisibleCounts();
         initializeListeners();
-
         showPausedDueToNoMotionMessage(getApplication().isIsScanningPausedDueToNoMotion());
 
         showCopyright();
-        return mRootView;
     }
 
     private void hideLowResMapMessage() {
@@ -408,7 +415,7 @@ public class MapFragment extends android.support.v4.app.Fragment
     // To handle the case where the user zooms out to show a large area when in low bandwidth mode,
     // we need an additional "LowZoom" overlay. So in low bandwidth mode, you will see
     // that based on the current zoom level of the map, we show "HighZoom" or "LowZoom" overlays.
-    private void setHighBandwidthMap(boolean isHighBandwidth) {
+    void setHighBandwidthMap(boolean isHighBandwidth) {
         final ClientPrefs prefs = ClientPrefs.getInstance(mRootView.getContext());
         if (prefs == null || getActivity() == null) {
             return;
@@ -642,6 +649,14 @@ public class MapFragment extends android.support.v4.app.Fragment
         super.onResume();
         Log.d(LOG_TAG, "onResume");
 
+        doOnResume();
+    }
+
+    /*
+     This method has been extracted from onResume so that we can just disable the behavior when
+     the class is under test
+     */
+    void doOnResume() {
         mMapLocationListener = new MapLocationListener(this);
 
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/AboutActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/AboutActivity.java
@@ -10,6 +10,7 @@ import android.view.Menu;
 import android.widget.TextView;
 
 import org.mozilla.mozstumbler.R;
+import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.client.PackageUtils;
 
 public class AboutActivity extends ActionBarActivity {
@@ -27,6 +28,10 @@ public class AboutActivity extends ActionBarActivity {
         String str = getResources().getString(R.string.about_version);
         str = String.format(str, PackageUtils.getAppVersion(this));
         textView.setText(str);
+
+
+        textView = (TextView) findViewById(R.id.about_git_version);
+        textView.setText(BuildConfig.GIT_DESCRIPTION);
     }
 
     @Override

--- a/android/src/main/res/layout/activity_about.xml
+++ b/android/src/main/res/layout/activity_about.xml
@@ -19,6 +19,7 @@
             android:gravity="center"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/app_name" />
+
         <TextView
             android:id="@+id/about_version"
             android:layout_width="match_parent"
@@ -26,6 +27,16 @@
             android:gravity="center"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:text="@string/about_version" />
+
+        <TextView
+            android:id="@+id/about_git_version"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_horizontal"
+            android:text="unknown" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/src/test/java/org/mozilla/mozstumbler/client/mapview/CustomShadowConnectivityManager.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/mapview/CustomShadowConnectivityManager.java
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client.mapview;
+
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.support.v4.app.FragmentActivity;
+
+import org.mockito.Mockito;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowConnectivityManager;
+
+import java.io.File;
+
+import static org.mockito.Mockito.when;
+
+/*
+  This custom shadow is only used to check if the network connectivity has changed.
+
+  It's used by MapFragmentTest.
+ */
+@Implements(ConnectivityManager.class)
+public class CustomShadowConnectivityManager extends ShadowConnectivityManager {
+
+    @Implementation
+    public NetworkInfo getActiveNetworkInfo() {
+
+        // NetworkInfo doesn't provide a proper constructor, so we're just going to clobber
+        // that with mockito.
+        final NetworkInfo networkInfo = Mockito.mock( NetworkInfo.class );
+        when(networkInfo.isConnected()).thenReturn( false );
+        when(networkInfo.getType()).thenReturn(ConnectivityManager.TYPE_DUMMY);
+
+        return networkInfo;
+    }
+
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/client/mapview/MapFragmentTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/mapview/MapFragmentTest.java
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client.mapview;
+
+import android.content.Context;
+import android.support.v4.app.FragmentActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.AppGlobals;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.util.FragmentTestUtil.startFragment;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class MapFragmentTest {
+
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MapFragmentTest.class);
+
+    @Test
+    @Config(shadows = {CustomShadowConnectivityManager.class})
+    public void testMapNetworkConnectionChanged() {
+        MapFragment mapFragment = new MapFragment();
+
+        startFragment(mapFragment);
+
+    }
+
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/client/mapview/MapFragmentTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/mapview/MapFragmentTest.java
@@ -52,7 +52,10 @@ public class MapFragmentTest {
         // now verify that a network connection changed just shows a no map available message
         verify(mapFragment).showMapNotAvailableMessage(MapFragment.NoMapAvailableMessage.eNoMapDueToNoInternet);
 
-        // Check that the setHighBandwidthMap method was called
+        // Check that the setHighBandwidthMap method was called. This
+        // never happened before
+        // https://github.com/mozilla/MozStumbler/pull/1370 was
+        // merged.
         verify(mapFragment).setHighBandwidthMap(false);
     }
 


### PR DESCRIPTION
I've added mockito support to the testing infrastructure.

This should allow patches like #1370 to be tested going forward.

The only feature I've added to the application itself is the git-version to the About Activity.  Dirty trees will also append -dirty to the git hash.
