### PR TITLE
1365 - Simulation as a service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 // each of the version numbers must be 0-99
 def versionMajor = 1
-def versionMinor = 6 // minor feature releases
+def versionMinor = 7 // minor feature releases
 def versionPatch = 99 // This should be bumped for hot fixes
 
 // Double check the versioning

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -37,6 +37,7 @@ import org.mozilla.mozstumbler.service.core.http.ILocationService;
 import org.mozilla.mozstumbler.service.core.logging.MockAcraLog;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.MotionSensor;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.ISimulatorService;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellScanner;
@@ -105,6 +106,8 @@ public class MainApp extends Application
                 ServiceConfig.load("org.mozilla.mozstumbler.svclocator.services.SystemClock"));
         result.put(ILocationService.class,
                 ServiceConfig.load("org.mozilla.mozstumbler.service.core.http.MLS"));
+        result.put(ISimulatorService.class,
+                ServiceConfig.load("org.mozilla.mozstumbler.service.stumblerthread.scanners.SimulatorService"));
 
         if (BuildConfig.BUILD_TYPE.equals("unittest")) {
             result.put(ILogger.class, ServiceConfig.load("org.mozilla.mozstumbler.svclocator.services.log.DebugLogger"));

--- a/android/src/main/java/org/mozilla/mozstumbler/client/cellscanner/ScreenMonitor.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/cellscanner/ScreenMonitor.java
@@ -106,7 +106,8 @@ public class ScreenMonitor {
     }
 
     private void load() {
-        SharedPreferences prefs = mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+        SharedPreferences prefs = mContext
+                                    .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
         mLocationUpdatesCount = prefs.getLong(LOCATION_UPDATES_COUNT_PREF, NO_DATA);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
@@ -12,6 +12,8 @@ import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.DateTimeUtils;
 import org.mozilla.mozstumbler.client.MainApp;
 import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
 
 public class NotificationUtil {
     public static final int NOTIFICATION_ID = 1;
@@ -51,7 +53,10 @@ public class NotificationUtil {
         String uploadLine = mContext.getString(R.string.metrics_notification_extraline);
         uploadLine = String.format(uploadLine, uploadtime);
 
-        sLastUpdateTime = System.currentTimeMillis();
+        ISystemClock clock = (ISystemClock) ServiceLocator.getInstance()
+                                           .getService(ISystemClock.class);
+
+        sLastUpdateTime = clock.currentTimeMillis();
 
         return new NotificationCompat.Builder(mContext)
                 .setSmallIcon(R.drawable.ic_status_scanning)

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -58,7 +58,7 @@ public class StumblerService extends PersistentIntentService
     }
 
     public synchronized void startScanning() {
-        mScanManager.startScanning(this);
+        mScanManager.startScanning();
     }
 
     public synchronized Prefs getPrefs(Context c) {
@@ -105,7 +105,9 @@ public class StumblerService extends PersistentIntentService
         Prefs.getInstance(this);
         NetworkInfo.createGlobalInstance(this);
         DataStorageManager.createGlobalInstance(this, this);
+
         mReporter.startup(this);
+        mScanManager.initContext(this.getApplicationContext());
     }
 
     // Called from the main thread.
@@ -161,7 +163,7 @@ public class StumblerService extends PersistentIntentService
         init();
 
         // Post-init(), set the mode to passive.
-        mScanManager.setPassiveMode(true);
+        setPassiveMode();
 
         if (intent == null) {
             return;
@@ -187,7 +189,6 @@ public class StumblerService extends PersistentIntentService
             final long timeNow = System.currentTimeMillis();
 
             if (timeNow - lastAttemptedTime < PASSIVE_UPLOAD_FREQ_GUARD_MSEC) {
-                // TODO Consider telemetry to track this.
                 if (AppGlobals.isDebug) {
                     Log.d(LOG_TAG, "Upload attempt too frequent.");
                 }
@@ -212,6 +213,10 @@ public class StumblerService extends PersistentIntentService
         }
 
         startScanning();
+    }
+
+    public void setPassiveMode() {
+        mScanManager.setPassiveMode(true);
     }
 
     // Note that in passive mode, having data isn't an upload trigger, it is triggered by the start intent

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ISimulatorService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ISimulatorService.java
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread.scanners;
+
+
+import android.content.Context;
+import android.location.Location;
+import android.net.wifi.ScanResult;
+
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
+
+import java.util.List;
+
+public interface ISimulatorService {
+
+    public void startSimulation(Context ctx);
+    public void stopSimulation();
+
+    public Location getNextGPSLocation();
+    public List<ScanResult> getNextMockWifiBlock();
+    public List<CellInfo> getNextMockCellBlock();
+
+}

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiManagerProxy.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiManagerProxy.java
@@ -10,6 +10,7 @@ import android.os.Build;
 
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.util.LinkedList;
@@ -54,11 +55,16 @@ public class WifiManagerProxy extends BroadcastReceiver {
     public List<ScanResult> getScanResults() {
         if (Prefs.getInstance(mAppContext).isSimulateStumble()) {
             LinkedList<ScanResult> result = new LinkedList<ScanResult>();
-            SimulationContext ctx;
+
+            ISimulatorService simSvc = (ISimulatorService) ServiceLocator.getInstance()
+                    .getService(ISimulatorService.class);
+
             try {
+                List<ScanResult> wifiBlock = simSvc.getNextMockWifiBlock();
                 // fetch scan results from the context
-                ctx = ((SimulationContext) mAppContext);
-                result.addAll(ctx.getNextMockWifiBlock());
+                if (wifiBlock != null) {
+                    result.addAll(wifiBlock);
+                }
             } catch (ClassCastException ex) {
                 ClientLog.e(LOG_TAG, "Simulation was enabled, but invalid context was found", ex);
             }
@@ -97,7 +103,7 @@ public class WifiManagerProxy extends BroadcastReceiver {
     }
 
     public void onReceive(Context c, Intent intent) {
-        // TODO: this is the hook we need to call to send in fake
+        // this is the hook we need to call to send in fake
         // Wifi signals.
         // WifiScanner will expect and intent with
         // action ==  WifiManager.SCAN_RESULTS_AVAILABLE_ACTION

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -16,9 +16,6 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
-import org.mozilla.mozstumbler.svclocator.ServiceLocator;
-import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
-import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -28,9 +25,6 @@ import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CellScanner {
-    private ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
-    private static final String LOG_TAG = LoggerUtil.makeLogTag(CellScanner.class);
-
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".CellScanner.";
     public static final String ACTION_CELLS_SCANNED = ACTION_BASE + "CELLS_SCANNED";
     public static final String ACTION_CELLS_SCANNED_ARG_CELLS = "cells";
@@ -48,8 +42,8 @@ public class CellScanner {
 
     public CellScanner(Context appCtx) {
         mAppContext = appCtx;
-        if (AppGlobals.isDebug && Prefs.getInstance(appCtx).isSimulateStumble()) {
-            mSimpleCellScanner = new MockSimpleCellScanner(mAppContext);
+        if (AppGlobals.isDebug && Prefs.getInstance(mAppContext).isSimulateStumble()) {
+            mSimpleCellScanner = new MockSimpleCellScanner();
         } else {
             mSimpleCellScanner = new SimpleCellScannerImplementation(mAppContext);
         }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/MockSimpleCellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/MockSimpleCellScanner.java
@@ -4,10 +4,9 @@
 
 package org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner;
 
-import android.content.Context;
-
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
-import org.mozilla.mozstumbler.service.stumblerthread.scanners.SimulationContext;
+import org.mozilla.mozstumbler.service.stumblerthread.scanners.ISimulatorService;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.util.LinkedList;
@@ -18,11 +17,9 @@ public class MockSimpleCellScanner implements ISimpleCellScanner {
 
     private static final String LOG_TAG = LoggerUtil.makeLogTag(MockSimpleCellScanner.class);
 
-    private final Context mAppContext;
     private boolean started = false;
 
-    public MockSimpleCellScanner(Context appCtx) {
-        mAppContext = appCtx;
+    public MockSimpleCellScanner() {
     }
 
     @Override
@@ -42,14 +39,15 @@ public class MockSimpleCellScanner implements ISimpleCellScanner {
 
     @Override
     public List<CellInfo> getCellInfo() {
-
         LinkedList<CellInfo> result = new LinkedList<CellInfo>();
 
-        SimulationContext ctx;
-
+        ISimulatorService simSvc = (ISimulatorService) ServiceLocator.getInstance()
+                                        .getService(ISimulatorService.class);
         try {
-            ctx = (SimulationContext) mAppContext;
-            result.addAll(ctx.getNextMockCellBlock());
+            List<CellInfo> cellBlock = simSvc.getNextMockCellBlock();
+            if (cellBlock != null) {
+                result.addAll(cellBlock);
+            }
         } catch (ClassCastException ex) {
             ClientLog.e(LOG_TAG, "Error getting the proper context", ex);
         }

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/mainthread/PassiveServiceReceiverTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/mainthread/PassiveServiceReceiverTest.java
@@ -20,7 +20,6 @@ import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.CustomSens
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.DebugLogger;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
-import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -39,12 +38,7 @@ import static org.mockito.Mockito.verify;
         shadows = {CustomSensorManager.class})
 public class PassiveServiceReceiverTest {
 
-
-    private static final String LOG_TAG = LoggerUtil.makeLogTag(PassiveServiceReceiverTest.class);
-    private ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
-
     private Context appCtx;
-
 
     @Before
     public void setUp() {
@@ -58,6 +52,7 @@ public class PassiveServiceReceiverTest {
 
     public void doAndroidTest(Intent intent) {
         PassiveServiceReceiver psr = new PassiveServiceReceiver();
+
         // Robolectric won't hand off messages using the BroadcastReceiver
         // and LocalBroadcastManager, so just manually call onReceive
         psr.onReceive(appCtx, intent);
@@ -150,6 +145,8 @@ public class PassiveServiceReceiverTest {
 
     @Test
     public void testStumblerServiceOnHandleIntent() {
+        // This just checks that we can run all the way through the PassiveServiceReceiver's
+        // onHandle method.
 
         // Ok, so now we need to see that the intent is actually processed correctly by
         // StumblerService.  robolectric doesn't pass the start intent down to
@@ -163,6 +160,10 @@ public class PassiveServiceReceiverTest {
         // Stub out startScanning as we don't want to actually engage any of GPSScanner, WifiScanner
         ss = spy(ss);
         doNothing().when(ss).startScanning();
+
+        // We need to no-op this as the StumblerService won't have an application context yet
+        // and binding in the BatteryCheckReceiver is just going to NPE on us.
+        doNothing().when(ss).setPassiveMode();
 
         ss.onHandleIntent(intent);
 


### PR DESCRIPTION
This refactors the SimulationContext into a service in the ServiceLocator.

This simplifies the lifecycle of objects in the `ScanManager` as wrapping and unwrapping of the application context with the `SimulationContext` is no longer necessary.  This prevents the GPS, Wifi and Cell scanners from ever being cleared to a null pointer which caused crashes in #1485.
