### PR TITLE
make the upload service not sticky (not auto-restarted if killed).

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/UploadAlarmReceiver.java
@@ -79,10 +79,12 @@ public class UploadAlarmReceiver extends BroadcastReceiver {
 
         public UploadAlarmService(String name) {
             super(name);
+            // makes the service START_NOT_STICKY, that is, the service is not auto-restarted
+            setIntentRedelivery(false);
         }
 
         public UploadAlarmService() {
-            super(LOG_TAG);
+            this(LOG_TAG);
         }
 
         @Override


### PR DESCRIPTION
For one, this is unnecessary, as the app does rescheduling of this as needed.
Also, it prevents the os trying to restart this after killing the stumbler, when resources might still be low.
