### PR TITLE
Motion detection cleanup + remote unreliable linear. accel

### DIFF
--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
@@ -96,7 +96,8 @@ public class LocationChangeSensorTest {
         locationChangeSensor.removeTimeoutCheck();
 
         setPosition(0, 0);
-        assertTrue(locationChangeSensor.removeTimeoutCheck());
+        assertTrue(locationChangeSensor.mIsCheckTimeoutPosted);
+        locationChangeSensor.removeTimeoutCheck();
     }
 
     @Test

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
@@ -53,32 +53,26 @@ public class LegacyMotionSensor implements IMotionSensor {
      Real SensorEvent instances cannot be constructed on a test platform.
      */
     public void sensorChanged(int sensorType, float[] event_values) {
-        if (sensorType == Sensor.TYPE_ACCELEROMETER) {
-            gravity[0] = alpha * gravity[0] + (1 - alpha) * event_values[0];
-            gravity[1] = alpha * gravity[1] + (1 - alpha) * event_values[1];
-            gravity[2] = alpha * gravity[2] + (1 - alpha) * event_values[2];
+        gravity[0] = alpha * gravity[0] + (1 - alpha) * event_values[0];
+        gravity[1] = alpha * gravity[1] + (1 - alpha) * event_values[1];
+        gravity[2] = alpha * gravity[2] + (1 - alpha) * event_values[2];
 
-            linear_acceleration[0] = event_values[0] - gravity[0];
-            linear_acceleration[1] = event_values[1] - gravity[1];
-            linear_acceleration[2] = event_values[2] - gravity[2];
+        linear_acceleration[0] = event_values[0] - gravity[0];
+        linear_acceleration[1] = event_values[1] - gravity[1];
+        linear_acceleration[2] = event_values[2] - gravity[2];
 
-            computed_gravity = FloatMath.sqrt(gravity[0] * gravity[0] +
-                    gravity[1] * gravity[1] +
-                    gravity[2] * gravity[2]);
+        computed_gravity = FloatMath.sqrt(gravity[0] * gravity[0] +
+                gravity[1] * gravity[1] +
+                gravity[2] * gravity[2]);
 
-            if (iterations_for_convergence > 0) {
-                // We don't use an epsilon to detect convergence because imperically
-                // devices don't seem to comply to the 0.05m/s^2 error that Google
-                // specifies.  The Motorola XT1032 seems to get ~10.10 m/s^s for gravity
-                // when it's tilted to stand on it's edge.  When laid flat,
-                // it gets pretty close with 9.89m/s^2 which is still far from 9.81m/s^2
-                iterations_for_convergence--;
-                return;
-            }
-        } else {
-            linear_acceleration[0] = event_values[0];
-            linear_acceleration[1] = event_values[1];
-            linear_acceleration[2] = event_values[2];
+        if (iterations_for_convergence > 0) {
+            // We don't use an epsilon to detect convergence because empirically
+            // devices don't seem to comply to the 0.05m/s^2 error that Google
+            // specifies.  The Motorola XT1032 seems to get ~10.10 m/s^s for gravity
+            // when it's tilted to stand on it's edge.  When laid flat,
+            // it gets pretty close with 9.89m/s^2 which is still far from 9.81m/s^2
+            iterations_for_convergence--;
+            return;
         }
 
         float x = linear_acceleration[0];
@@ -110,14 +104,6 @@ public class LegacyMotionSensor implements IMotionSensor {
 
     @Override
     public void start() {
-        mSensorManager.registerListener(mSensorEventListener,
-                mSensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION),
-                SensorManager.SENSOR_DELAY_NORMAL);
-
-        // Some devices are really terrible. The Moto G XT1032 should respond to the
-        // TYPE_LINEAR_ACCELERATION, but will only respond to the TYPE_ACCELEROMETER (API 3).
-        // Luckily, both event types emit the same struct.  Who knows why there are two
-        // different constants.
         mSensorManager.registerListener(mSensorEventListener,
                 mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
                 SensorManager.SENSOR_DELAY_NORMAL);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
@@ -180,15 +180,8 @@ public class LocationChangeSensor extends BroadcastReceiver {
         ClientLog.d(LOG_TAG, "Scheduled timeout check for " + (delay / 1000.0) + " seconds");
     }
 
-    boolean removeTimeoutCheck() {
-        boolean wasScheduled = false;
-        try {
-            mHandler.removeCallbacks(mCheckTimeout);
-            wasScheduled = true;
-        } catch (Exception e) {
-        }
-
-        return wasScheduled;
+    private void removeTimeoutCheck() {
+        mHandler.removeCallbacks(mCheckTimeout);
     }
 
     public void quickCheckForFalsePositiveAfterMotionSensorMovement() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensor.java
@@ -53,6 +53,8 @@ public class LocationChangeSensor extends BroadcastReceiver {
     private long mStartTimeMs;
     private boolean mDoSingleLocationCheck;
     private Location mLastLocation;
+    // Package scoped for testing
+    boolean mIsCheckTimeoutPosted;
 
     public LocationChangeSensor(Context context, BroadcastReceiver callbackReceiver) {
         sDebugInstance = this;
@@ -176,12 +178,14 @@ public class LocationChangeSensor extends BroadcastReceiver {
         // trigger this earlier than requested (by a fraction of a second).
         final long addedDelayMs = 100;
         mHandler.postDelayed(mCheckTimeout, delay + addedDelayMs);
+        mIsCheckTimeoutPosted = true;
 
         ClientLog.d(LOG_TAG, "Scheduled timeout check for " + (delay / 1000.0) + " seconds");
     }
 
-    private void removeTimeoutCheck() {
+    void removeTimeoutCheck() {
         mHandler.removeCallbacks(mCheckTimeout);
+        mIsCheckTimeoutPosted = false;
     }
 
     public void quickCheckForFalsePositiveAfterMotionSensorMovement() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -21,7 +21,7 @@ public class MotionSensor {
     private final SensorManager mSensorManager;
     private final Context mAppContext;
 
-    private IMotionSensor motionSensor;
+    private IMotionSensor mMotionSensor;
     private static MotionSensor sDebugInstance;
 
     public MotionSensor(Context appCtx) {
@@ -35,18 +35,14 @@ public class MotionSensor {
 
         sDebugInstance = this;
 
-        motionSensor = SignificantMotionSensor.getSensor(mAppContext);
-
-        // If no TYPE_SIGNIFICANT_MOTION is available, use alternate means to sense motion
-        if (motionSensor == null) {
-            motionSensor = new LegacyMotionSensor(mAppContext);
-        }
         setTypeFromPrefs();
     }
 
     private void setTypeFromPrefs() {
         if (Prefs.getInstance(mAppContext).isMotionSensorTypeSignificant()) {
-            motionSensor = SignificantMotionSensor.getSensor(mAppContext);
+            mMotionSensor = SignificantMotionSensor.getSensor(mAppContext);
+        } else {
+            mMotionSensor = new LegacyMotionSensor(mAppContext);
         }
     }
 
@@ -57,7 +53,7 @@ public class MotionSensor {
     }
 
     public static void debugMotionDetected() {
-        if (!sDebugInstance.motionSensor.isActive()) {
+        if (!sDebugInstance.mMotionSensor.isActive()) {
             return;
         }
         AppGlobals.guiLogInfo("TEST: Major motion detected.");
@@ -69,10 +65,10 @@ public class MotionSensor {
     }
 
     public void start() {
-        motionSensor.start();
+        mMotionSensor.start();
     }
 
     public void stop() {
-        motionSensor.stop();
+        mMotionSensor.stop();
     }
 }


### PR DESCRIPTION
Some minor cleanup items and remove the TYPE_LINEAR_ACCELEROMETER and use TYPE_ACCELEROMETER only. The linear. accel doesn't work reliably.
