### PR TITLE
Cleaning up ScanManager stop/started/paused state

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -75,9 +75,11 @@ public class MainApp extends Application
     private ServiceBroadcastReceiver mReceiver;
     private WeakReference<IMainActivity> mMainActivity = new WeakReference<IMainActivity>(null);
     private boolean mIsScanningPausedDueToNoMotion;
-    private final BroadcastReceiver mReceivePausedState = new BroadcastReceiver() {
+    private final BroadcastReceiver mReceivePausedOrUnpausedState = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
-            mIsScanningPausedDueToNoMotion = intent.getBooleanExtra(ScanManager.ACTION_EXTRA_IS_PAUSED, false);
+            mIsScanningPausedDueToNoMotion =
+                intent.getAction().equals(ScanManager.ACTION_SCAN_PAUSED_USER_MOTIONLESS) && !mStumblerService.isStopped();
+
             new Handler(context.getMainLooper()).post(new Runnable() {
                 public void run() {
                     updateMotionDetected();
@@ -226,8 +228,9 @@ public class MainApp extends Application
         Intent intent = new Intent(this, ClientStumblerService.class);
         bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
 
-        LocalBroadcastManager.getInstance(this).
-                registerReceiver(mReceivePausedState, new IntentFilter(ScanManager.ACTION_SCAN_PAUSED_USER_MOTIONLESS));
+        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
+        lbm.registerReceiver(mReceivePausedOrUnpausedState, new IntentFilter(ScanManager.ACTION_SCAN_UNPAUSED_USER_MOVED));
+        lbm.registerReceiver(mReceivePausedOrUnpausedState, new IntentFilter(ScanManager.ACTION_SCAN_PAUSED_USER_MOTIONLESS));
     }
 
     private void checkSimulationPermission() {
@@ -323,7 +326,7 @@ public class MainApp extends Application
         if (mStumblerService == null) {
             return false;
         }
-        return mStumblerService.isScanning() || mIsScanningPausedDueToNoMotion;
+        return !mStumblerService.isStopped();
     }
 
     public void showDeveloperDialog(Activity activity) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -78,7 +78,7 @@ public class MainApp extends Application
     private final BroadcastReceiver mReceivePausedOrUnpausedState = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
             mIsScanningPausedDueToNoMotion =
-                intent.getAction().equals(ScanManager.ACTION_SCAN_PAUSED_USER_MOTIONLESS) && !mStumblerService.isStopped();
+                intent.getAction().equals(ScanManager.ACTION_SCAN_PAUSED_USER_MOTIONLESS);
 
             new Handler(context.getMainLooper()).post(new Runnable() {
                 public void run() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -469,7 +469,7 @@ public class MapFragment extends android.support.v4.app.Fragment
 
         final ClientStumblerService service = getApplication().getService();
         float alpha = 0.5f;
-        if (service != null && service.isScanning()) {
+        if (service != null && !service.isStopped()) {
             alpha = 1.0f;
         }
         v.setAlpha(alpha);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -160,7 +160,7 @@ public class MainDrawerActivity
         if (svc == null) {
             return;
         }
-        if (svc.isScanning()) {
+        if (!svc.isStopped()) {
             keepScreenOn(ClientPrefs.getInstance(this).getKeepScreenOn());
         } else {
             keepScreenOn(false);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -53,8 +53,8 @@ public class StumblerService extends PersistentIntentService
         super(name);
     }
 
-    public synchronized boolean isScanning() {
-        return mScanManager.isScanning();
+    public synchronized boolean isStopped() {
+        return mScanManager.isStopped();
     }
 
     public synchronized void startScanning() {
@@ -121,7 +121,7 @@ public class StumblerService extends PersistentIntentService
     public void onDestroy() {
         super.onDestroy();
 
-        if (!isScanning()) {
+        if (isStopped()) {
             return;
         }
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -53,10 +53,10 @@ public class ScanManager {
     private LocationChangeSensor mLocationChangeSensor;
     private MotionSensor mMotionSensor;
 
-    private enum ScannerState {
+    enum ScannerState {
         STOPPED, STARTED, STARTED_BUT_PAUSED_MOTIONLESS
     }
-    private ScannerState mScannerState = ScannerState.STOPPED;
+     ScannerState mScannerState = ScannerState.STOPPED;
 
     // After DetectUnchangingLocation reports the user is not moving, and the scanning pauses,
     // then use MotionSensor to determine when to wake up and start scanning again.
@@ -67,8 +67,7 @@ public class ScanManager {
                     Prefs.getInstance(mAppContext).getPowerSavingMode() == Prefs.PowerSavingModeOptions.Off) {
                 return;
             }
-            stopScanning();
-            mScannerState = ScannerState.STARTED_BUT_PAUSED_MOTIONLESS;
+            pauseScanning();
 
             if (AppGlobals.isDebug) {
                 ClientLog.d(LOG_TAG, "MotionSensor started");
@@ -210,13 +209,23 @@ public class ScanManager {
         }
     }
 
+    private synchronized boolean pauseScanning() {
+        if (isStopped()) {
+            return false;
+        }
+        mScannerState = ScannerState.STARTED_BUT_PAUSED_MOTIONLESS;
+        return stopAllScanners();
+    }
+
     public synchronized boolean stopScanning() {
         if (isStopped()) {
             return false;
         }
-
         mScannerState = ScannerState.STOPPED;
+        return stopAllScanners();
+    }
 
+    private boolean stopAllScanners() {
         if (mAppContext instanceof SimulationContext) {
             ((SimulationContext) mAppContext).deactivateSimulation();
         }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -28,11 +28,10 @@ import java.util.TimerTask;
 
 public class ScanManager {
     public static final String ACTION_SCAN_PAUSED_USER_MOTIONLESS = AppGlobals.ACTION_NAMESPACE + ".NOTIFY_USER_MOTIONLESS";
-    public static final String ACTION_EXTRA_IS_PAUSED = "IS_PAUSED";
+    public static final String ACTION_SCAN_UNPAUSED_USER_MOVED = AppGlobals.ACTION_NAMESPACE + ".NOTIFY_USER_MOVED";
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ScanManager.class);
     private static Context mAppContext;
     private Timer mPassiveModeFlushTimer;
-    private boolean mIsScanning;
     private GPSScanner mGPSScanner;
     private WifiScanner mWifiScanner;
     private CellScanner mCellScanner;
@@ -53,34 +52,41 @@ public class ScanManager {
     };
     private LocationChangeSensor mLocationChangeSensor;
     private MotionSensor mMotionSensor;
-    private boolean mIsMotionlessPausedState;
+
+    private enum ScannerState {
+        STOPPED, STARTED, STARTED_BUT_PAUSED_MOTIONLESS
+    }
+    private ScannerState mScannerState = ScannerState.STOPPED;
+
     // After DetectUnchangingLocation reports the user is not moving, and the scanning pauses,
     // then use MotionSensor to determine when to wake up and start scanning again.
     private final BroadcastReceiver mDetectUserIdleReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (!isScanning() ||
+            if (isStopped() ||
                     Prefs.getInstance(mAppContext).getPowerSavingMode() == Prefs.PowerSavingModeOptions.Off) {
                 return;
             }
             stopScanning();
-            mIsMotionlessPausedState = true;
+            mScannerState = ScannerState.STARTED_BUT_PAUSED_MOTIONLESS;
+
             if (AppGlobals.isDebug) {
                 ClientLog.d(LOG_TAG, "MotionSensor started");
             }
             mMotionSensor.start();
 
             Intent sendIntent = new Intent(ACTION_SCAN_PAUSED_USER_MOTIONLESS);
-            sendIntent.putExtra(ACTION_EXTRA_IS_PAUSED, mIsMotionlessPausedState);
             LocalBroadcastManager.getInstance(mAppContext).sendBroadcastSync(sendIntent);
         }
     };
+
     private final BroadcastReceiver mDetectMotionReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (isScanning() || !mIsMotionlessPausedState) {
+            if (mScannerState != ScannerState.STARTED_BUT_PAUSED_MOTIONLESS ) {
                 return;
             }
+            mScannerState = ScannerState.STOPPED; // To ensure startScanning() runs
             startScanning(context);
             mMotionSensor.stop();
 
@@ -88,8 +94,7 @@ public class ScanManager {
                 mLocationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement();
             }
 
-            Intent sendIntent = new Intent(ACTION_SCAN_PAUSED_USER_MOTIONLESS);
-            sendIntent.putExtra(ACTION_EXTRA_IS_PAUSED, mIsMotionlessPausedState);
+            Intent sendIntent = new Intent(ACTION_SCAN_UNPAUSED_USER_MOVED);
             LocalBroadcastManager.getInstance(mAppContext).sendBroadcastSync(sendIntent);
         }
     };
@@ -154,7 +159,7 @@ public class ScanManager {
     public synchronized void startScanning(Context ctx) {
         ClientLog.d(LOG_TAG, "ScanManager::startScanning");
 
-        if (isScanning()) {
+        if (!isStopped()) {
             return;
         }
 
@@ -164,7 +169,7 @@ public class ScanManager {
             return;
         }
 
-        mIsMotionlessPausedState = false;
+        mScannerState = ScannerState.STARTED;
 
         if (mLocationChangeSensor == null) {
             mLocationChangeSensor = new LocationChangeSensor(mAppContext, mDetectUserIdleReceiver);
@@ -203,13 +208,14 @@ public class ScanManager {
 
             // in passive mode, these scans are started by passive gps notifications
         }
-        mIsScanning = true;
     }
 
     public synchronized boolean stopScanning() {
-        if (!this.isScanning() && !mIsMotionlessPausedState) {
+        if (isStopped()) {
             return false;
         }
+
+        mScannerState = ScannerState.STOPPED;
 
         if (mAppContext instanceof SimulationContext) {
             ((SimulationContext) mAppContext).deactivateSimulation();
@@ -221,7 +227,6 @@ public class ScanManager {
             ClientLog.d(LOG_TAG, "Scanning stopped");
         }
 
-        mIsMotionlessPausedState = false;
         mLocationChangeSensor.stop();
         mMotionSensor.stop();
 
@@ -241,12 +246,11 @@ public class ScanManager {
         mWifiScanner = null;
         mCellScanner = null;
 
-        mIsScanning = false;
         return true;
     }
 
-    public synchronized boolean isScanning() {
-        return mIsScanning;
+    public synchronized boolean isStopped() {
+        return mScannerState == ScannerState.STOPPED;
     }
 
     public int getVisibleAPCount() {


### PR DESCRIPTION
I find this code confusing (because the paused state was grafted on
without changing the ScanManager isScanning logic.
Now ScanManager has an enum for state (stop/started/started but paused).
I find this code more readable.

I would suggest starting by looking at the changes in ScanManager.java. Everything else was a product of this change:
https://github.com/mozilla/MozStumbler/commit/33574021b483324e17b7755e692c070a849d1e7e#diff-a0bf0529c9d81614f9223e2715512cb9R57
