### PR TITLE
NetworkLocationListener PR that is now superseded by 1588 and 1589

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -18,6 +18,9 @@ public interface IMainActivity {
     public void isPausedDueToNoMotion(boolean isPaused);
 
     // Call from main thread only
+    public void start();
+
+    // Call from main thread only
     public void stop();
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -307,6 +307,7 @@ public class MainApp extends Application
 
         if (mMainActivity.get() != null) {
             mMainActivity.get().updateUiOnMainThread(false);
+            mMainActivity.get().start();
         }
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -10,7 +10,6 @@ import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.location.Location;
-import android.location.LocationManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
@@ -674,20 +673,25 @@ public class MapFragment extends android.support.v4.app.Fragment
         }
     }
 
-    public void showPausedDueToNoMotionMessage(boolean show) {
-        mRootView.findViewById(R.id.scanning_paused_message).setVisibility(show ? View.VISIBLE : View.INVISIBLE);
+    public void showPausedDueToNoMotionMessage(boolean paused) {
+        mRootView.findViewById(R.id.scanning_paused_message).setVisibility(paused ? View.VISIBLE : View.INVISIBLE);
         if (mMapLocationListener != null) {
-            mMapLocationListener.pauseGpsUpdates(show);
+            mMapLocationListener.enableActiveLocationUpdates(!paused);
         }
         updateGPSInfo(0, 0);
         dimToolbar();
     }
 
+    public void start() {
+        if (mMapLocationListener != null) {
+            mMapLocationListener.enableActiveLocationUpdates(true);
+        }
+    }
+
     public void stop() {
         mRootView.findViewById(R.id.scanning_paused_message).setVisibility(View.INVISIBLE);
         if (mMapLocationListener != null) {
-            mMapLocationListener.removeListener();
-            mMapLocationListener = null;
+            mMapLocationListener.enableActiveLocationUpdates(false);
         }
         updateGPSInfo(0, 0);
         dimToolbar();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -373,6 +373,11 @@ public class MainDrawerActivity
     }
 
     @Override
+    public void start() {
+        mMapFragment.start();
+    }
+
+    @Override
     public void stop() {
         mMapFragment.stop();
     }


### PR DESCRIPTION
Right now the `MapLocationListener` is activating the network location listener when scanning is paused. Does that make any sense? These listeners are only for updating the position marker on the map, not for motion detection, right?
And as far as I know, the network location provider will scan for cells and wifis and use the internet, which also consumes energy.
