### PR TITLE
Minor update to test infrastructure

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,15 +17,15 @@ buildscript {
     }
 
     dependencies {
+
         classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'org.robolectric:robolectric-gradle-plugin:0.14.+'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
+        classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
     }
 }
 
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
-apply plugin: 'robolectric'
 
 repositories {
     jcenter()
@@ -174,6 +174,8 @@ android {
     }
 
 }
+
+apply plugin: 'android-unit-test'
 
 
 dependencies {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Usage: ./test.sh <TestClassName>
+# Gory details:
+# This runs just some of your test cases using a pattern matcher.  In
+# genral, you probably just want the test class name.
+
+# See: https://github.com/JCAndKSolutions/android-unit-test for more
+# details.
+
+./gradlew testGithubUnittest -DtestGithubUnittest.single=$1


### PR DESCRIPTION
I've upgraded us to use a new gradle test plugin so that we can run individual tests.  It's marginally useful right now as you can only drive those smaller test runs from the command line, but this should at least make it possible to have Android Studio integration to run tests from the IDE.

test.sh is included as the basic test runner to run tests based on test class name.
