### PR TITLE
Features/1.5.5 hotfixes

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -37,14 +37,17 @@ import org.mozilla.mozstumbler.client.Updater;
 import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.mozstumbler.client.subactivities.FirstRunFragment;
 import org.mozilla.mozstumbler.client.subactivities.LeaderboardActivity;
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.http.HttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
+import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 
 public class MainDrawerActivity
         extends ActionBarActivity
         implements IMainActivity {
 
+    private static final String LOG_TAG = AppGlobals.makeLogTag(MainDrawerActivity.class);
     private DrawerLayout mDrawerLayout;
     private ActionBarDrawerToggle mDrawerToggle;
     private MetricsView mMetricsView;
@@ -321,6 +324,11 @@ public class MainDrawerActivity
             remoteViews.setImageViewResource(R.id.toggleServiceButton, R.drawable.ic_status_scanning);
             remoteViews.setViewVisibility(R.id.stumbler_info_bar, View.INVISIBLE);
         }
-        (AppWidgetManager.getInstance(getApplicationContext())).updateAppWidget(new ComponentName(getApplicationContext(), ToggleWidgetProvider.class), remoteViews);
+        try {
+
+            (AppWidgetManager.getInstance(getApplicationContext())).updateAppWidget(new ComponentName(getApplicationContext(), ToggleWidgetProvider.class), remoteViews);
+        } catch (RuntimeException rEx) {
+            Log.w(LOG_TAG, "Error with updating widget: " + rEx.toString());
+        }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -4,7 +4,6 @@
 
 package org.mozilla.mozstumbler.client.navdrawer;
 
-import android.app.Service;
 import android.appwidget.AppWidgetManager;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -23,8 +22,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.CompoundButton;
-import android.widget.Switch;
 import android.widget.RemoteViews;
+import android.widget.Switch;
 
 import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.R;
@@ -38,10 +37,10 @@ import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.mozstumbler.client.subactivities.FirstRunFragment;
 import org.mozilla.mozstumbler.client.subactivities.LeaderboardActivity;
 import org.mozilla.mozstumbler.service.AppGlobals;
-import org.mozilla.mozstumbler.service.core.http.HttpUtil;
-import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.logging.Log;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.AppWidgetManagerProxy;
+import org.mozilla.mozstumbler.svclocator.services.IAppWidgetManagerProxy;
 
 public class MainDrawerActivity
         extends ActionBarActivity
@@ -53,7 +52,7 @@ public class MainDrawerActivity
     private MetricsView mMetricsView;
     private MapFragment mMapFragment;
     private MenuItem mMenuItemStartStop;
-    private RemoteViews remoteViews;
+    RemoteViews remoteViews;
 
     final CompoundButton.OnCheckedChangeListener mStartStopButtonListener =
             new CompoundButton.OnCheckedChangeListener() {
@@ -309,7 +308,7 @@ public class MainDrawerActivity
         mMapFragment.stop();
     }
 
-    private void updateWidget(ClientStumblerService service) {
+    void updateWidget(ClientStumblerService service) {
         boolean isScanning = service.isScanning();
         if (isScanning) {
             remoteViews.setImageViewResource(R.id.toggleServiceButton, R.drawable.ic_launcher);
@@ -325,8 +324,11 @@ public class MainDrawerActivity
             remoteViews.setViewVisibility(R.id.stumbler_info_bar, View.INVISIBLE);
         }
         try {
-
-            (AppWidgetManager.getInstance(getApplicationContext())).updateAppWidget(new ComponentName(getApplicationContext(), ToggleWidgetProvider.class), remoteViews);
+            ServiceLocator svcLocator = ServiceLocator.getInstance();
+            AppWidgetManagerProxy managerProxy = (AppWidgetManagerProxy) svcLocator.getService(IAppWidgetManagerProxy.class);
+            managerProxy.updateAppWidget(getApplicationContext(),
+                    new ComponentName(getApplicationContext(), ToggleWidgetProvider.class),
+                    remoteViews);
         } catch (RuntimeException rEx) {
             Log.w(LOG_TAG, "Error with updating widget: " + rEx.toString());
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/core/logging/Log.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/core/logging/Log.java
@@ -1,5 +1,7 @@
 package org.mozilla.mozstumbler.service.core.logging;
 
+import android.support.v4.util.CircularArray;
+
 import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.service.AppGlobals;
 
@@ -13,9 +15,13 @@ import java.io.Writer;
  */
 public class Log {
 
+    public static CircularArray<String> messageBuffer = new CircularArray<String>(10);
+
     public static void w(String logTag, String s) {
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
-            System.out.println("W: " + logTag + ", " + s);
+            String msg = "W: " + logTag + ", " + s;
+            System.out.println(msg);
+            messageBuffer.addLast(msg);
         } else {
             android.util.Log.w(logTag, s);
         }
@@ -45,10 +51,13 @@ public class Log {
         }
 
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
-            System.out.println("E: " + logTag + ", " + s);
+            msg = "E: " + logTag + ", " + s;
+            System.out.println(msg);
             if (e != null) {
                 e.printStackTrace();
             }
+            messageBuffer.addLast(msg);
+
         } else {
             android.util.Log.e(logTag, s + ":" + msg);
         }
@@ -58,7 +67,9 @@ public class Log {
 
     public static void i(String logTag, String s) {
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
-            System.out.println("i: " + logTag + ", " + s);
+            String msg = "i: " + logTag + ", " + s;
+            System.out.println(msg);
+            messageBuffer.addLast(msg);
         } else {
             android.util.Log.i(logTag, s);
         }
@@ -71,7 +82,9 @@ public class Log {
         }
 
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
-            System.out.println("d: " + logTag + ", " + s);
+            String msg = "d: " + logTag + ", " + s;
+            System.out.println(msg);
+            messageBuffer.addLast(msg);
         } else {
             android.util.Log.d(logTag, s);
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceConfig.java
@@ -4,6 +4,7 @@
 package org.mozilla.mozstumbler.svclocator;
 
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
+import org.mozilla.mozstumbler.svclocator.services.IAppWidgetManagerProxy;
 import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
 
 import java.lang.reflect.Constructor;
@@ -18,8 +19,12 @@ public class ServiceConfig extends HashMap<Class<?>, Object> {
         ServiceConfig result = new ServiceConfig();
 
         // All classes here must have an argument free constructor.
-        result.put(ISystemClock.class, load("org.mozilla.mozstumbler.svclocator.services.SystemClock"));
-        result.put(IHttpUtil.class, load("org.mozilla.mozstumbler.service.core.http.HttpUtil"));
+        result.put(ISystemClock.class,
+                load("org.mozilla.mozstumbler.svclocator.services.SystemClock"));
+        result.put(IAppWidgetManagerProxy.class,
+                load("org.mozilla.mozstumbler.svclocator.services.AppWidgetManagerProxy"));
+        result.put(IHttpUtil.class,
+                load("org.mozilla.mozstumbler.service.core.http.HttpUtil"));
 
         return result;
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/AppWidgetManagerProxy.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/AppWidgetManagerProxy.java
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.svclocator.services;
+
+import android.appwidget.AppWidgetManager;
+
+/*
+ This class just provides a proxy around the AppWidgetManager so that we can safely mock it out
+ when we need to run tests.
+ */
+public class AppWidgetManagerProxy {
+    public void updateAppWidget(android.content.Context context,
+                                android.content.ComponentName provider,
+                                android.widget.RemoteViews views) {
+        AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        manager.updateAppWidget(provider, views);
+    }
+
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/IAppWidgetManagerProxy.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/svclocator/services/IAppWidgetManagerProxy.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.svclocator.services;
+
+public interface IAppWidgetManagerProxy {
+    public void updateAppWidget(android.content.Context context,
+                                android.content.ComponentName provider,
+                                android.widget.RemoteViews views);
+}

--- a/android/src/test/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivityTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivityTest.java
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client.navdrawer;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.widget.RemoteViews;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.R;
+import org.mozilla.mozstumbler.client.ClientStumblerService;
+import org.mozilla.mozstumbler.service.core.logging.Log;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.AppWidgetManagerProxy;
+import org.mozilla.mozstumbler.svclocator.services.IAppWidgetManagerProxy;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ActivityController;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class MainDrawerActivityTest {
+
+    @Before
+    public void setup() {
+        while (!Log.messageBuffer.isEmpty()) {
+            Log.messageBuffer.popLast();
+        }
+    }
+
+
+    @Test
+    public void testUpdateWidget() {
+        // Sometimes, the widget will die because AppWidgetManager::updateAppWidget will throw
+        // a runtime-exception.  We don't want the whole application to die if this is the case.
+        // Just stop updating the widget.
+
+        ActivityController<MainDrawerActivity> controller = Robolectric.buildActivity(MainDrawerActivity.class);
+        MainDrawerActivity activity = controller.get();
+
+        ClientStumblerService clientStumberSvc = mock(ClientStumblerService.class);
+
+        // Mock out the AppWidgetManager
+
+        AppWidgetManagerProxy myMockProxy = spy(new AppWidgetManagerProxy());
+
+        doThrow(new RuntimeException()).when(myMockProxy).updateAppWidget(any(Context.class),
+                any(ComponentName.class),
+                any(RemoteViews.class));
+
+
+        activity.remoteViews =  new RemoteViews(Robolectric.application.getPackageName(),
+                R.layout.toggle_widget);
+
+        ServiceLocator.getInstance().putService(IAppWidgetManagerProxy.class, myMockProxy);
+        activity.updateWidget(clientStumberSvc);
+
+        // Check that a runtime exception was logged
+        assertEquals(1, Log.messageBuffer.size());
+
+        String msg = Log.messageBuffer.getLast();
+        assertTrue(msg.contains("Error with updating widget"));
+    }
+
+}


### PR DESCRIPTION
This adds an AppWidgetManagerProxy service to the list of injected services. This is required for testing as the AppWidgetManager is normally a global singeton and there is no easy way of mocking that service.

A RuntimeException check has been added around the AppWidgetManager::updateAppWidget call to prevent application death.  A bug tracking a proper fix for this has been filed in #1396
