### PR TITLE
Increase cache time of map tiles

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -485,6 +485,7 @@ public class MapFragment extends android.support.v4.app.Fragment
                         new String[]{BuildConfig.TILE_SERVER_URL});
             }
             System.gc();
+            mHighResMapSource.setCacheTime(7 * 24 * 60 * 60 * 1000);
             mMap.setTileSource(mHighResMapSource);
         } else {
             if (mLowResMapOverlayHighZoom != null) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -32,6 +32,7 @@ public class CoverageOverlay extends AbstractMapOverlay {
                 ".png",
                 new String[] { coverageUrl });
         this.setLoadingBackgroundColor(Color.TRANSPARENT);
+        coverageTileSource.setCacheTime(12 * 60 * 60 * 1000);
         mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
         mTileProvider.setTileSource(coverageTileSource);
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -40,6 +40,7 @@ public class LowResMapOverlay extends AbstractMapOverlay {
                     "http://otile4.mqcdn.com/tiles/1.0.0/map/"});
         }
         this.setLoadingBackgroundColor(Color.TRANSPARENT);
+        coverageTileSource.setCacheTime(7 * 24 * 60 * 60 * 1000);
         mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
         mTileProvider.setTileSource(coverageTileSource);
     }

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTile.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTile.java
@@ -10,11 +10,9 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,11 +23,6 @@ import java.util.Map;
  * This class represents a serializable Tile.
  */
 public class SerializableTile {
-
-    // Cache tiles locally for 12 hours. Ichanea doesn't update tiles
-    // more than once a day anyway and this should be good enough to 
-    // enable offline stumbles.
-    public static final long CACHE_TILE_MS = 60 * 60 * 12 * 1000;
 
     private static final String LOG_TAG =
             AppGlobals.LOG_PREFIX + SerializableTile.class.getSimpleName();
@@ -120,12 +113,12 @@ public class SerializableTile {
         return buff.toByteArray();
     }
 
-    public boolean saveFile(File aFile) {
+    public boolean saveFile(File aFile, long aCacheTime) {
         try {
             myFile = aFile;
             // Always update cache-control on save
             setHeader("cache-control",
-                    Long.toString(CACHE_TILE_MS + System.currentTimeMillis()));
+                    Long.toString(aCacheTime + System.currentTimeMillis()));
             FileOutputStream fos = new FileOutputStream(aFile);
             fos.write(this.asBytes());
             fos.flush();
@@ -142,9 +135,9 @@ public class SerializableTile {
 
     Generally only used to update a file that was previously loaded from disk.
      */
-    public boolean saveFile() {
+    public boolean saveFile(long aCacheTime) {
         if (myFile != null) {
-            return saveFile(myFile);
+            return saveFile(myFile, aCacheTime);
         }
         return false;
     }

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
@@ -8,14 +8,7 @@ import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.osmdroid.tileprovider.MapTile;
 import org.mozilla.osmdroid.tileprovider.tilesource.ITileSource;
-import org.mozilla.osmdroid.tileprovider.util.StreamUtils;
 
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,7 +91,7 @@ public class TileDownloaderDelegate {
 
         if (resp.httpResponse() == 304) {
             // Resave the file - this will automatically update the cache-control value
-            serializableTile.saveFile();
+            serializableTile.saveFile(tileSource.getCacheTime());
             return true;
         }
         return false;

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileIOFacade.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileIOFacade.java
@@ -5,18 +5,9 @@ import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.osmdroid.tileprovider.MapTile;
 import org.mozilla.osmdroid.tileprovider.constants.OSMConstants;
 import org.mozilla.osmdroid.tileprovider.tilesource.ITileSource;
-import org.mozilla.osmdroid.tileprovider.util.StreamUtils;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -116,7 +107,7 @@ public class TileIOFacade  {
         SerializableTile serializableTile = new SerializableTile();
         serializableTile.setTileData(tileBytes);
         serializableTile.setHeader("etag", etag);
-        serializableTile.saveFile(sTileFile);
+        serializableTile.saveFile(sTileFile, pTileSource.getCacheTime());
 
         mUsedCacheSpace += tileBytes.length;
         if (mUsedCacheSpace > OSMConstants.TILE_MAX_CACHE_SIZE_BYTES) {

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/ITileSource.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/ITileSource.java
@@ -6,8 +6,6 @@ import org.mozilla.osmdroid.ResourceProxy;
 import org.mozilla.osmdroid.tileprovider.MapTile;
 import org.mozilla.osmdroid.tileprovider.tilesource.BitmapTileSourceBase.LowMemoryException;
 
-import java.io.InputStream;
-
 public interface ITileSource {
 
     /**
@@ -45,7 +43,7 @@ public interface ITileSource {
     /**
      * Get a rendered Drawable from the specified file path.
      *
-     * @param aFilePath a file path
+     * @param tileData a file path
      * @return the rendered Drawable
      */
     Drawable getDrawable(byte[] tileData) throws LowMemoryException;
@@ -73,4 +71,7 @@ public interface ITileSource {
 
     public String getTileURLString(MapTile tile);
 
+    public long getCacheTime();
+
+    public void setCacheTime(long cacheTime);
 }

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/OnlineTileSourceBase.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/OnlineTileSourceBase.java
@@ -6,6 +6,7 @@ import org.mozilla.osmdroid.tileprovider.MapTile;
 public abstract class OnlineTileSourceBase extends BitmapTileSourceBase {
 
     public String mBaseUrls[];
+    private long mCacheTime = 12 * 60 * 60 * 1000;
 
     /**
      * Constructor
@@ -33,5 +34,15 @@ public abstract class OnlineTileSourceBase extends BitmapTileSourceBase {
      */
     protected String getBaseUrl() {
         return mBaseUrls[random.nextInt(mBaseUrls.length)];
+    }
+
+    @Override
+    public long getCacheTime() {
+        return mCacheTime;
+    }
+
+    @Override
+    public void setCacheTime(long aCacheTime) {
+        mCacheTime = aCacheTime;
     }
 }

--- a/android/src/test/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTileTest.java
+++ b/android/src/test/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTileTest.java
@@ -88,7 +88,7 @@ public class SerializableTileTest {
         sTile.setTileData(tileData);
 
         SerializableTile newTile = new SerializableTile();
-        sTile.saveFile(temp);
+        sTile.saveFile(temp, 0);
         newTile.fromFile(temp);
 
         // There's going to be an etag header


### PR DESCRIPTION
This PR increases the cache time of map tiles to 7 days, while leaving the cache time of the coverage overlay unchanged at 12 hours.
From what I read from the code, the cache is only cleared when it is exceeding `OSMConstants.TILE_MAX_CACHE_SIZE_BYTES` (which is at a pretty high value of 600MB).
So this should only influence how long cached map tiles are assumed to be current and thus reduce data usage.
