### PR TITLE
Performance-safe stats reporting

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/QueuedCountsTracker.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/QueuedCountsTracker.java
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.client;
+
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
+import org.mozilla.mozstumbler.service.utils.Zipper;
+
+// Tracks counts of queued data for reporting in the UI
+public class QueuedCountsTracker {
+    long mCachedByteCount;
+    long mPrevAccessTimeMs;
+
+    public static class QueuedCounts {
+        public final int mReportCount;
+        public final int mWifiCount;
+        public final int mCellCount;
+        public final long mBytes;
+
+        QueuedCounts(int reportCount, int wifiCount, int cellCount, long bytes) {
+            this.mReportCount = reportCount;
+            this.mWifiCount = wifiCount;
+            this.mCellCount = cellCount;
+            this.mBytes = bytes;
+        }
+    }
+
+    private static QueuedCountsTracker sInstance;
+
+    public static QueuedCountsTracker getInstance() {
+        if (sInstance == null) {
+            sInstance = new QueuedCountsTracker();
+        }
+        return sInstance;
+    }
+
+    private QueuedCountsTracker() {}
+
+    private long getInMemoryReportsUploadBytes() {
+        DataStorageManager dsm = DataStorageManager.getInstance();
+        byte[] bytes = dsm.getCurrentReportsRawBytes();
+        if (bytes == null) {
+            mCachedByteCount = 0;
+            return 0;
+        }
+
+        final long kTimeGapMs = 2000;
+        if (System.currentTimeMillis() - mPrevAccessTimeMs < kTimeGapMs) {
+            return mCachedByteCount;
+        }
+
+        mPrevAccessTimeMs = System.currentTimeMillis();
+
+        bytes = Zipper.zipData(bytes);
+        if (bytes == null) {
+            return 0;
+        }
+
+        mCachedByteCount = bytes.length;
+        return mCachedByteCount;
+    }
+
+    /* Some data is calculated on-demand, don't abuse this function */
+    public QueuedCounts getQueuedCounts() {
+        DataStorageManager dsm = DataStorageManager.getInstance();
+        long byteLength = getInMemoryReportsUploadBytes() +  dsm.getQueuedZippedDataSize();
+        return new QueuedCounts(dsm.getQueuedReportCount(),
+                dsm.getQueuedWifiCount(),
+                dsm.getQueuedCellCount(),
+                byteLength);
+    }
+}

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -16,7 +16,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -34,11 +33,9 @@ import org.mozilla.mozstumbler.client.subactivities.PreferencesScreen;
 import org.mozilla.mozstumbler.client.util.NotificationUtil;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageContract;
-import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.PersistedStats;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploadParam;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
-import org.mozilla.mozstumbler.service.utils.PersistentIntentService;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.IOException;
@@ -213,11 +210,6 @@ public class MetricsView {
     }
 
     public void update() {
-        DataStorageManager dm = DataStorageManager.getInstance();
-        if (dm == null) {
-            return;
-        }
-
         if (ClientPrefs.getInstance(mView.getContext()).isOptionEnabledToShowMLSOnMap()) {
             mOnMapShowMLS.setVisibility(View.VISIBLE);
         } else {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
-import android.widget.Button;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.utils.TelemetryWrapper;
@@ -27,7 +26,7 @@ public class PersistedStats {
     public static final String EXTRAS_PERSISTENT_SYNC_STATUS_UPDATED = ACTION_PERSISTENT_SYNC_STATUS_UPDATED + ".EXTRA";
     public PersistedStats(String baseDir, Context context) {
         mStatsFile = new File(baseDir, "upload_stats.ini");
-        mContext = context;
+        mContext = context.getApplicationContext();
     }
 
     public synchronized Properties readSyncStats() throws IOException {
@@ -74,6 +73,9 @@ public class PersistedStats {
                 Long.parseLong(properties.getProperty(DataStorageContract.Stats.KEY_WIFIS_SENT, "0")) + wifis,
                 observationsToday);
 
+        if (newProps == null || newProps.keySet().size() < 1) {
+            return;
+        }
 
         Intent intent = new Intent();
         intent.setAction(ACTION_PERSISTENT_SYNC_STATUS_UPDATED);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -13,42 +13,39 @@ public class ReportBatchBuilder {
     // Once this size is reached, data is persisted to disk, mCurrentReports is cleared.
     public static final int MAX_REPORTS_IN_MEMORY = 50;
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ReportBatchBuilder.class);
-    private final ArrayList<String> reports = new ArrayList<String>();
     public int wifiCount;
     public int cellCount;
-
+    StringBuilder reportString;
+    int reportCount;
     public int reportsCount() {
-        return reports.size();
+        return reportCount;
     }
 
     String finalizeReports() {
-        final String kPrefix = "{\"items\":[";
         final String kSuffix = "]}";
-        final StringBuilder sb = new StringBuilder(kPrefix);
-        String sep = "";
-        final String separator = ",";
-        if (reports != null) {
-            for (String s : reports) {
-                sb.append(sep).append(s);
-                sep = separator;
-            }
-        }
-
-        final String result = sb.append(kSuffix).toString();
-        return result;
+        return reportString.toString() + kSuffix;
     }
 
     public void clearReports() {
-        reports.clear();
+        reportCount = 0;
+        reportString = null;
     }
 
     public void addReport(String report) {
-        if (reports.size() == MAX_REPORTS_IN_MEMORY) {
+        if (reportCount == MAX_REPORTS_IN_MEMORY) {
             // This can happen in the event that serializing reports to disk fails
             // and the reports list is never cleared.
             return;
         }
-        reports.add(report);
+        reportCount++;
+
+        if (reportString == null) {
+            final String kPrefix = "{\"items\":[";
+            reportString = new StringBuilder(kPrefix);
+            reportString.append(report);
+        } else {
+            reportString.append("," + report);
+        }
     }
 
     public boolean maxReportsReached() {


### PR DESCRIPTION
The synchronous stats reporting is removed. There were 2 performance problems in the code. 

1) Problem: to show the metrics of how much data is in the queue, requires zipping the in-memory contents to get the correct size, which is very slow.
Solution: Remove the calc of the zipped size of in-memory stumbles from DataStorageManager, and put it in a new class QueuedCountsTracker, that has a rate-limited (every 2sec) max freq of updating. Alternatively, I could have had this update when new reports come in (i.e. new report arrives, recalculate the in-memory zip size) and broadcast the size to listeners. I wanted this decoupled from the report frequency, which is something that might change. Also, this would update far more frequently than necessary, as the metrics only needs to update when it is visible. (Note also, that this part of the code is client-side only, it is very specific to the Mozilla Stumbler use case, and I don't want the service to "know" about this use case).

2) Problem: the stats for previous uploaded data is stored as a small text file, and reading this from disk is slow. Solution: Change the reporting of uploaded stats from an on-demand query, to a broadcast listener, so this info is sent out only when it changes. (This code _is_ part of the service, and makes sense to have it broadcast, because saving to disk is part of the regular data storage flow, unlike case 1 which is an optional query). 
