### PR TITLE
Testcase for bugzilla ticket 1130052 and extra guard in AsyncUploader

### DIFF
--- a/android/src/test/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.svclocator.services.log;
+
+import android.support.v4.util.CircularArray;
+
+import org.robolectric.shadows.ShadowLog;
+
+/*
+ This is a proxy around the android logger so that we can see what the heck
+ is happening when we run under test.
+ */
+public class DebugLogger implements ILogger {
+
+    static {
+        ShadowLog.stream = System.out;
+    }
+
+    public static CircularArray<String> messageBuffer = new CircularArray<String>(10);
+
+    public void w(String logTag, String s) {
+        String msg = "W: " + logTag + ", " + s;
+        System.out.println(msg);
+        messageBuffer.addLast(msg);
+    }
+
+    public String e(String logTag, String s, Throwable e) {
+        if (e instanceof OutOfMemoryError) {
+            // These are usually going to be OutOfMemoryErrors
+            // We want the full stacktrace for full errors, but
+            // not regular exception types.
+            System.gc();
+        }
+
+        String msg = "E: " + logTag + ", " + s;
+        System.out.println(msg);
+        if (e != null) {
+            e.printStackTrace();
+        }
+        messageBuffer.addLast(msg);
+        return msg;
+    }
+
+    public void i(String logTag, String s) {
+        String msg = "i: " + logTag + ", " + s;
+        System.out.println(msg);
+        messageBuffer.addLast(msg);
+    }
+
+    public void d(String logTag, String s) {
+        String msg = "d: " + logTag + ", " + s;
+        System.out.println(msg);
+        messageBuffer.addLast(msg);
+    }
+}

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -58,6 +58,8 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
 
     @Override
     protected Void doInBackground(AsyncUploadParam... params) {
+        AsyncProgressListenerStatusWrapper wrapper;
+
         if (params.length != 1) {
             return null;
         }
@@ -67,11 +69,12 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
             return null;
         }
 
-        AsyncProgressListenerStatusWrapper wrapper =
-                new AsyncProgressListenerStatusWrapper(sAsyncListener, true);
-        sAsyncListener.onUploadProgress(true);
+        if (sAsyncListener != null) {
+             wrapper = new AsyncProgressListenerStatusWrapper(sAsyncListener, true);
+            sAsyncListener.onUploadProgress(true);
+            publishProgress(wrapper);
+        }
 
-        publishProgress(wrapper);
 
         if (Prefs.getInstanceWithoutContext().isSaveStumbleLogs()) {
             try {
@@ -83,8 +86,10 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
         uploadReports(param);
 
         isUploading.set(false);
-        wrapper = new AsyncProgressListenerStatusWrapper(sAsyncListener, false);
-        publishProgress(wrapper);
+        if (sAsyncListener != null) {
+            wrapper = new AsyncProgressListenerStatusWrapper(sAsyncListener, false);
+            publishProgress(wrapper);
+        }
 
         return null;
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
@@ -87,6 +87,9 @@ public class UploadAlarmReceiver extends BroadcastReceiver {
 
         @Override
         protected void onHandleIntent(Intent intent) {
+            if (intent == null) {
+                return;
+            }
             boolean isRepeating = intent.getBooleanExtra(EXTRA_IS_REPEATING, true);
             if (DataStorageManager.getInstance() == null) {
                 DataStorageManager.createGlobalInstance(this, null);
@@ -112,10 +115,6 @@ public class UploadAlarmReceiver extends BroadcastReceiver {
                 }
             }
 
-            // @TODO: Check the buildtype to see if we're running in Client mode
-            // or inside of Fennec.  If we're in Client mode, we should send a
-            // signal to MainApp that we want to initiate
-            // an upload instead of doing it right here.
             if (NetworkInfo.getInstance().isWifiAvailable()) {
                 Log.d(LOG_TAG, "Alarm upload(), call AsyncUploader");
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/NetworkInfo.java
@@ -10,7 +10,7 @@ import android.util.Log;
 
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
-public final class NetworkInfo {
+public class NetworkInfo {
     private static final String LOG_TAG = LoggerUtil.makeLogTag(NetworkInfo.class);
     static NetworkInfo instance;
     ConnectivityManager mConnectivityManager;

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiverTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiverTest.java
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.uploadthread;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.AsyncTask;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mozilla.mozstumbler.service.utils.NetworkInfo;
+import org.mozilla.mozstumbler.service.utils.NetworkInfoTestUtil;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.log.DebugLogger;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.robolectric.bytecode.ShadowWrangler.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(emulateSdk = 18)
+public class UploadAlarmReceiverTest {
+
+    @Before
+    public void setUp() {
+        ServiceLocator.getInstance().putService(ILogger.class, new DebugLogger());
+    }
+
+    @Test
+    public void testNPEBug_1130052_startService() {
+        // This is a testcase for bugzilla bug 1130052
+        // Verify that passing in NULL as the intent to onReceive to the UploadAlarmReceiver
+        // will invoke a well formed startService call with a non-null intent.
+        Context ctx = Robolectric.application;
+        ctx = spy(ctx);
+
+        UploadAlarmReceiver uar = new UploadAlarmReceiver();
+        uar.onReceive(ctx, null);
+
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+
+        // Verify that the startService call was invoked as expected
+        verify(ctx, times(1)).startService(intentCaptor.capture());
+        Intent intent = intentCaptor.getValue();
+
+        // Names are tricky to match for inner classes.
+        assertTrue(intent.getComponent().getClassName().contains("UploadAlarmService"));
+    }
+
+
+    @Test
+    public void testNPEBug_1130052_NoNPEOnAlarmService() {
+        // This is a testcase for bugzilla bug 1130052
+
+        // Verify that passing in NULL as the intent to onHandleIntent to the UploadAlarmService
+        // will not cause a NPE
+        UploadAlarmReceiver.UploadAlarmService uas = new UploadAlarmReceiver.UploadAlarmService();
+        uas.onHandleIntent(null);
+    }
+
+    @Test
+    public void testNPEBug_1130052_ValidIntentOnAlarmService() {
+        // This is a testcase for bugzilla bug 1130052
+
+
+        Context ctx = Robolectric.application;
+        NetworkInfo.createGlobalInstance(ctx);
+
+        // Setup NetworkInfo to say that wifi is available.
+        NetworkInfo niSpy = spy(NetworkInfo.getInstance());
+        doReturn(true).when(niSpy).isWifiAvailable();
+
+        NetworkInfoTestUtil.setNetworkInfo(niSpy);
+
+            // Verify that passing in valid intent to the onHandleIntent to the UploadAlarmService
+        // will cause
+        UploadAlarmReceiver.UploadAlarmService uas = new UploadAlarmReceiver.UploadAlarmService();
+
+        // Wrap the UAS in a spy so that we can assert method calls
+        uas = spy(uas);
+
+        uas.onHandleIntent(new Intent("any_other_intent"));
+
+        // verify that the upload() method was invoked once.
+        verify(uas, times(1)).upload(true);
+    }
+
+
+}

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTestUtil.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/utils/NetworkInfoTestUtil.java
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.utils;
+
+/*
+ Just a test utility to manually set the global instance
+ */
+public class NetworkInfoTestUtil {
+
+    public static void setNetworkInfo(NetworkInfo info) {
+        NetworkInfo.instance = info;
+    }
+
+
+}

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
@@ -6,11 +6,17 @@ package org.mozilla.mozstumbler.svclocator.services.log;
 
 import android.support.v4.util.CircularArray;
 
+import org.robolectric.shadows.ShadowLog;
+
 /*
  This is a proxy around the android logger so that we can see what the heck
  is happening when we run under test.
  */
 public class DebugLogger implements ILogger {
+
+    static {
+        ShadowLog.stream = System.out;
+    }
 
     public static CircularArray<String> messageBuffer = new CircularArray<String>(10);
 


### PR DESCRIPTION
This patch updates the UploadAlarmReceiver::onHandleIntent to match the patch in bugzilla ticket 1130052.

Test cases to pass in null intents through the onHandleIntent have been added as well as some extra test to exercise the service startup code.

One extra guard has been added into the AsyncUploader code, but this change does not affect the Fennec stumbler as it's a wrapper around a notification mechanism that only exists in the standalone Android stumbler.
