### PR TITLE
(1524) Force sync stats broadcast on startup so the metrics view has initial values

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -14,6 +14,7 @@ import android.util.Log;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.stumblerthread.StumblerService;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.ClientDataStorageManager;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.utils.BatteryCheckReceiver;
 import org.mozilla.mozstumbler.service.utils.BatteryCheckReceiver.BatteryCheckCallback;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -64,7 +64,6 @@ public class MetricsView {
     private final View mView;
     private final String mObservationAndSize = "%1$d  %2$s";
     private WeakReference<IMapLayerToggleListener> mMapLayerToggleListener = new WeakReference<IMapLayerToggleListener>(null);
-    private long mTotalBytesUploadedThisSession_lastDisplayed = -1;
     private long mLastUploadTime = 0;
     private boolean mHasQueuedObservations;
     private boolean buttonIsSyncIcon;
@@ -79,6 +78,7 @@ public class MetricsView {
                     public void onReceive(Context context, Intent intent) {
                         Bundle bundle = intent.getExtras();
                         mPersistedStats = (Properties) bundle.get(PersistedStats.EXTRAS_PERSISTENT_SYNC_STATUS_UPDATED);
+                        updateSentStats();
                     }
                 },
                 new IntentFilter(PersistedStats.ACTION_PERSISTENT_SYNC_STATUS_UPDATED));
@@ -261,15 +261,6 @@ public class MetricsView {
     }
 
     private void updateSentStats() {
-
-        final long bytesUploadedThisSession = AsyncUploader.sTotalBytesUploadedThisSession.get();
-
-        if (mTotalBytesUploadedThisSession_lastDisplayed == bytesUploadedThisSession) {
-            // no need to update
-            return;
-        }
-        mTotalBytesUploadedThisSession_lastDisplayed = bytesUploadedThisSession;
-
         if (mPersistedStats != null) {
             String sent = mPersistedStats.getProperty(DataStorageContract.Stats.KEY_OBSERVATIONS_SENT, "0");
             String bytes = mPersistedStats.getProperty(DataStorageContract.Stats.KEY_BYTES_SENT, "0");

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManager.java
@@ -22,6 +22,8 @@ public class ClientDataStorageManager extends DataStorageManager {
 
     private ClientDataStorageManager(Context c, StorageIsEmptyTracker tracker, long maxBytesStoredOnDisk, int maxWeeksDataStored) {
         super(c, tracker, maxBytesStoredOnDisk, maxWeeksDataStored);
+
+        mPersistedOnDiskUploadStats.forceBroadcastOfSyncStats();
     }
 
     public static String sdcardArchivePath() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManager.java
@@ -34,6 +34,7 @@ public class ClientDataStorageManager extends DataStorageManager {
     // DataStorageManager.  Sorta.  You can't really override static methods.
     public static synchronized DataStorageManager createGlobalInstance(Context context, StorageIsEmptyTracker tracker,
                                                                        long maxBytesStoredOnDisk, int maxWeeksDataStored) {
+
         if (sInstance == null) {
             sInstance = new ClientDataStorageManager(context, tracker, maxBytesStoredOnDisk, maxWeeksDataStored);
         }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -65,7 +65,7 @@ public class DataStorageManager {
     // Set to the default value specified above.
     private final int mMaxWeeksStored;
     private final StorageIsEmptyTracker mTracker;
-    private final PersistedStats mPersistedOnDiskUploadStats;
+    protected final PersistedStats mPersistedOnDiskUploadStats;
     protected ReportBatch mCurrentReportsSendBuffer;
     protected ReportFileList mFileList;
     private ReportBatchIterator mReportBatchIterator;

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManagerTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManagerTest.java
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.LocationChangeSensor;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.MockSystemClock;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Properties;
+
+import static junit.framework.Assert.assertEquals;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class ClientDataStorageManagerTest {
+
+    private class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+        public void notifyStorageStateEmpty(boolean isEmpty) {
+        }
+    }
+
+    private final BroadcastReceiver callbackReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            // Just capture the intent for testing
+            receivedIntent.add(intent);
+        }
+    };
+
+    private LinkedList<Intent> receivedIntent = new LinkedList<Intent>();
+
+    @Before
+    public void setUp() {
+        ClientDataStorageManager.sInstance = null;
+    }
+
+    @Test
+    public void testForceSendMetrics() {
+
+        receivedIntent.clear();
+
+        Context ctx = Robolectric.application;
+
+        LocalBroadcastManager.getInstance(ctx).registerReceiver(callbackReceiver,
+                new IntentFilter(PersistedStats.ACTION_PERSISTENT_SYNC_STATUS_UPDATED));
+
+        StorageTracker tracker = new StorageTracker();
+
+        long maxBytes = 20000;
+        int maxWeeks = 10;
+
+        MockSystemClock clock = new MockSystemClock();
+
+        final long ARBITRARY_CLOCK_TIME = 12150;
+        clock.setCurrentTime(ARBITRARY_CLOCK_TIME);
+
+        ServiceLocator.getInstance().putService(ISystemClock.class, clock);
+
+        ClientDataStorageManager.createGlobalInstance(ctx, tracker, maxBytes, maxWeeks);
+
+        assertEquals(1, receivedIntent.size());
+        Intent i = receivedIntent.get(0);
+
+        Bundle bundle = i.getExtras();
+        Properties props = (Properties) bundle.get(PersistedStats.EXTRAS_PERSISTENT_SYNC_STATUS_UPDATED);
+        assertEquals(Long.toString(ARBITRARY_CLOCK_TIME), props.getProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "0"));
+    }
+}


### PR DESCRIPTION
When the ClientStumblerService is initialized, force a single read of the sync stats, and broadcast this for the metrics view to update on startup.
Note that in the app the UI components are initialized before the service.

https://github.com/mozilla/MozStumbler/issues/1524
