### PR TITLE
Synchronization fix for DynamicProxies

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/DynamicProxy.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/DynamicProxy.java
@@ -20,14 +20,23 @@ public class DynamicProxy implements InvocationHandler {
         this.svcDefinition = svcDef;
     }
 
-    @Override
-    public Object invoke(Object proxy, Method method, Object[] args)
-            throws Throwable {
+    /*
+    Gets an instance of the delegate
+     */
+    private synchronized Object getInstance() {
         if (this.impl == null) {
             this.impl = ServiceLocator.getInstance().getDirectService(this.svcDefinition);
         }
+        return this.impl;
+    }
 
-        if (this.impl == null) {
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args)
+            throws Throwable {
+
+        Object obj = getInstance();
+
+        if (obj == null) {
             // return a reasonable default for primitive types
             // and a NULL for anything that's not primitive.
 
@@ -77,6 +86,6 @@ public class DynamicProxy implements InvocationHandler {
                 throw new IllegalStateException(String.valueOf(method));
             }
         }
-        return method.invoke(impl, args);
+        return method.invoke(obj, args);
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceLocator.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/ServiceLocator.java
@@ -33,7 +33,7 @@ public class ServiceLocator {
     /*
      Call this method with an interface class to get a lazily bound proxy to the service.
      */
-    public Object getService(Class<?> svcDefinition) {
+    public synchronized Object getService(Class<?> svcDefinition) {
         return Proxy.newProxyInstance(svcDefinition.getClassLoader(),
                 new Class<?>[]{svcDefinition},
                 new DynamicProxy(svcDefinition));
@@ -43,7 +43,7 @@ public class ServiceLocator {
      You almost certainly don't want to be calling this.  Use getService instead to get a lazily
      bound proxy instance.
      */
-    public Object getDirectService(Class<?> svcInterface) {
+    public synchronized Object getDirectService(Class<?> svcInterface) {
         Object result = null;
 
         if (svcMap.containsKey(svcInterface)) {
@@ -56,7 +56,7 @@ public class ServiceLocator {
         return result;
     }
 
-    public void putService(Class<?> svcInterface, Object obj) {
+    public synchronized void putService(Class<?> svcInterface, Object obj) {
         svcMap.put(svcInterface, obj);
     }
 }


### PR DESCRIPTION
Fixed some incorrect synchronization in the DynamicProxy which caused `ServiceLocator::getService()` to sometimes always return NULL.

I saw lots of ISystemClock and ILogger services which were always null before this patch.

I don't think I can wrap this in a test case as it only breaks under multithreaded conditions.
