### PR TITLE
Legacy sensor: use a rolling average to detect motion

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -254,11 +254,6 @@ public class MapFragment extends android.support.v4.app.Fragment
         return (MainApp) getActivity().getApplication();
     }
 
-    public LocationManager getLocationManager() {
-        return (LocationManager) getActivity().getApplicationContext().
-                getSystemService(Context.LOCATION_SERVICE);
-    }
-
     private void initCoverageTiles(String coverageUrl) {
         ClientLog.i(LOG_TAG, "initCoverageTiles: " + coverageUrl);
         mCoverageTilesOverlayLowZoom = new CoverageOverlay(CoverageOverlay.LowResType.LOWER_ZOOM,

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensorTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensorTest.java
@@ -37,58 +37,6 @@ public class LegacyMotionSensorTest {
         ServiceLocator.getInstance().putService(ISystemClock.class, clock);
     }
 
-    @Test
-    public void testConvergence() {
-
-        Context ctx = Robolectric.application;
-
-        LegacyMotionSensor lms = new LegacyMotionSensor(ctx);
-        assertNotNull(lms.mSensorManager);
-
-        // Register against the SENSOR_SERVICE
-        lms.start();
-
-        float[][] values = {{-0.2353596f, 0.1569064f, 9.963556f},
-                {-0.19613299f, 0.0784532f, 9.963556f},
-                {-0.2745862f, 0.19613299f, 10.002783f},
-                {-0.2353596f, 0.19613299f, 9.92433f},
-                {-0.3138128f, 0.19613299f, 9.845877f},
-                {-0.3138128f, 0.1176798f, 9.885103f},
-                {-0.2745862f, 0.1176798f, 9.963556f},
-                {-0.3138128f, 0.1569064f, 10.002783f},
-                {-0.2745862f, 0.0784532f, 9.885103f},
-                {-0.19613299f, 0.1176798f, 9.92433f},
-                {-0.2353596f, 0.1176798f, 9.92433f},
-                {-0.19613299f, 0.2353596f, 10.002783f},
-                {-0.19613299f, 0.2745862f, 9.963556f},
-                {-0.39226598f, 0.3138128f, 10.042009f},
-                {-0.35303938f, 0.1569064f, 9.963556f},
-                {-0.39226598f, 0.1569064f, 9.92433f},
-                {-0.39226598f, 0.1569064f, 10.042009f},
-                {-0.2745862f, 0.2745862f, 9.963556f},
-                {-0.2353596f, 0.1176798f, 9.92433f},
-                {-0.3138128f, 0.1569064f, 9.963556f},
-                {-0.3138128f, 0.19613299f, 9.963556f},
-                {-0.2745862f, 0.1569064f, 10.002783f},
-                {-0.3138128f, 0.1569064f, 9.845877f},
-                {-0.2745862f, 0.0784532f, 9.963556f},
-                {-0.35303938f, -0.0392266f, 9.963556f},
-                {-0.2745862f, 0.0392266f, 9.963556f},
-                {-0.39226598f, 0.0392266f, 9.885103f},
-                {-0.1569064f, 0.1176798f, 9.963556f},
-                {-0.3138128f, 0.0392266f, 9.963556f},
-                {-0.3138128f, 0.0784532f, 10.002783f}};
-
-
-        // Push events through now.
-        for (float[] row : values) {
-            lms.sensorChanged(Sensor.TYPE_ACCELEROMETER, row);
-        }
-
-        // This is close enough.  Android sensors have a lot of noise.
-        assert (Math.abs(lms.computed_gravity - 9.81) < 0.25);
-    }
-
     double mLat, mLon;
 
     public Location getNextGPSLocation() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/LegacyMotionSensor.java
@@ -10,7 +10,6 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.FloatMath;
 
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
@@ -31,16 +30,8 @@ public class LegacyMotionSensor implements IMotionSensor {
         public void onAccuracyChanged(Sensor sensor, int accuracy) {
         }
     };
+
     private final Context mAppContext;
-    // A few sensor movements are required within a time window before we say there is user motion.
-    private final int TIME_WINDOW_MS = 1000;
-    private final int MOVEMENTS_REQUIRED_IN_TIME_WINDOW = 3;
-    private final float alpha = (float) 0.8;
-    public float computed_gravity = 0;
-    private long mLastTimeThereWasMovementMs;
-    private int mMovementCountWithinTimeWindow;
-    private float[] gravity = {0, 0, 0};
-    private float[] linear_acceleration = {0, 0, 0};
     private boolean isActive;
 
     public LegacyMotionSensor(Context ctx) {
@@ -48,57 +39,65 @@ public class LegacyMotionSensor implements IMotionSensor {
         mSensorManager = (SensorManager) mAppContext.getSystemService(Context.SENSOR_SERVICE);
     }
 
+    // Each time the baseline average changes by greater than the threshold,
+    // indicate this (see isOverThreshold) and update the baseline average to the current rolling average.
+    // So, if the threshold is 1, and the current baseline average is 10,
+    // then we need the rolling average to to reach 9 (or 11) for isOverThreshold to return true and
+    // then the baseline average is set the rolling average.
+    // This 'baseline average' method ensures that changes of acceleration can be detected over any time period.
+    class RollingAverage {
+        float[] mSamples;
+        final float mThreshold;
+        int mIdx;
+        float mTotal;
+        float mBaselineAverage;
+        boolean mIsInitialized;
+
+        public RollingAverage(int sampleCount, float changeThreshold) {
+            mSamples = new float[sampleCount];
+            mThreshold = changeThreshold;
+        }
+
+        public boolean isOverThreshold(float val) {
+            mTotal -= mSamples[mIdx];
+            mTotal += val;
+            mSamples[mIdx] = val;
+            if (++mIdx == mSamples.length) {
+                mIdx = 0;
+                float average = average();
+                if (!mIsInitialized) {
+                    mIsInitialized = true;
+                    mBaselineAverage = average;
+                } else if (Math.abs(average - mBaselineAverage) > mThreshold) {
+                    mBaselineAverage = average;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        float average() {
+            return mTotal / mSamples.length;
+        }
+
+        void clear() {
+            mSamples = new float[mSamples.length];
+            mIdx = 0;
+            mIsInitialized = false;
+        }
+    }
+
+    final RollingAverage mRollingAverage = new RollingAverage(10, 0.5f);
+
     /*
      This function is called by the SensorEventListener so that we have something to test.
      Real SensorEvent instances cannot be constructed on a test platform.
      */
     public void sensorChanged(int sensorType, float[] event_values) {
-        gravity[0] = alpha * gravity[0] + (1 - alpha) * event_values[0];
-        gravity[1] = alpha * gravity[1] + (1 - alpha) * event_values[1];
-        gravity[2] = alpha * gravity[2] + (1 - alpha) * event_values[2];
-
-        linear_acceleration[0] = event_values[0] - gravity[0];
-        linear_acceleration[1] = event_values[1] - gravity[1];
-        linear_acceleration[2] = event_values[2] - gravity[2];
-
-        computed_gravity = FloatMath.sqrt(gravity[0] * gravity[0] +
-                gravity[1] * gravity[1] +
-                gravity[2] * gravity[2]);
-
-        if (iterations_for_convergence > 0) {
-            // We don't use an epsilon to detect convergence because empirically
-            // devices don't seem to comply to the 0.05m/s^2 error that Google
-            // specifies.  The Motorola XT1032 seems to get ~10.10 m/s^s for gravity
-            // when it's tilted to stand on it's edge.  When laid flat,
-            // it gets pretty close with 9.89m/s^2 which is still far from 9.81m/s^2
-            iterations_for_convergence--;
-            return;
-        }
-
-        float x = linear_acceleration[0];
-        float y = linear_acceleration[1];
-        float z = linear_acceleration[2];
-
-        final float accel = FloatMath.sqrt(x * x + y * y + z * z);
-
-        // I found this to be a very low threshold, slight movements of the device are greater than 1.0.
-        // False positives are fine, what we don't want is devices that can't be woken up easily.
-        final float arbitraryThresholdForMovement = 1.0f;
-
-        if (accel > arbitraryThresholdForMovement) {
-            final long prevTime = mLastTimeThereWasMovementMs;
-            mLastTimeThereWasMovementMs = System.currentTimeMillis();
-
-            if (mLastTimeThereWasMovementMs - prevTime < TIME_WINDOW_MS) {
-                mMovementCountWithinTimeWindow++;
-                if (mMovementCountWithinTimeWindow >= MOVEMENTS_REQUIRED_IN_TIME_WINDOW) {
-                    mMovementCountWithinTimeWindow = 0;
-                    LocalBroadcastManager.getInstance(mAppContext).
-                            sendBroadcastSync(new Intent(MotionSensor.ACTION_USER_MOTION_DETECTED));
-                }
-            } else {
-                mMovementCountWithinTimeWindow = 0;
-            }
+         if (mRollingAverage.isOverThreshold(event_values[0] + event_values[1] + event_values[2])) {
+            LocalBroadcastManager.getInstance(mAppContext).
+                  sendBroadcastSync(new Intent(MotionSensor.ACTION_USER_MOTION_DETECTED));
+             mRollingAverage.clear();
         }
     }
 


### PR DESCRIPTION
Use the rolling average at t1  as a baseline, and when the average exceeds
a theshold relative to the baseline average at t1, then notify movement has
occurred, and update the baseline.
Sounds fancy but it isn't :).
