### PR TITLE
Minor tweaks for the homescreen widget

### DIFF
--- a/android/src/main/res/layout/toggle_widget.xml
+++ b/android/src/main/res/layout/toggle_widget.xml
@@ -25,34 +25,6 @@
         android:orientation="horizontal">
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:minHeight="40dp"
-            android:layout_weight="0.4"
-            android:layout_gravity="center"
-            android:orientation="horizontal">
-            <ImageView
-                android:layout_width="36dp"
-                android:minHeight="36dp"
-                android:layout_gravity="center"
-                android:layout_height="36dp"
-                android:src="@drawable/ic_wifi_flaticondotcom"/>
-            <TextView
-                android:id="@+id/stumbler_info1"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:minHeight="36dp"
-                android:layout_gravity="center_vertical"
-                android:textAlignment="gravity"
-                android:paddingLeft="7dp"
-                android:paddingRight="7dp"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"
-                android:text="0"
-                android:gravity="center_vertical" />
-
-        </LinearLayout>
-        <LinearLayout
-            android:layout_width="match_parent"
             android:minHeight="40dp"
             android:layout_height="36dp"
             android:layout_weight="0.4"
@@ -66,6 +38,33 @@
                 android:src="@drawable/ic_cell_flaticondotcom"/>
             <TextView
                 android:id="@+id/stumbler_info2"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:minHeight="36dp"
+                android:layout_gravity="center_vertical"
+                android:textAlignment="gravity"
+                android:paddingLeft="7dp"
+                android:paddingRight="7dp"
+                android:textSize="16sp"
+                android:textColor="@android:color/black"
+                android:text="0"
+                android:gravity="center_vertical" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:minHeight="40dp"
+            android:layout_weight="0.4"
+            android:layout_gravity="center"
+            android:orientation="horizontal">
+            <ImageView
+                android:layout_width="36dp"
+                android:minHeight="36dp"
+                android:layout_gravity="center"
+                android:layout_height="36dp"
+                android:src="@drawable/ic_wifi_flaticondotcom"/>
+            <TextView
+                android:id="@+id/stumbler_info1"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
                 android:minHeight="36dp"

--- a/android/src/main/res/layout/toggle_widget.xml
+++ b/android/src/main/res/layout/toggle_widget.xml
@@ -47,7 +47,8 @@
                 android:paddingRight="7dp"
                 android:textSize="16sp"
                 android:textColor="@android:color/black"
-                android:text="0" />
+                android:text="0"
+                android:gravity="center_vertical" />
 
         </LinearLayout>
         <LinearLayout
@@ -74,7 +75,8 @@
                 android:paddingRight="7dp"
                 android:textSize="16sp"
                 android:textColor="@android:color/black"
-                android:text="0" />
+                android:text="0"
+                android:gravity="center_vertical" />
         </LinearLayout>
         <LinearLayout
           android:layout_width="match_parent"
@@ -100,7 +102,8 @@
               android:paddingRight="7dp"
               android:textSize="16sp"
               android:textColor="@android:color/black"
-              android:text="0" />
+              android:text="0"
+                android:gravity="center_vertical" />
             </LinearLayout>
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
This fixes 2 layout issues with the homscreen widget:
- The counter numbers were not vertically centered.  This has been changed with gravity="center_vertical" now.
- The order of the counters in the widget did not match up to the ones in the MapView.  Cell tower and Wifi positions are transposed in this patch.
