### PR TITLE
Fixes to passive scanning mode

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -26,7 +26,7 @@ public class AppGlobals {
     /* Location constructor requires a named origin, these are created in the app. */
     public static final String LOCATION_ORIGIN_INTERNAL = "internal";
     /* In passive mode, only scan this many times for each gps. */
-    public static final int PASSIVE_MODE_MAX_SCANS_PER_GPS = 3;
+    public static final int PASSIVE_MODE_MAX_SCANS_PER_GPS = 2;
     public static final String NO_TRUNCATE_FLAG = "~";
     public static final String ACTION_TEST_SETTING_ENABLED = "stumbler-test-setting-enabled";
     public static final String ACTION_TEST_SETTING_DISABLED = "stumbler-test-setting-disabled";

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -38,6 +38,13 @@ public class ScanManager {
     private static Context mAppContext;
     private Timer mPassiveModeFlushTimer;
 
+    // how often to flush a leftover bundle to the reports table
+    // If there is a bundle, and nothing happens for 10sec, then flush it
+    // MAX_SCANS_PER_GPS    is 2
+    // CELL_MIN_UPDATE_TIME is 1sec
+    // WIFI_MIN_UPDATE_TIME is 4sec
+    private static final int FLUSH_RATE_MS = 10000; // 10 sec
+
     private GPSScanner mGPSScanner;
     private WifiScanner mWifiScanner;
     private CellScanner mCellScanner;
@@ -126,16 +133,12 @@ public class ScanManager {
         mWifiScanner.start(ActiveOrPassiveStumbling.PASSIVE_STUMBLING);
         mCellScanner.start(ActiveOrPassiveStumbling.PASSIVE_STUMBLING);
 
-        // how often to flush a leftover bundle to the reports table
-        // If there is a bundle, and nothing happens for 10sec, then flush it
-        final int flushRate_ms = 10000;
-
         if (mPassiveModeFlushTimer != null) {
             mPassiveModeFlushTimer.cancel();
         }
 
         Date when = new Date();
-        when.setTime(when.getTime() + flushRate_ms);
+        when.setTime(when.getTime() + FLUSH_RATE_MS);
         mPassiveModeFlushTimer = new Timer();
         mPassiveModeFlushTimer.schedule(new TimerTask() {
             @Override

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -158,7 +158,7 @@ public class WifiScanner {
             @Override
             public void run() {
                 if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        mPassiveScanCount++ > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                        ++mPassiveScanCount > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     mPassiveScanCount = 0;
                     stop(); // set mWifiScanTimer to null
                     return;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -35,7 +35,7 @@ public class WifiScanner {
     public static final int STATUS_WIFI_DISABLED = -1;
 
     private static final String LOG_TAG = LoggerUtil.makeLogTag(WifiScanner.class);
-    private static final long WIFI_MIN_UPDATE_TIME = 5000; // milliseconds
+    private static final long WIFI_MIN_UPDATE_TIME = 4000; // milliseconds
     private final Context mAppContext;
     private final WifiManagerProxy wifiManagerProxy;
     private boolean mStarted;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -74,6 +74,7 @@ public class WifiScanner {
     }
 
     public synchronized void start(final ActiveOrPassiveStumbling stumblingMode) {
+        // If the scan timer is active, this will reset the number of times it has run
         mPassiveScanCount.set(0);
 
         if (mStarted) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -39,6 +39,7 @@ public class WifiScanner {
     private final Context mAppContext;
     private final WifiManagerProxy wifiManagerProxy;
     private boolean mStarted;
+    private AtomicInteger mPassiveScanCount = new AtomicInteger();
     private WifiLock mWifiLock;
     private Timer mWifiScanTimer;
     private AtomicInteger mVisibleAPs = new AtomicInteger();
@@ -73,6 +74,8 @@ public class WifiScanner {
     }
 
     public synchronized void start(final ActiveOrPassiveStumbling stumblingMode) {
+        mPassiveScanCount.set(0);
+
         if (mStarted) {
             return;
         }
@@ -153,13 +156,11 @@ public class WifiScanner {
         // Ensure that we are constantly scanning for new access points.
         mWifiScanTimer = new Timer();
         mWifiScanTimer.schedule(new TimerTask() {
-            int mPassiveScanCount;
 
             @Override
             public void run() {
                 if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        ++mPassiveScanCount > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
-                    mPassiveScanCount = 0;
+                        mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     stop(); // set mWifiScanTimer to null
                     return;
                 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CellScanner {
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE + ".CellScanner.";
@@ -39,6 +40,7 @@ public class CellScanner {
     private final ISimpleCellScanner mSimpleCellScanner;
     private Timer mCellScanTimer;
     private Handler mBroadcastScannedHandler;
+    private AtomicInteger mPassiveScanCount = new AtomicInteger();
 
     public CellScanner(Context appCtx) {
         mAppContext = appCtx;
@@ -53,6 +55,8 @@ public class CellScanner {
         if (!mSimpleCellScanner.isSupportedOnThisDevice()) {
             return;
         }
+
+        mPassiveScanCount.set(0);
 
         if (mCellScanTimer != null) {
             return;
@@ -75,7 +79,6 @@ public class CellScanner {
         mCellScanTimer = new Timer();
 
         mCellScanTimer.schedule(new TimerTask() {
-            int mPassiveScanCount;
 
             @Override
             public void run() {
@@ -84,8 +87,7 @@ public class CellScanner {
                 }
 
                 if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        ++mPassiveScanCount > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
-                    mPassiveScanCount = 0;
+                        mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     stop();
                     return;
                 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -84,7 +84,7 @@ public class CellScanner {
                 }
 
                 if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        mPassiveScanCount++ > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                        ++mPassiveScanCount > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     mPassiveScanCount = 0;
                     stop();
                     return;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -56,6 +56,7 @@ public class CellScanner {
             return;
         }
 
+        // If the scan timer is active, this will reset the number of times it has run
         mPassiveScanCount.set(0);
 
         if (mCellScanTimer != null) {


### PR DESCRIPTION
I found some issues in passive scanning mode:
- number of passive scans per location was always one too many because of post increment
- the scanners always needed to be stopped even if a new position was reported instantly
- scanner data was flushed after 10 seconds while wifi scanning continued (3 \* 5 sec = 15 sec). So I decreased `MAX_SCANS_PER_GPS` and `WIFI_MIN_UPDATE_TIME` to fit into one interval, which should also increase data accuracy

I learned that changes to the library code are especially critical, so I'm awaiting comments.
