### PR TITLE
Pushes HttpUtil into the ServiceLocator

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -19,6 +19,7 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,10 +32,8 @@ public class Updater {
     private static final String LOG_TAG = AppGlobals.makeLogTag(Updater.class.getSimpleName());
     private static final String LATEST_URL = "https://github.com/mozilla/MozStumbler/releases/latest";
     private static final String APK_URL_FORMAT = "https://github.com/mozilla/MozStumbler/releases/download/v%s/MozStumbler-v%s.apk";
-    private final IHttpUtil httpClient;
 
-    public Updater(IHttpUtil httpUtil) {
-        httpClient = httpUtil;
+    public Updater() {
     }
 
     public boolean wifiExclusiveAndUnavailable(Context c) {
@@ -57,6 +56,7 @@ public class Updater {
         new AsyncTask<Void, Void, IResponse>() {
             @Override
             public IResponse doInBackground(Void... params) {
+                IHttpUtil httpClient = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
                 return httpClient.head(LATEST_URL, null);
             }
 
@@ -234,6 +234,7 @@ public class Updater {
         }
 
         try {
+            IHttpUtil httpClient = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
             return httpClient.getUrlAsFile(url, file);
         } catch (IOException e) {
             Log.e(LOG_TAG, "", e);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MLSLocationGetter.java
@@ -17,6 +17,7 @@ import org.mozilla.mozstumbler.service.core.http.ILocationService;
 import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.core.http.MLS;
 import org.mozilla.mozstumbler.service.utils.LocationAdapter;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -41,7 +42,7 @@ public class MLSLocationGetter extends AsyncTask<String, Void, Location> {
         mCallback = callback;
         mQueryMLSBytes  = mlsQueryObj.toString().getBytes();
 
-        IHttpUtil httpUtil = new HttpUtil();
+        IHttpUtil httpUtil = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
         mls = new MLS(httpUtil);
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -42,6 +42,7 @@ import org.mozilla.mozstumbler.service.core.http.HttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.osmdroid.ResourceProxy;
 import org.mozilla.osmdroid.api.IGeoPoint;
 import org.mozilla.osmdroid.events.DelayedMapListener;
@@ -316,8 +317,7 @@ public class MapFragment extends android.support.v4.app.Fragment
                     mGetUrl.schedule(new TimerTask() {
                         @Override
                         public void run() {
-                            IHttpUtil httpUtil = new HttpUtil();
-
+                            IHttpUtil httpUtil = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
                             java.util.Scanner scanner;
                             try {
                                 scanner = new java.util.Scanner(httpUtil.getUrlAsStream(COVERAGE_REDIRECT_URL), "UTF-8");

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.mozstumbler.client.navdrawer;
 
+import android.app.Service;
 import android.appwidget.AppWidgetManager;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -38,6 +39,7 @@ import org.mozilla.mozstumbler.client.subactivities.FirstRunFragment;
 import org.mozilla.mozstumbler.client.subactivities.LeaderboardActivity;
 import org.mozilla.mozstumbler.service.core.http.HttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 
 public class MainDrawerActivity
         extends ActionBarActivity
@@ -116,9 +118,8 @@ public class MainDrawerActivity
 
         getApp().setMainActivity(this);
 
-        IHttpUtil httpUtil = new HttpUtil();
         if (BuildConfig.GITHUB) {
-            Updater upd = new Updater(httpUtil);
+            Updater upd = new Updater();
             upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
         }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -19,6 +19,7 @@ import org.mozilla.mozstumbler.service.core.http.MLS;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.service.utils.Zipper;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -123,7 +124,7 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
             return;
         }
 
-        IHttpUtil httpUtil = new HttpUtil();
+        IHttpUtil httpUtil = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
         ILocationService mls = new MLS(httpUtil);
         DataStorageManager dm = DataStorageManager.getInstance();
 

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
@@ -3,9 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.mozstumbler.svclocator;
 
+import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
-import org.mozilla.mozstumbler.svclocator.services.SystemClock;
 
+import java.lang.reflect.Constructor;
 import java.util.HashMap;
 
 public class ServiceConfig extends HashMap<Class<?>, Object> {
@@ -16,9 +17,39 @@ public class ServiceConfig extends HashMap<Class<?>, Object> {
 
         ServiceConfig result = new ServiceConfig();
 
-        result.put(ISystemClock.class, new SystemClock());
+        // All classes here must have an argument free constructor.
+        result.put(ISystemClock.class, load("org.mozilla.mozstumbler.svclocator.services.SystemClock"));
+        result.put(IHttpUtil.class, load("org.mozilla.mozstumbler.service.core.http.HttpUtil"));
 
         return result;
     }
 
+    public static Object load(String className) {
+
+        Class<?> c = null;
+        try {
+            c = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Error loading ScanResult class");
+        }
+        Constructor[] constructors = c.getConstructors();
+
+        Constructor<?> myConstructor= null;
+        for (Constructor<?> construct: constructors) {
+            if (construct.getParameterTypes().length == 0) {
+                myConstructor = construct;
+                break;
+            }
+        }
+
+        if (myConstructor == null) {
+            throw new RuntimeException("No constructor found");
+        }
+
+        try {
+            return myConstructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e.toString());
+        }
+    }
 }

--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
@@ -6,6 +6,7 @@ import org.mozilla.mozstumbler.service.core.http.HttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.core.logging.Log;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.osmdroid.tileprovider.MapTile;
 import org.mozilla.osmdroid.tileprovider.tilesource.ITileSource;
 import org.mozilla.osmdroid.tileprovider.util.StreamUtils;
@@ -131,7 +132,7 @@ public class TileDownloaderDelegate {
         // downloading again.
         HTTP404_CACHE.remove(tileURLString);
 
-        IHttpUtil httpClient = new HttpUtil();
+        IHttpUtil httpClient = (IHttpUtil) ServiceLocator.getInstance().getService(IHttpUtil.class);
         IResponse resp = httpClient.get(tileURLString, null);
 
         if (resp == null) {


### PR DESCRIPTION
This fixes a long standing oddity that IHttpUtil was passed in as a reference sometimes, and instantiated raw other times.

Now we just grab it from the ServiceLocator.

The UpdaterTest has been simplified to overload the mock networking
using the ServiceLocator.

Minor changes to ServiceConfig are included so that only strings are
needed to instantiate classes, so that the ServiceConfig class does
not need build time dependencies on any other class.
