### PR TITLE
Show MLS coverage overlay when offline

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/XYTileSource.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/tilesource/XYTileSource.java
@@ -17,7 +17,12 @@ public class XYTileSource extends OnlineTileSourceBase implements ITileSource {
 
     @Override
     public String getTileURLString(final MapTile aTile) {
-        return getBaseUrl() + aTile.getZoomLevel() + "/" + aTile.getX() + "/" + aTile.getY()
+        final String baseUrl = getBaseUrl();
+        if (baseUrl == null) {
+            return null;
+        }
+
+        return baseUrl + aTile.getZoomLevel() + "/" + aTile.getX() + "/" + aTile.getY()
                 + mImageFilenameEnding;
     }
 }


### PR DESCRIPTION
This fixes #1401 

Initially no internet access available:
- `CoverageOverlay` will have URL = `null`, but yet it is able to display cached tiles

Internet access becomes available:
- `sCoverageUrl` will be updated
- coverage tiles are removed
- coverage tiles are then added back with the right URL

Intended changes:
- removed check for `mCoverageTilesOverlayLowZoom != null` is still done in `initOnMainThread()`
- just move `scanner` code so that `initOnMainThread()` is always called
- always remove coverage layers when `sCoverageUrl` is set, they are then added back in `initOnMainThread()`
