### PR TITLE
Fix notification updates

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -36,6 +36,7 @@ import org.mozilla.mozstumbler.client.Updater;
 import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.mozstumbler.client.subactivities.FirstRunFragment;
 import org.mozilla.mozstumbler.client.subactivities.LeaderboardActivity;
+import org.mozilla.mozstumbler.client.util.NotificationUtil;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 public class MainDrawerActivity
@@ -265,6 +266,11 @@ public class MainDrawerActivity
 
                 updateStartStopMenuItemState();
                 updateNumberDisplay(updateMetrics);
+
+                if (getApp().isScanningOrPaused()) {
+                    NotificationUtil notification = new NotificationUtil(getApplicationContext());
+                    notification.update();
+                }
             }
         });
     }
@@ -282,9 +288,13 @@ public class MainDrawerActivity
         mMapFragment.formatTextView(R.id.text_observation_count, "%d", observationCount);
 
         if (updateMetrics) {
-            mMetricsView.setObservationCount(observationCount, service.getUniqueCellCount(),
-                    service.getUniqueAPCount(), getApp().isScanningOrPaused());
+            int cells = service.getUniqueCellCount();
+            int wifis = service.getUniqueAPCount();
+            mMetricsView.setObservationCount(observationCount, cells, wifis);
             mMetricsView.update();
+
+            NotificationUtil notification = new NotificationUtil(getApplicationContext());
+            notification.setMetrics(observationCount, cells, wifis);
         }
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -38,7 +38,6 @@ import org.mozilla.mozstumbler.service.uploadthread.AsyncUploadParam;
 import org.mozilla.mozstumbler.service.uploadthread.AsyncUploader;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
-import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.Properties;
 
@@ -275,6 +274,9 @@ public class MetricsView {
             String value = String.format(mObservationAndSize, Integer.parseInt(sent), formatKb(Long.parseLong(bytes)));
             mAllTimeObservationsSentView.setText(value);
             mLastUploadTime = Long.parseLong(mPersistedStats.getProperty(DataStorageContract.Stats.KEY_LAST_UPLOAD_TIME, "0"));
+
+            NotificationUtil notification = new NotificationUtil(mView.getContext().getApplicationContext());
+            notification.setUploadTime(mLastUploadTime);
         }
         updateLastUploadedLabel();
     }
@@ -294,13 +296,10 @@ public class MetricsView {
         }
     };
 
-    public void setObservationCount(int observations, int cells, int wifis, boolean isActive) {
+    public void setObservationCount(int observations, int cells, int wifis) {
         sThisSessionObservationsCount = observations;
         sThisSessionUniqueCellCount = cells;
         sThisSessionUniqueWifiCount = wifis;
-
-        NotificationUtil util = new NotificationUtil(mView.getContext().getApplicationContext());
-        util.updateMetrics(observations, cells, wifis, mLastUploadTime, isActive);
     }
 
     public interface IMapLayerToggleListener {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
@@ -21,7 +21,7 @@ public class NotificationUtil {
     private static String sStopTitle;
     private static int sObservations, sCells, sWifis;
     private static long sUploadTime, sDisplayTime, sLastUpdateTime;
-    private static boolean sIsPaused;
+    private static boolean sIsPaused, sNeedsUpdate;
     private final Context mContext;
 
     public NotificationUtil(Context context) {
@@ -57,6 +57,7 @@ public class NotificationUtil {
                                            .getService(ISystemClock.class);
 
         sLastUpdateTime = clock.currentTimeMillis();
+        sNeedsUpdate = false;
 
         return new NotificationCompat.Builder(mContext)
                 .setSmallIcon(R.drawable.ic_status_scanning)
@@ -73,7 +74,7 @@ public class NotificationUtil {
                 .build();
     }
 
-    private void update() {
+    private void forceUpdate() {
         Notification notification = build();
         NotificationManager nm = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         nm.notify(NOTIFICATION_ID, notification);
@@ -89,19 +90,32 @@ public class NotificationUtil {
     public void setPaused(boolean isPaused) {
         sIsPaused = isPaused;
         sDisplayTime = System.currentTimeMillis();
-        update();
+        forceUpdate();
     }
 
-    public void updateMetrics(int observations, int cells, int wifis, long uploadtime, boolean isActive) {
+    public void setMetrics(int observations, int cells, int wifis) {
         sObservations = observations;
         sCells = cells;
         sWifis = wifis;
+        sNeedsUpdate = true;
+    }
+
+    public void setUploadTime(long uploadtime) {
         sUploadTime = uploadtime;
+        sNeedsUpdate = true;
+    }
+
+    public void update() {
+        if (!sNeedsUpdate) {
+            return;
+        }
 
         long diffLastUpdate = System.currentTimeMillis() - sLastUpdateTime;
         boolean isUpdateAnimated = Build.VERSION.SDK_INT < 21;
-        if (isActive && (!isUpdateAnimated || diffLastUpdate > UPDATE_FREQUENCY)) {
-            update();
+        if (isUpdateAnimated && diffLastUpdate < UPDATE_FREQUENCY) {
+            return;
         }
+
+        forceUpdate();
     }
 }


### PR DESCRIPTION
Fixes #1484 
Now sets the last upload time in the notification on start.
The metrics are always zero on app start, and (of course) it still takes one minute until they are updated (on devices < Android 5).
