### PR TITLE
Improve etag usage when downloading map tiles

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SmartFSProvider.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SmartFSProvider.java
@@ -215,7 +215,7 @@ public class SmartFSProvider extends MapTileModuleProviderBase {
             }
 
             boolean writeOK = false;
-            writeOK = delegate.downloadTile(tileSource, tile);
+            writeOK = delegate.downloadTile(serializableTile, tileSource, tile);
 
             // @TODO: the writeOK flag isn't always going to succeed
             // because of network failures - just ignore it for now


### PR DESCRIPTION
This removes the extra request that is done to only check the map tile etag status. Instead, the etag is checked when an actual tile download happens. This way, the response can be used in case of a non-matching etag as well. See https://github.com/mozilla/MozStumbler/issues/1323#issuecomment-69102515
