### PR TITLE
Rate limit update checks (github builds)

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -32,6 +32,8 @@ public class Updater {
     private static final String LOG_TAG = AppGlobals.makeLogTag(Updater.class.getSimpleName());
     private static final String LATEST_URL = "https://github.com/mozilla/MozStumbler/releases/latest";
     private static final String APK_URL_FORMAT = "https://github.com/mozilla/MozStumbler/releases/download/v%s/MozStumbler-v%s.apk";
+    private static final long UPDATE_CHECK_FREQ = 6 * 60 * 60 * 1000; // 6 hours
+    private static long sLastUpdateCheck = 0;
 
     public Updater() {
     }
@@ -40,11 +42,21 @@ public class Updater {
         return !NetworkInfo.getInstance().isWifiAvailable() && ClientPrefs.getInstance(c).getUseWifiOnly();
     }
 
+    public boolean checkForUpdatesRateLimited(final Activity activity, String api_key) {
+        if (System.currentTimeMillis() - sLastUpdateCheck < UPDATE_CHECK_FREQ) {
+            return false;
+        }
+        return this.checkForUpdates(activity, api_key);
+    }
 
     public boolean checkForUpdates(final Activity activity, String api_key) {
 
         // No API Key means skip the update
         if (api_key == null || api_key.equals("")) {
+            return false;
+        }
+
+        if (!NetworkInfo.getInstance().isConnected()) {
             return false;
         }
 
@@ -99,6 +111,7 @@ public class Updater {
             }
         }.execute();
 
+        sLastUpdateCheck = System.currentTimeMillis();
         return true;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -112,7 +112,7 @@ public class MainDrawerActivity
 
         if (BuildConfig.GITHUB) {
             Updater upd = new Updater();
-            upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
+            upd.checkForUpdatesRateLimited(this, BuildConfig.MOZILLA_API_KEY);
         }
 
         mMetricsView = new MetricsView(findViewById(R.id.left_drawer));

--- a/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -31,6 +31,16 @@ public final class NetworkInfo {
         return sInstance;
     }
 
+    public synchronized boolean isConnected() {
+        if (mConnectivityManager == null) {
+            Log.e(LOG_TAG, "ConnectivityManager is null!");
+            return false;
+        }
+
+        android.net.NetworkInfo aNet = mConnectivityManager.getActiveNetworkInfo();
+        return (aNet != null && aNet.isConnected());
+    }
+
     public synchronized boolean isWifiAvailable() {
         if (mConnectivityManager == null) {
             Log.e(LOG_TAG, "ConnectivityManager is null!");


### PR DESCRIPTION
This fixes #324 by only checking for updates once every 6 hours, and on app start, but still makes sure that updates are checked if there was no useable network connection previously. This only affects github builds.
