### PR TITLE
Always use passive scanning in cell and wifi scanners

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -26,7 +26,7 @@ public class AppGlobals {
     /* Location constructor requires a named origin, these are created in the app. */
     public static final String LOCATION_ORIGIN_INTERNAL = "internal";
     /* In passive mode, only scan this many times for each gps. */
-    public static final int PASSIVE_MODE_MAX_SCANS_PER_GPS = 2;
+    public static final int MAX_SCANS_PER_GPS = 2;
     public static final String NO_TRUNCATE_FLAG = "~";
     public static final String ACTION_TEST_SETTING_ENABLED = "stumbler-test-setting-enabled";
     public static final String ACTION_TEST_SETTING_DISABLED = "stumbler-test-setting-disabled";

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -201,7 +201,7 @@ public class GPSScanner implements LocationListener {
         reportNewLocationReceived(location);
         mLocationCount++;
 
-        mScanManager.newPassiveGpsLocation();
+        mScanManager.newGpsLocation();
 
         if (timeDeltaMs > 0) {
             TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_TIME_BETWEEN_RECEIVED_LOCATIONS_SEC,

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -201,9 +201,7 @@ public class GPSScanner implements LocationListener {
         reportNewLocationReceived(location);
         mLocationCount++;
 
-        if (mIsPassiveMode) {
-            mScanManager.newPassiveGpsLocation();
-        }
+        mScanManager.newPassiveGpsLocation();
 
         if (timeDeltaMs > 0) {
             TelemetryWrapper.addToHistogram(AppGlobals.TELEMETRY_TIME_BETWEEN_RECEIVED_LOCATIONS_SEC,

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -126,12 +126,8 @@ public class ScanManager {
             return;
         }
 
-        if (AppGlobals.isDebug) {
-            ClientLog.d(LOG_TAG, "New passive location");
-        }
-
-        mWifiScanner.start(ActiveOrPassiveStumbling.PASSIVE_STUMBLING);
-        mCellScanner.start(ActiveOrPassiveStumbling.PASSIVE_STUMBLING);
+        mWifiScanner.start();
+        mCellScanner.start();
 
         if (mPassiveModeFlushTimer != null) {
             mPassiveModeFlushTimer.cancel();
@@ -211,13 +207,6 @@ public class ScanManager {
         mCellScanner = new CellScanner(mAppContext);
 
         mGPSScanner.start(mStumblingMode);
-        if (mStumblingMode == ActiveOrPassiveStumbling.ACTIVE_STUMBLING) {
-            mWifiScanner.start(mStumblingMode);
-            mCellScanner.start(mStumblingMode);
-            // in passive mode, these scans are started by passive gps notifications
-        } else {
-            Log.d(LOG_TAG, "Wifi and Cell Scanners are not engaged with passive mode.");
-        }
     }
 
     public synchronized boolean stopScanning() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -36,7 +36,7 @@ public class ScanManager {
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ScanManager.class);
 
     private static Context mAppContext;
-    private Timer mPassiveModeFlushTimer;
+    private Timer mFlushTimer;
 
     // how often to flush a leftover bundle to the reports table
     // If there is a bundle, and nothing happens for 10sec, then flush it
@@ -121,7 +121,7 @@ public class ScanManager {
                 PassiveModeBatteryState.IGNORE_BATTERY_STATE;
     }
 
-    public void newPassiveGpsLocation() {
+    public void newGpsLocation() {
         if (mPassiveModeBatteryState == PassiveModeBatteryState.LOW) {
             return;
         }
@@ -129,14 +129,14 @@ public class ScanManager {
         mWifiScanner.start();
         mCellScanner.start();
 
-        if (mPassiveModeFlushTimer != null) {
-            mPassiveModeFlushTimer.cancel();
+        if (mFlushTimer != null) {
+            mFlushTimer.cancel();
         }
 
         Date when = new Date();
         when.setTime(when.getTime() + FLUSH_RATE_MS);
-        mPassiveModeFlushTimer = new Timer();
-        mPassiveModeFlushTimer.schedule(new TimerTask() {
+        mFlushTimer = new Timer();
+        mFlushTimer.schedule(new TimerTask() {
             @Override
             public void run() {
                 Intent flush = new Intent(Reporter.ACTION_FLUSH_TO_BUNDLE);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -38,7 +38,7 @@ public class WifiScanner {
     private final Context mAppContext;
     private final WifiManagerProxy wifiManagerProxy;
     private boolean mStarted;
-    private AtomicInteger mPassiveScanCount = new AtomicInteger();
+    private AtomicInteger mScanCount = new AtomicInteger();
     private WifiLock mWifiLock;
     private Timer mWifiScanTimer;
     private AtomicInteger mVisibleAPs = new AtomicInteger();
@@ -74,7 +74,7 @@ public class WifiScanner {
 
     public synchronized void start() {
         // If the scan timer is active, this will reset the number of times it has run
-        mPassiveScanCount.set(0);
+        mScanCount.set(0);
 
         if (mStarted) {
             return;
@@ -159,7 +159,7 @@ public class WifiScanner {
 
             @Override
             public void run() {
-                if (mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                if (mScanCount.incrementAndGet() > AppGlobals.MAX_SCANS_PER_GPS) {
                     stop(); // set mWifiScanTimer to null
                     return;
                 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -13,7 +13,6 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
-import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.BSSIDBlockList;
 import org.mozilla.mozstumbler.service.stumblerthread.blocklist.SSIDBlockList;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
@@ -73,7 +72,7 @@ public class WifiScanner {
         return wifiManagerProxy.getScanResults();
     }
 
-    public synchronized void start(final ActiveOrPassiveStumbling stumblingMode) {
+    public synchronized void start() {
         // If the scan timer is active, this will reset the number of times it has run
         mPassiveScanCount.set(0);
 
@@ -83,7 +82,7 @@ public class WifiScanner {
         mStarted = true;
 
         if (isScanEnabled()) {
-            activatePeriodicScan(stumblingMode);
+            activatePeriodicScan();
         }
 
         wifiManagerProxy.registerReceiver(this);
@@ -102,7 +101,7 @@ public class WifiScanner {
 
         if (WifiManager.WIFI_STATE_CHANGED_ACTION.equals(action)) {
             if (isScanEnabled()) {
-                activatePeriodicScan(ActiveOrPassiveStumbling.ACTIVE_STUMBLING);
+                activatePeriodicScan();
             } else {
                 deactivatePeriodicScan();
             }
@@ -142,7 +141,7 @@ public class WifiScanner {
         return STATUS_ACTIVE;
     }
 
-    synchronized void activatePeriodicScan(final ActiveOrPassiveStumbling stumblingMode) {
+    synchronized void activatePeriodicScan() {
         if (mWifiScanTimer != null) {
             return;
         }
@@ -160,8 +159,7 @@ public class WifiScanner {
 
             @Override
             public void run() {
-                if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                if (mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     stop(); // set mWifiScanTimer to null
                     return;
                 }
@@ -207,7 +205,7 @@ public class WifiScanner {
 
         if (WifiManager.WIFI_STATE_CHANGED_ACTION.equals(action)) {
             if (isScanEnabled()) {
-                activatePeriodicScan(ActiveOrPassiveStumbling.ACTIVE_STUMBLING);
+                activatePeriodicScan();
             } else {
                 deactivatePeriodicScan();
             }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/WifiScanner.java
@@ -185,8 +185,6 @@ public class WifiScanner {
 
         mWifiScanTimer.cancel();
         mWifiScanTimer = null;
-
-        mVisibleAPs.set(0);
     }
 
     private void reportScanResults(ArrayList<ScanResult> scanResults) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -39,7 +39,7 @@ public class CellScanner {
     private final ISimpleCellScanner mSimpleCellScanner;
     private Timer mCellScanTimer;
     private Handler mBroadcastScannedHandler;
-    private AtomicInteger mPassiveScanCount = new AtomicInteger();
+    private AtomicInteger mScanCount = new AtomicInteger();
 
     public CellScanner(Context appCtx) {
         mAppContext = appCtx;
@@ -56,7 +56,7 @@ public class CellScanner {
         }
 
         // If the scan timer is active, this will reset the number of times it has run
-        mPassiveScanCount.set(0);
+        mScanCount.set(0);
 
         if (mCellScanTimer != null) {
             return;
@@ -86,7 +86,7 @@ public class CellScanner {
                     return;
                 }
 
-                if (mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                if (mScanCount.incrementAndGet() > AppGlobals.MAX_SCANS_PER_GPS) {
                     stop();
                     return;
                 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -13,7 +13,6 @@ import android.os.Message;
 import android.support.v4.content.LocalBroadcastManager;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
-import org.mozilla.mozstumbler.service.AppGlobals.ActiveOrPassiveStumbling;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 
@@ -51,7 +50,7 @@ public class CellScanner {
         }
     }
 
-    public void start(final ActiveOrPassiveStumbling stumblingMode) {
+    public void start() {
         if (!mSimpleCellScanner.isSupportedOnThisDevice()) {
             return;
         }
@@ -87,8 +86,7 @@ public class CellScanner {
                     return;
                 }
 
-                if (stumblingMode == ActiveOrPassiveStumbling.PASSIVE_STUMBLING &&
-                        mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
+                if (mPassiveScanCount.incrementAndGet() > AppGlobals.PASSIVE_MODE_MAX_SCANS_PER_GPS) {
                     stop();
                     return;
                 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -58,6 +58,9 @@ public class CellScanner {
         // If the scan timer is active, this will reset the number of times it has run
         mScanCount.set(0);
 
+        // clear cells on next scan
+        mReportWasFlushed.set(true);
+
         if (mCellScanTimer != null) {
             return;
         }
@@ -126,8 +129,6 @@ public class CellScanner {
     }
 
     public synchronized void stop() {
-        mReportWasFlushed.set(false);
-        clearCells();
         LocalBroadcastManager.getInstance(mAppContext).unregisterReceiver(mReportFlushedReceiver);
 
         if (mCellScanTimer != null) {


### PR DESCRIPTION
I think it might be a good idea to always run the cell and wifi scans in passive mode.
As a result, only two scans will be done per location, and only when a new location is reported by the active GPS. After that the report will be flushed.
That also means that scanning is not active if the device is not reporting new locations because it is either not moving (which works independently from motion sensing settings) or has no GPS fix.
And the number of scans is reduced if you are moving slowly. The current min distance for GPS to report a new location is 30 meters. At a regular walking speed of 5-6km/h this takes ~20 seconds. In that time, 20 cell and 5 wifi scans are made. With this patch, it's always only 2 scans each.
With the current settings, wifi scanning will become permanently active at ~13km/h, cell scanning at ~50km/h.
And Stumbler users will be running and actively testing the same code that is run in passive mode used in Android Firefox.
Also fixes #1503, fixes #1301 and basically fixes #1055.
