### PR TITLE
Fix #1505

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/TileDownloaderDelegate.java
@@ -95,8 +95,8 @@ public class TileDownloaderDelegate {
         if (AppGlobals.isDebug) {
             ClientLog.d(LOG_TAG, "Got a response: " + resp.httpStatusCode());
         }
+
         if (resp == null) {
-            ClientLog.w(LOG_TAG, "A NULL response was returned from the HTTP client.  This should never have happened.");
             return null;
         }
 
@@ -117,8 +117,6 @@ public class TileDownloaderDelegate {
         if (resp.httpStatusCode() != 200) {
             if (resp.httpStatusCode() == 404) {
                 HTTP404_CACHE.put(tileURLString, System.currentTimeMillis() + ONE_HOUR_MS);
-            } else {
-                ClientLog.w(LOG_TAG, "Unexpected response from tile server: [" + resp.httpStatusCode() + "]");
             }
 
             // @TODO vng: This is a hack so that we skip over anything that errors from the mozilla

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
@@ -5,6 +5,7 @@ import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,6 +17,14 @@ public class HTTPResponse implements IResponse {
     private final byte[] bodyBytes;
     private final int bytesSent;
     private final Map<String, List<String>> headers;
+
+    public HTTPResponse(int responseCode, int txByteLength)
+    {
+        statusCode = responseCode;
+        bodyBytes = new byte[]{};
+        bytesSent = txByteLength;
+        headers = new HashMap<String, List<String>>();
+    }
 
     public HTTPResponse(int responseCode, Map<String, List<String>> headerFields, byte[] contentBody, int txByteLength) {
         statusCode = responseCode;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
@@ -20,10 +20,7 @@ public class HTTPResponse implements IResponse {
 
     public HTTPResponse(int responseCode, int txByteLength)
     {
-        statusCode = responseCode;
-        bodyBytes = new byte[]{};
-        bytesSent = txByteLength;
-        headers = new HashMap<String, List<String>>();
+        this(responseCode, new HashMap<String, List<String>>(), new byte[]{}, txByteLength);
     }
 
     public HTTPResponse(int responseCode, Map<String, List<String>> headerFields, byte[] contentBody, int txByteLength) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
@@ -147,7 +147,7 @@ public class HttpUtil implements IHttpUtil {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
             ClientLog.e(LOG_TAG, "Bad URL", e);
-            return null;
+            return new HTTPResponse(404, 0);
         }
 
         if (headers == null) {
@@ -160,12 +160,11 @@ public class HttpUtil implements IHttpUtil {
                 httpURLConnection.setInstanceFollowRedirects(false);
             }
             httpURLConnection.setConnectTimeout(5000); // set timeout to 5 seconds
-
             httpURLConnection.setRequestMethod(HTTP_METHOD);
             httpURLConnection.setRequestProperty(USER_AGENT_HEADER, userAgent);
         } catch (IOException e) {
             ClientLog.e(LOG_TAG, "Couldn't open a connection: ", e);
-            return null;
+            return new HTTPResponse(598, 0);
         }
 
         // Workaround for a bug in Android mHttpURLConnection. When the library
@@ -190,7 +189,7 @@ public class HttpUtil implements IHttpUtil {
         } finally {
             httpURLConnection.disconnect();
         }
-        return null;
+        return new HTTPResponse(598, 0);
     }
 
     @Override


### PR DESCRIPTION
This fixes #1505 so that NPEs no longer show scary messages in the Client log.

Details:

I've removed a scary warning message in TileDownloaderDelegate referenced in #1505 removed a duplicate ClientLog.w message.
HTTPResponse now has an additional constructor that accepts a HTTP Status code and a transmit byte length. This makes construction of statuses like 598 easier to build.
HTTPUtil no longer returns NULL in any case.  You will always get a 404, or a 598 on an error.
