### PR TITLE
Hardcoded strings replaced with references to strings.xml

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FileBugActivity.java
@@ -66,7 +66,7 @@ public class FileBugActivity extends ActionBarActivity {
             ACRA.getErrorReporter().handleException(null);
 
             // Notify the user that the report was sent
-            Toast toast = Toast.makeText(this, "Bug Report Sent\n Thank you!", Toast.LENGTH_LONG);
+            Toast toast = Toast.makeText(this, getResources().getString(R.string.file_bug_toast_success), Toast.LENGTH_LONG);
             toast.show();
             this.finish();
         }
@@ -78,7 +78,7 @@ public class FileBugActivity extends ActionBarActivity {
         for (EditText field : args) {
             String input = field.getText().toString();
             if (input.trim().length() == 0) {
-                field.setError("This field is required!");
+                field.setError(getResources().getString(R.string.file_bug_missing_field));
                 allValid = false;
             }
         }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
         <item>Feature Request</item>
         <item>Other</item>
     </string-array>
+    <string name="file_bug_toast_success">Bug Report Sent\n Thank you!</string>
+    <string name="file_bug_missing_field">This field is required!</string>
 
     <string name="action_view_log">View Log</string>
     <string name="scroll_to_start">Scroll to Top</string>


### PR DESCRIPTION
Small fix to #1369. There were two instances where I hard coded string messages for the user. Those are now being pulled from the strings.xml file. 
