### PR TITLE
Check if offline before querying MLS

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -56,7 +56,7 @@ public class ObservationPoint implements MLSLocationGetter.MLSLocationGetterCall
             return;
         }
         ClientPrefs prefs = ClientPrefs.getInstanceWithoutContext();
-        if (prefs == null ||
+        if (prefs == null || !NetworkInfo.getInstance().isConnected() ||
                 (prefs.getUseWifiOnly() && !NetworkInfo.getInstance().isWifiAvailable())) {
             return;
         }


### PR DESCRIPTION
Querying MLS does not check if any network is available. This can result in lots of `UnknownHostException` being displayed in the log.

STR:
- enable querying MLS
- disable wifi only
- be offline
- stumble and check GUI log
