### PR TITLE
Motion detection options: off, on, or extra power savings

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -17,7 +17,6 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
 import android.text.TextUtils;
-import android.widget.Toast;
 
 import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
@@ -200,9 +199,14 @@ public class PreferencesScreen extends PreferenceActivity {
         mPowerSavingMode.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-                int i = mPowerSavingMode.findIndexOfValue(newValue.toString());
+                final int i = mPowerSavingMode.findIndexOfValue(newValue.toString());
                 getPrefs().setPowerSavingMode(i);
                 updatePowerSavingMode(i);
+                final MainApp app = ((MainApp) getApplication());
+                if (app.isScanningOrPaused()) {
+                    app.stopScanning();
+                    app.startScanning();
+                }
                 return true;
             }
         });

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -33,6 +33,7 @@ public class PreferencesScreen extends PreferenceActivity {
     private CheckBoxPreference mEnableShowMLSLocations;
     private CheckBoxPreference mCrashReportsOn;
     private ListPreference mMapTileDetail;
+    private ListPreference mPowerSavingMode;
 
     private ClientPrefs getPrefs() {
         return ClientPrefs.getInstance(this);
@@ -57,6 +58,11 @@ public class PreferencesScreen extends PreferenceActivity {
         int valueIndex = ClientPrefs.getInstance(this).getMapTileResolutionType().ordinal();
         mMapTileDetail.setValueIndex(valueIndex);
         updateMapDetailTitle(valueIndex);
+
+        mPowerSavingMode = (ListPreference) getPreferenceManager().findPreference(Prefs.POWER_SAVING_MODE);
+        valueIndex = Prefs.getInstance(this).getPowerSavingMode().ordinal();
+        mPowerSavingMode.setValueIndex(valueIndex);
+        updatePowerSavingMode(valueIndex);
 
         setPreferenceListener();
         setButtonListeners();
@@ -117,6 +123,11 @@ public class PreferencesScreen extends PreferenceActivity {
         mMapTileDetail.setTitle(
             getString(R.string.map_tile_resolution_options_label) + " " +
             mMapTileDetail.getEntries()[index]);
+    }
+
+    private void updatePowerSavingMode(int index) {
+        mPowerSavingMode.setTitle(getString(R.string.power_saving_mode) + ": " +
+            mPowerSavingMode.getEntries()[index]);
     }
 
     private void setPreferenceListener() {
@@ -183,6 +194,15 @@ public class PreferencesScreen extends PreferenceActivity {
                 int i = mMapTileDetail.findIndexOfValue(newValue.toString());
                 getPrefs().setMapTileResolutionType(i);
                 updateMapDetailTitle(i);
+                return true;
+            }
+        });
+        mPowerSavingMode.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                int i = mPowerSavingMode.findIndexOfValue(newValue.toString());
+                getPrefs().setPowerSavingMode(i);
+                updatePowerSavingMode(i);
                 return true;
             }
         });

--- a/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
@@ -18,6 +18,7 @@ public class Prefs {
     public static final String NICKNAME_PREF = "nickname";
     public static final String EMAIL_PREF = "email";
     public static final String WIFI_ONLY = "wifi_only";
+    public static final String POWER_SAVING_MODE = "power_saving_mode_type";
     protected static final String PREFS_FILE = Prefs.class.getSimpleName();
     private static final String LOG_TAG = AppGlobals.makeLogTag(Prefs.class.getSimpleName());
     private static final String USER_AGENT_PREF = "user-agent";
@@ -38,6 +39,8 @@ public class Prefs {
 
     private static final String SAVE_STUMBLE_LOGS = "save_stumble_logs";
     private final SharedPreferences mSharedPrefs;
+
+    public enum PowerSavingModeOptions { Off, On, Aggressive }
 
     protected static Prefs sInstance;
 
@@ -256,4 +259,24 @@ public class Prefs {
         apply(editor);
     }
 
+    public void setPowerSavingMode(int index) {
+        if (index >= PowerSavingModeOptions.values().length) {
+            index = 0;
+        }
+        setPowerSavingMode(PowerSavingModeOptions.values()[index]);
+    }
+
+    public void setPowerSavingMode(PowerSavingModeOptions mode) {
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putInt(POWER_SAVING_MODE, mode.ordinal());
+        apply(editor);
+    }
+
+    public PowerSavingModeOptions getPowerSavingMode() {
+        int i = getPrefs().getInt(POWER_SAVING_MODE, 1);
+        if (i >= PowerSavingModeOptions.values().length) {
+            i = 0;
+        }
+        return PowerSavingModeOptions.values()[i];
+    }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -242,7 +242,8 @@ public class ScanManager {
     private final BroadcastReceiver mDetectUserIdleReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (!isScanning()) {
+            if (!isScanning() ||
+                Prefs.getInstance(mAppContext).getPowerSavingMode() == Prefs.PowerSavingModeOptions.Off) {
                 return;
             }
             stopScanning();
@@ -267,7 +268,9 @@ public class ScanManager {
             startScanning(context);
             mMotionSensor.stop();
 
-            mLocationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement();
+            if (Prefs.getInstance(mAppContext).getPowerSavingMode() == Prefs.PowerSavingModeOptions.Aggressive) {
+                mLocationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement();
+            }
 
             Intent sendIntent = new Intent(ACTION_SCAN_PAUSED_USER_MOTIONLESS);
             sendIntent.putExtra(ACTION_EXTRA_IS_PAUSED, mIsMotionlessPausedState);

--- a/android/src/main/res/values/arrays.xml
+++ b/android/src/main/res/values/arrays.xml
@@ -15,4 +15,11 @@
         <item>60%</item>
         <item>75%</item>
     </string-array>
+
+    <string-array name="power_saving_mode_options_intvalues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -165,12 +165,12 @@
     <string name="category_power_saving">Power Saving</string>
     <string name="power_saving_mode">Motion detection</string>
     <string name="power_saving_mode_summary">Pauses and unpauses the app if you aren\'t moving.
-        If your GPS takes a long time to get a fix, don\'t use Aggressive mode.</string>
+        If your GPS takes a long time to get a fix, don\'t use extra power saving mode.</string>
 
     <string-array name="power_saving_mode_options">
         <item>Off</item>
         <item>On</item>
-        <item>Aggressive</item>
+        <item>On, extra power saving</item>
     </string-array>
 
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -159,9 +159,18 @@
     <string name="motion_detection_options_conjunction">in</string>
     <string name="map_scanning_paused_no_motion">Location not changing, scanning paused.</string>
 
-
     <string name="save_stumble_logs">Save Stumble Logs</string>
     <string name="create_log_archive_failure">Unable to create archive directory for logs</string>
     <string name="create_log_archive_success">Logs will be save to:</string>
+    <string name="category_power_saving">Power Saving</string>
+    <string name="power_saving_mode">Motion detection</string>
+    <string name="power_saving_mode_summary">Pauses and unpauses the app if you aren\'t moving.
+        If your GPS takes a long time to get a fix, don\'t use Aggressive mode.</string>
+
+    <string-array name="power_saving_mode_options">
+        <item>Off</item>
+        <item>On</item>
+        <item>Aggressive</item>
+    </string-array>
 
 </resources>

--- a/android/src/main/res/xml/stumbler_preferences.xml
+++ b/android/src/main/res/xml/stumbler_preferences.xml
@@ -13,6 +13,18 @@
         android:summary="@string/enter_email_longtext" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/category_power_saving" >
+
+        <!-- friendly reminder: the android:key must match the name of the value in [Client]Prefs.java -->
+        <ListPreference
+            android:key="power_saving_mode_type"
+            android:title="@string/power_saving_mode"
+            android:entries="@array/power_saving_mode_options"
+            android:entryValues="@array/power_saving_mode_options_intvalues"
+            android:summary="@string/power_saving_mode_summary"
+            />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/category_network_usage" >
 
     <CheckBoxPreference


### PR DESCRIPTION
Issue #1394

Motion detection can be:
- off
- on
- on, with extra savings (a.k.a. aggressive mode), this requires that after detecting motion, there is a 20 sec window in which the GPS must show a change in location beyond the threshold (default is 50m).

The previous default (before this code lands) was "On, with extra savings". The new default state is to have motion detection "On", but not to call LocationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement() which I suspect is causing the problem we are seeing.

This is the end of the fix. If this commit fixes the problem, then we should try to get the above function working better in all cases. 
