### PR TITLE
Features/GitHub throttling

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -43,15 +43,10 @@ public class Updater {
     }
 
 
-    public boolean checkForUpdatesRateLimited(final Activity activity, String api_key) {
+    public boolean checkForUpdates(final Activity activity, String api_key) {
         if (System.currentTimeMillis() - sLastUpdateCheck < UPDATE_CHECK_FREQ) {
             return false;
         }
-        return this.checkForUpdates(activity, api_key);
-    }
-
-
-    public boolean checkForUpdates(final Activity activity, String api_key) {
 
         // No API Key means skip the update
         if (api_key == null || api_key.equals("")) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -19,6 +19,7 @@ import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.http.IResponse;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.File;
@@ -32,11 +33,8 @@ public class Updater {
     private static final String LOG_TAG = LoggerUtil.makeLogTag(Updater.class);
     private static final String LATEST_URL = "https://github.com/mozilla/MozStumbler/releases/latest";
     private static final String APK_URL_FORMAT = "https://github.com/mozilla/MozStumbler/releases/download/v%s/MozStumbler-v%s.apk";
-     private static final long UPDATE_CHECK_FREQ = 6 * 60 * 60 * 1000; // 6 hours
-     private static long sLastUpdateCheck = 0;
-
-    public Updater() {
-    }
+    public static final long UPDATE_CHECK_FREQ_MS = 6 * 60 * 60 * 1000; // 6 hours
+    static long sLastUpdateCheck = 0;
 
     public boolean wifiExclusiveAndUnavailable(Context c) {
         return !NetworkInfo.getInstance().isWifiAvailable() && ClientPrefs.getInstance(c).getUseWifiOnly();
@@ -44,7 +42,10 @@ public class Updater {
 
 
     public boolean checkForUpdates(final Activity activity, String api_key) {
-        if (System.currentTimeMillis() - sLastUpdateCheck < UPDATE_CHECK_FREQ) {
+
+        ISystemClock clock = (ISystemClock) ServiceLocator.getInstance().getService(ISystemClock.class);
+
+        if (clock.currentTimeMillis() - sLastUpdateCheck < UPDATE_CHECK_FREQ_MS) {
             return false;
         }
 
@@ -108,7 +109,7 @@ public class Updater {
             }
         }.execute();
 
-        sLastUpdateCheck = System.currentTimeMillis();
+        sLastUpdateCheck = clock.currentTimeMillis();
         return true;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/Updater.java
@@ -32,6 +32,8 @@ public class Updater {
     private static final String LOG_TAG = LoggerUtil.makeLogTag(Updater.class);
     private static final String LATEST_URL = "https://github.com/mozilla/MozStumbler/releases/latest";
     private static final String APK_URL_FORMAT = "https://github.com/mozilla/MozStumbler/releases/download/v%s/MozStumbler-v%s.apk";
+     private static final long UPDATE_CHECK_FREQ = 6 * 60 * 60 * 1000; // 6 hours
+     private static long sLastUpdateCheck = 0;
 
     public Updater() {
     }
@@ -41,10 +43,22 @@ public class Updater {
     }
 
 
+    public boolean checkForUpdatesRateLimited(final Activity activity, String api_key) {
+        if (System.currentTimeMillis() - sLastUpdateCheck < UPDATE_CHECK_FREQ) {
+            return false;
+        }
+        return this.checkForUpdates(activity, api_key);
+    }
+
+
     public boolean checkForUpdates(final Activity activity, String api_key) {
 
         // No API Key means skip the update
         if (api_key == null || api_key.equals("")) {
+            return false;
+        }
+
+        if (!NetworkInfo.getInstance().isConnected()) {
             return false;
         }
 
@@ -99,6 +113,7 @@ public class Updater {
             }
         }.execute();
 
+        sLastUpdateCheck = System.currentTimeMillis();
         return true;
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -121,7 +121,7 @@ public class MainDrawerActivity
 
         if (BuildConfig.GITHUB) {
             Updater upd = new Updater();
-            upd.checkForUpdatesRateLimited(this, BuildConfig.MOZILLA_API_KEY);
+            upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
         }
 
         mMetricsView = new MetricsView(findViewById(R.id.left_drawer));

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -121,7 +121,7 @@ public class MainDrawerActivity
 
         if (BuildConfig.GITHUB) {
             Updater upd = new Updater();
-            upd.checkForUpdates(this, BuildConfig.MOZILLA_API_KEY);
+            upd.checkForUpdatesRateLimited(this, BuildConfig.MOZILLA_API_KEY);
         }
 
         mMetricsView = new MetricsView(findViewById(R.id.left_drawer));

--- a/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
@@ -71,9 +71,6 @@ public class UpdaterTest {
         clock.setCurrentTime(now);
 
         assertTrue(upd.checkForUpdates(activity, "anything_else"));
-        now += Updater.UPDATE_CHECK_FREQ_MS;
-        clock.setCurrentTime(now);
-
         assertEquals("1.3.0", upd.stripBuildHostName("1.3.0.Victors-MBPr"));
         assertEquals("1.3.0", upd.stripBuildHostName("1.3.0"));
     }
@@ -95,14 +92,6 @@ public class UpdaterTest {
 
         // wifi is always unavailable
         doReturn(false).when(upd).wifiExclusiveAndUnavailable(Mockito.any(Context.class));
-
-        assertFalse(upd.checkForUpdates(activity, ""));
-        now += Updater.UPDATE_CHECK_FREQ_MS;
-        clock.setCurrentTime(now);
-
-        assertFalse(upd.checkForUpdates(activity, null));
-        now += Updater.UPDATE_CHECK_FREQ_MS;
-        clock.setCurrentTime(now);
 
         assertTrue(upd.checkForUpdates(activity, "anything_else"));
         now += Updater.UPDATE_CHECK_FREQ_MS;

--- a/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/UpdaterTest.java
@@ -13,6 +13,8 @@ import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.http.MockHttpUtil;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.MockSystemClock;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -34,6 +36,7 @@ public class UpdaterTest {
     @Before
     public void setUp() throws Exception {
         activity = Robolectric.newInstanceOf(MainDrawerActivity.class);
+        Updater.sLastUpdateCheck = 0;
     }
 
     @Test
@@ -49,20 +52,67 @@ public class UpdaterTest {
         upd = spy(upd);
 
         // Setup mocks.
-        // Replace the HTTP client
+        // Replace the HTTP client and clock
+        MockSystemClock clock = new MockSystemClock();
+        long now = System.currentTimeMillis();
+        clock.setCurrentTime(now);
         ServiceLocator.getInstance().putService(IHttpUtil.class, mockHttp);
+        ServiceLocator.getInstance().putService(ISystemClock.class, clock);
 
         // wifi is always unavailable
         doReturn(false).when(upd).wifiExclusiveAndUnavailable(Mockito.any(Context.class));
 
-
         assertFalse(upd.checkForUpdates(activity, ""));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
+
         assertFalse(upd.checkForUpdates(activity, null));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
+
         assertTrue(upd.checkForUpdates(activity, "anything_else"));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
 
         assertEquals("1.3.0", upd.stripBuildHostName("1.3.0.Victors-MBPr"));
         assertEquals("1.3.0", upd.stripBuildHostName("1.3.0"));
     }
+
+    @Test
+    public void testUpdaterThrottlesRequests() {
+        IHttpUtil mockHttp = new MockHttpUtil();
+
+        Updater upd = new Updater();
+        upd = spy(upd);
+
+        // Setup mocks.
+        // Replace the HTTP client and clock
+        MockSystemClock clock = new MockSystemClock();
+        long now = System.currentTimeMillis();
+        clock.setCurrentTime(now);
+        ServiceLocator.getInstance().putService(IHttpUtil.class, mockHttp);
+        ServiceLocator.getInstance().putService(ISystemClock.class, clock);
+
+        // wifi is always unavailable
+        doReturn(false).when(upd).wifiExclusiveAndUnavailable(Mockito.any(Context.class));
+
+        assertFalse(upd.checkForUpdates(activity, ""));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
+
+        assertFalse(upd.checkForUpdates(activity, null));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
+
+        assertTrue(upd.checkForUpdates(activity, "anything_else"));
+        now += Updater.UPDATE_CHECK_FREQ_MS;
+        clock.setCurrentTime(now);
+        assertTrue(upd.checkForUpdates(activity, "anything_else"));
+
+        // This should fail as the clock hasn't been pushed forward
+        assertFalse(upd.checkForUpdates(activity, "anything_else"));
+    }
+
 
     @Test(expected = RuntimeException.class)
     public void testUpdaterThrowsExceptions() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -12,23 +12,23 @@ import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 public final class NetworkInfo {
     private static final String LOG_TAG = LoggerUtil.makeLogTag(NetworkInfo.class);
-    static NetworkInfo sInstance;
+    static NetworkInfo instance;
     ConnectivityManager mConnectivityManager;
 
-    private NetworkInfo() {
-    }
+    // must be private as createGlobalInstance() is the entry point.
+    private NetworkInfo(){};
 
     /* Created at startup by app, or service, using a context. */
     public static synchronized void createGlobalInstance(Context context) {
         getInstance();
-        sInstance.mConnectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        instance.mConnectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 
     public static synchronized NetworkInfo getInstance() {
-        if (sInstance == null) {
-            sInstance = new NetworkInfo();
+        if (instance == null) {
+            instance = new NetworkInfo();
         }
-        return sInstance;
+        return instance;
     }
 
     public synchronized boolean isConnected() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -31,6 +31,16 @@ public final class NetworkInfo {
         return sInstance;
     }
 
+    public synchronized boolean isConnected() {
+        if (mConnectivityManager == null) {
+            Log.e(LOG_TAG, "ConnectivityManager is null!");
+            return false;
+        }
+
+        android.net.NetworkInfo aNet = mConnectivityManager.getActiveNetworkInfo();
+        return (aNet != null && aNet.isConnected());
+    }
+
     public synchronized boolean isWifiAvailable() {
         if (mConnectivityManager == null) {
             Log.e(LOG_TAG, "ConnectivityManager is null!");

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/MyShadowConnectivityManager.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/MyShadowConnectivityManager.java
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.utils;
+
+import android.net.*;
+
+import org.mockito.Mockito;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowConnectivityManager;
+
+import static org.mockito.Mockito.when;
+
+@Implements(ConnectivityManager.class)
+public class MyShadowConnectivityManager extends ShadowConnectivityManager {
+
+    private Boolean connectedFlag = false;
+
+    @Implementation
+    public android.net.NetworkInfo getActiveNetworkInfo() {
+
+        // NetworkInfo doesn't provide a proper constructor, so we're just going to clobber
+        // that with mockito.
+        final android.net.NetworkInfo networkInfo = Mockito.mock(android.net.NetworkInfo.class);
+        when(networkInfo.isConnected()).thenReturn(connectedFlag);
+        when(networkInfo.getType()).thenReturn(ConnectivityManager.TYPE_DUMMY);
+        return networkInfo;
+    }
+
+    public void setConnectedFlag(boolean flag) {
+        connectedFlag = flag;
+    }
+
+
+}

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTest.java
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.utils;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.robolectric.Robolectric.shadowOf;
+
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class NetworkInfoTest {
+
+    Context ctx;
+
+    @Before
+    public void setup() {
+        NetworkInfo.instance = null;
+        ctx = Robolectric.application;
+    }
+
+    @Test
+    @Config(shadows = {MyShadowConnectivityManager.class})
+    public void testIsConnectedNoConnManager() {
+        // Test that the isConnected method doesn't bomb out without a connection manager
+
+        // This first instance will have no connection manager
+        NetworkInfo ni = NetworkInfo.getInstance();
+        assertFalse(ni.isConnected());
+    }
+
+    @Test
+    public void testIsConnectedWithGlobal() {
+        NetworkInfo.createGlobalInstance(ctx);
+        NetworkInfo ni = NetworkInfo.getInstance();
+
+        ConnectivityManager connectivityManager = (ConnectivityManager) ctx.getSystemService(Context.CONNECTIVITY_SERVICE);
+        MyShadowConnectivityManager shadowConnManager = (MyShadowConnectivityManager) shadowOf(connectivityManager);
+
+        assertFalse(ni.isConnected());
+
+        shadowConnManager.setConnectedFlag(true);
+        assertTrue(ni.isConnected());
+    }
+
+
+}


### PR DESCRIPTION
This supercedes #1432.  The first commit recreates @cascheberg 's code on the new tree layout.

The 3 subsequent patches apply the comments in the review and add tests around the new logic added to `NetworkInfo` and the `Updater` class.

The testcases for NetworkInfo instrument a custom shadow of ConnectionManager to simulate different connection states.
