### PR TITLE
check network provider is available before trying to use (ACRA report)

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/MotionSensor.java
@@ -161,6 +161,9 @@ public class MotionSensor {
         public void start(Context c) {
             mContext = c;
             LocationManager lm = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+            if (!lm.getAllProviders().contains(LocationManager.NETWORK_PROVIDER)) {
+                return;
+            }
 
             if (mLastLocation == null) {
                 mLastLocation = lm.getLastKnownLocation(LocationManager.GPS_PROVIDER);


### PR DESCRIPTION
This is to fix this ACRA crash:
java.lang.IllegalArgumentException: requested provider network doesn't exisit
at android.os.Parcel.readException(Parcel.java:1429)
at android.os.Parcel.readException(Parcel.java:1379)
at android.location.ILocationManager$Stub$Proxy.requestLocationUpdates(ILocationManager.java:659)
at android.location.LocationManager._requestLocationUpdates(LocationManager.java:664)
at android.location.LocationManager.requestLocationUpdates(LocationManager.java:486)
at org.mozilla.mozstumbler.service.stumblerthread.motiondetection.MotionSensor$NetworkLocationChangeDetector.start(MotionSensor.java:172)
at org.mozilla.mozstumbler.service.stumblerthread.motiondetection.MotionSensor.start(MotionSensor.java:117)
at org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager$2.onReceive(ScanManager.java:81)
at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
at android.support.v4.content.LocalBroadcastManager.sendBroadcastSync(LocalBroadcastManager.java:278)
at org.mozilla.mozstumbler.service.stumblerthread.motiondetection.LocationChangeSensor$1.run(LocationChangeSensor.java:46)
