### PR TITLE
Reduce data: cellular map (mLowResMapOverlays) uses same cache as wi-fi (mHighResMapSource)

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -478,7 +478,7 @@ public class MapFragment extends android.support.v4.app.Fragment
             if (!isMLSTileStore) {
                 mHighResMapSource = TileSourceFactory.MAPQUESTOSM;
             } else {
-                mHighResMapSource = new XYTileSource("Stumbler-BaseMap-Tiles",
+                mHighResMapSource = new XYTileSource(AbstractMapOverlay.MLS_MAP_TILE_BASE_NAME,
                         null, 1, AbstractMapOverlay.MAX_ZOOM_LEVEL_OF_MAP,
                         AbstractMapOverlay.TILE_PIXEL_SIZE,
                         AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public abstract class AbstractMapOverlay extends TilesOverlay {
+    public static final String MLS_MAP_TILE_BASE_NAME = "Stumbler-BaseMap-Tiles";
     // We want the map to zoom to level 20, even if tiles have less zoom available
     public static final int MAX_ZOOM_LEVEL_OF_MAP = 20;
     private static int sMinZoomLevelOfMapDisplaySizeBased;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -23,15 +23,15 @@ public class LowResMapOverlay extends AbstractMapOverlay {
         final int zoomLevel = (type == LowResType.HIGHER_ZOOM)?
                 AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
 
-        ITileSource coverageTileSource;
+        ITileSource mapTileSource;
         if (isMLSTileStore) {
-            coverageTileSource = new XYTileSource("MLS-coverage-tiles", null,
+            mapTileSource = new XYTileSource(MLS_MAP_TILE_BASE_NAME, null,
                     zoomLevel, zoomLevel,
                     AbstractMapOverlay.TILE_PIXEL_SIZE,
                     AbstractMapOverlay.FILE_TYPE_SUFFIX_PNG,
                     new String[]{BuildConfig.TILE_SERVER_URL});
         } else {
-            coverageTileSource = new XYTileSource("MapquestOSM", ResourceProxy.string.mapquest_osm,
+            mapTileSource = new XYTileSource("MapquestOSM", ResourceProxy.string.mapquest_osm,
                     zoomLevel, zoomLevel,
                     AbstractMapOverlay.TILE_PIXEL_SIZE, ".jpg", new String[]{
                     "http://otile1.mqcdn.com/tiles/1.0.0/map/",
@@ -41,6 +41,6 @@ public class LowResMapOverlay extends AbstractMapOverlay {
         }
         this.setLoadingBackgroundColor(Color.TRANSPARENT);
         mTileProvider.setTileRequestCompleteHandler(new SimpleInvalidationHandler(mapView));
-        mTileProvider.setTileSource(coverageTileSource);
+        mTileProvider.setTileSource(mapTileSource);
     }
 }


### PR DESCRIPTION
Low-res and high-res map tiles are using the same URL, but not the same name for caching.
If the name is the same, then map tiles already downloaded in high-res mode can be used in low-res mode as well (and vice versa).
This is already the case if `!isMLSTileStore`. In that case, both are using the name "MapquestOSM".
