### PR TITLE
Minor bugfixes

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -210,11 +210,11 @@ public class MainDrawerActivity
         mMetricsView.update();
 
         ClientPrefs prefs = ClientPrefs.getInstance(this);
-
-        if (ClientPrefs.getInstance(this).isFirstRun()) {
+        if (prefs.isFirstRun()) {
             FragmentManager fm = getSupportFragmentManager();
             FirstRunFragment.showInstance(fm);
             prefs.setDontShowChangelog();
+            MainApp.getAndSetHasBootedOnce();
         } else if (!MainApp.getAndSetHasBootedOnce()) {
 
             long currentVersionNumber = BuildConfig.VERSION_CODE;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/LogActivity.java
@@ -159,6 +159,7 @@ public class LogActivity extends ActionBarActivity {
     @Override
     protected void onPause() {
         super.onPause();
+        mConsoleView.clear();
         sConsoleView = null;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -137,12 +137,6 @@ public class ScanManager {
             mMotionSensor = new MotionSensor(mAppContext, mDetectMotionReceiver);
         }
 
-        if (mGPSScanner == null) {
-            mGPSScanner = new GPSScanner(mAppContext, this);
-            mWifiScanner = new WifiScanner(mAppContext);
-            mCellScanner = new CellScanner(mAppContext);
-        }
-
         if (AppGlobals.isDebug) {
             // Simulation contexts are only allowed for debug builds.
             Prefs prefs = Prefs.getInstanceWithoutContext();


### PR DESCRIPTION
I hope these fixes are simple enough to put them into just one PR.

In `MainDrawerActivity`: set `hasBootedOnce` on first run, so that scanning does not restart unexpectedly

In `LogActivity`: fixes #1429 

In `ScanManager`: remove unused code, all those variables are always reassigned a few lines below
