### PR TITLE
Fix for #1557

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageContract.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageContract.java
@@ -17,6 +17,7 @@ public final class DataStorageContract {
         public static final String ALTITUDE = "altitude";
         public static final String CELL = "cellTowers";
         public static final String WIFI = "wifiAccessPoints";
+        public static final String RADIO = "radioType";
     }
 
     public static class Stats {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellInfo.java
@@ -162,14 +162,14 @@ public class CellInfo implements Parcelable {
         try {
             obj.put("radioType", getCellRadio());
 
-           // Bug #1510
-           // if (mCid != UNKNOWN_CID) {
-                obj.put("cellId", mCid);
+            // Bug #1510
+            // if (mCid != UNKNOWN_CID) {
+            obj.put("cellId", mCid);
             //}
 
             // Bug #1510
             //if (mLac != UNKNOWN_LAC) {
-                obj.put("locationAreaCode", mLac);
+            obj.put("locationAreaCode", mLac);
             //}
 
             obj.put("mobileCountryCode", mMcc);

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
@@ -9,7 +9,6 @@ import android.location.LocationManager;
 import android.net.wifi.ScanResult;
 import android.os.Build;
 import android.os.SystemClock;
-import android.telephony.TelephonyManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -64,6 +63,7 @@ public class StumblerBundleTest {
         stumbleBlob.put(DataStorageContract.ReportsColumns.CELL, cellTowerArray);
 
         stumbleBlob.put(DataStorageContract.ReportsColumns.TIME, 1405602028568L);
+        stumbleBlob.put("radioType", "lte");
         stumbleBlob.put(DataStorageContract.ReportsColumns.LON, -43.5f);
         stumbleBlob.put(DataStorageContract.ReportsColumns.LAT, -22.5f);
 
@@ -71,7 +71,7 @@ public class StumblerBundleTest {
     }
 
 
-    protected JSONObject getExpectedReportBatch() throws JSONException {
+    protected JSONObject getExpectedGeosubmit() throws JSONException {
 
         List<JSONObject> wifiList = new ArrayList<JSONObject>();
 
@@ -122,7 +122,7 @@ public class StumblerBundleTest {
 
     @Test
     public void testToGeosubmitJSON() throws JSONException {
-        JSONObject expectedJson = getExpectedReportBatch();
+        JSONObject expectedJson = getExpectedGeosubmit();
 
         Location mockLocation = new Location(LocationManager.GPS_PROVIDER); // a string
         mockLocation.setLatitude(-22.5f);
@@ -199,9 +199,9 @@ public class StumblerBundleTest {
 
         bundle.addCellData(cellInfo.getCellIdentity(), cellInfo);
 
-        JSONObject geoLocateJSON = bundle.toMLSGeolocate();
+        JSONObject actualJson = bundle.toMLSGeolocate();
 
-        JSONAssert.assertEquals(expectedJson, geoLocateJSON, true);
+        JSONAssert.assertEquals(expectedJson, actualJson, true);
     }
 
     public static CellInfo createLteCellInfo(int mcc,


### PR DESCRIPTION
This adds the radioType field back to the top level of the geolocate API call.   Cell tower-only based location requests were not handled correctly causing geo-ip results to be returned.
