### PR TITLE
hotfix to patch NPE on motionsensor code

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -135,7 +135,7 @@ public class MainApp extends Application
         AppGlobals.appVersionCode = BuildConfig.VERSION_CODE;
         AppGlobals.appName = this.getResources().getString(R.string.app_name);
 
-        AppGlobals.hasSignificantMotionSensor = new MotionSensor(this, null).hasSignificantMotionSensor();
+        AppGlobals.hasSignificantMotionSensor = (MotionSensor.getSignificantMotionSensor(this) != null);
 
         AsyncUploader.setGlobalUploadListener(this);
 


### PR DESCRIPTION
Hotfix to patch a crash with the new motionsensor code in 1.6.0.  

Tests to follow, but this adds a null check before registering an intent listener for ACTION_USER_MOTION_DETECTED. 

I've also extracted the acquisition of the significant motion sensor into a static method that takes a single context argument so that you don't need to instantiate the MotionSensor just to ask if there is a system service that provides the proper sensor.
