### PR TITLE
Fix the reset logic on the FalsePositiveFilter.

### DIFF
--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensorTest.java
@@ -102,15 +102,12 @@ public class LegacyMotionSensorTest {
     public void testFalsePositiveFilterInitialization() {
         MotionSensor motionSensor = new MotionSensor(Robolectric.application);
         clock.setCurrentTime(1000);
-        assertTrue(motionSensor.mFalsePositiveFilter.mTimeStartedMs == 0);
+        assertTrue(motionSensor.mFalsePositiveFilter.mLastLocation == null);
         motionSensor.start();
         motionSensor.mFalsePositiveFilter.mLastLocation = getNextGPSLocation();
-        assertTrue(motionSensor.mFalsePositiveFilter.mTimeStartedMs > 0);
         motionSensor.stop();
-        assertTrue(motionSensor.mFalsePositiveFilter.mTimeStartedMs > 0);
         assertTrue(motionSensor.mFalsePositiveFilter.mLastLocation != null);
         motionSensor.scannerFullyStopped();
-        assertTrue(motionSensor.mFalsePositiveFilter.mTimeStartedMs == 0);
         assertTrue(motionSensor.mFalsePositiveFilter.mLastLocation == null);
     }
 

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LocationChangeSensorTest.java
@@ -205,7 +205,6 @@ public class LocationChangeSensorTest {
         assertTrue(receivedIntent.size() == 0);
 
         ClientLog.d(LOG_TAG, "Movement that exceeds distance threshold while in paused state.");
-        locationChangeSensor.quickCheckForFalsePositiveAfterMotionSensorMovement();
         setPosition(x + 0.1, y);
 
         fakeWait(tick / 2);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -120,12 +120,12 @@ public class MotionSensor {
     FalsePositiveFilter mFalsePositiveFilter;
     private static class FalsePositiveFilter {
         private final Context mContext;
-        private final Handler handler = new Handler();
+        private final Handler mHandler = new Handler();
         private Location mLastLocation;
         private final long mMinMotionChangeDistanceMeters = 10;
         private long mTimeStartedMs;
 
-        private final Runnable mRunnable = new Runnable() {
+        private final Runnable mStopListeningTimer = new Runnable() {
             public void run() {
                 stop();
             }
@@ -181,13 +181,13 @@ public class MotionSensor {
             LocationManager lm = (LocationManager)mContext.getSystemService(Context.LOCATION_SERVICE);
             lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, mListener);
 
-            handler.postDelayed(mRunnable, 30 * 1000);
+            mHandler.postDelayed(mStopListeningTimer, 30 * 1000);
         }
 
         void stop() {
             LocationManager lm = (LocationManager)mContext.getSystemService(Context.LOCATION_SERVICE);
             lm.removeUpdates(mListener);
-            handler.removeCallbacks(mRunnable);
+            mHandler.removeCallbacks(mStopListeningTimer);
         }
 
         private void setTime() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -194,9 +194,10 @@ public class MotionSensor {
                 AppGlobals.guiLogInfo("Updated location for false pos. filter");
                 LocationManager lm = (LocationManager)mContext.getSystemService(Context.LOCATION_SERVICE);
                 mLastLocation = lm.getLastKnownLocation(LocationManager.GPS_PROVIDER);
-                // set the time to now, as if the location at *now* is this GPS location
-
-                mLastLocation.setTime(mClock.currentTimeMillis());
+                if (mLastLocation != null) {
+                    // set the time to now, as if the location at *now* is this GPS location
+                    mLastLocation.setTime(mClock.currentTimeMillis());
+                }
             }
 
             if (mLastLocation == null) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -22,7 +22,7 @@ public class MotionSensor {
     public static final String ACTION_USER_MOTION_DETECTED = AppGlobals.ACTION_NAMESPACE + ".USER_MOVE";
     private static final String LOG_TAG = LoggerUtil.makeLogTag(MotionSensor.class);
     private static final ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
-
+    static final long GPS_WARM_TIME_MS = 2 * 60 * 60 * 1000; // after this, the GPS is considered cold
     /// Testing code
     private final SensorManager mSensorManager;
     private final Context mAppContext;
@@ -118,12 +118,12 @@ public class MotionSensor {
     // Try to filter false positives by quickly checking to see if the user location has changed.
     // If the GPS has gone cold (~2 hours), then stop using this filter.
     FalsePositiveFilter mFalsePositiveFilter;
-    private static class FalsePositiveFilter {
+    static class FalsePositiveFilter {
         private final Context mContext;
         private final Handler mHandler = new Handler();
-        private Location mLastLocation;
+        Location mLastLocation;
         private final long mMinMotionChangeDistanceMeters = 10;
-        private long mTimeStartedMs;
+        long mTimeStartedMs;
 
         private final Runnable mStopListeningTimer = new Runnable() {
             public void run() {
@@ -204,9 +204,8 @@ public class MotionSensor {
             if (mTimeStartedMs == 0) {
                 setTime();
             }
-            final long twoHours = 2 * 60 * 60 * 1000;
             ISystemClock clock = (ISystemClock) ServiceLocator.getInstance().getService(ISystemClock.class);
-            return clock.currentTimeMillis() - mTimeStartedMs < twoHours;
+            return clock.currentTimeMillis() - mTimeStartedMs < GPS_WARM_TIME_MS;
         }
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -181,7 +181,6 @@ public class ScanManager {
             // Simulation contexts are only allowed for debug builds.
             Prefs prefs = Prefs.getInstanceWithoutContext();
             if (prefs != null) {
-                ClientLog.i(LOG_TAG, "ScanManager::startScanning simulation pref = " + prefs.isSimulateStumble());
                 if (prefs.isSimulateStumble()) {
                     mAppContext = new SimulationContext(mAppContext);
                     ClientLog.d(LOG_TAG, "ScanManager using SimulateStumbleContextWrapper");


### PR DESCRIPTION
 The last GPS location should stay unchanged until the user moves beyond the threshold distance or scanning is stopped+started (as opposed to when paused+started).

The FalsePositiveFilter gets initialized with a GPS location when the user is motionless, and this location should not get updated until the filter threshold is exceeded, or scanning is manually stopped+started.
