### PR TITLE
`make test` now runs tests on the libraries/stumbler package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-test: unittest
+test: libtest unittest
 	./gradlew copyTestResources
 	./gradlew testGithubUnittest --info
+
+libtest:
+	cd libraries/stumbler; ./gradlew test
 
 unittest:
 	./gradlew assembleGithubUnittest
@@ -23,7 +26,8 @@ fdroid:
 	sh rename_release.sh fdroid-release
 
 clean:
-	rm -rf outputs/*
+	rm -rf outputs
+	rm -rf libraries/stumbler/build
 	./gradlew clean
 
 install_debug:

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTest.java
@@ -32,7 +32,6 @@ public class NetworkInfoTest {
     }
 
     @Test
-    @Config(shadows = {MyShadowConnectivityManager.class})
     public void testIsConnectedNoConnManager() {
         // Test that the isConnected method doesn't bomb out without a connection manager
 
@@ -42,6 +41,7 @@ public class NetworkInfoTest {
     }
 
     @Test
+    @Config(shadows = {MyShadowConnectivityManager.class})
     public void testIsConnectedWithGlobal() {
         NetworkInfo.createGlobalInstance(ctx);
         NetworkInfo ni = NetworkInfo.getInstance();


### PR DESCRIPTION
Short term fix to get all test code to run until we pull out the services package as it's own repo.

This addresses #1457
