### PR TITLE
Unbind the ClientStumblerService

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -9,7 +9,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
 
 import org.mozilla.mozstumbler.R;
@@ -41,7 +40,7 @@ public class ClientStumblerService extends StumblerService {
 
         @Override
         public String toString() {
-            return NAMESPACE+ this.name();
+            return NAMESPACE + this.name();
         }
 
         public static RequestChangeScannerState fromString(String name)  {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -307,16 +307,7 @@ public class MainApp extends Application
     }
 
     public void startScanning() {
-        if (mStumblerService == null) {
-            return;
-        }
-        NotificationUtil nm = new NotificationUtil(this.getApplicationContext());
-        Notification notification = nm.buildNotification(getString(R.string.stop_scanning));
-
-        // TODO: change this to an intent broadcast
-        mStumblerService.startForeground(NotificationUtil.NOTIFICATION_ID, notification);
-        // TODO: change this to an intent broadcast
-        mStumblerService.startScanning();
+        ClientStumblerService.startForegroundScanning(this.getApplicationContext());
 
         if (mMainActivity.get() != null) {
             mMainActivity.get().updateUiOnMainThread(false);
@@ -324,17 +315,9 @@ public class MainApp extends Application
     }
 
     public void stopScanning() {
-        if (mStumblerService == null) {
-            return;
-        }
-
         mIsScanningPausedDueToNoMotion = false;
 
-        // TODO: change this to an intent broadcast
-        mStumblerService.stopScanning();
-
-        // TODO: change this to an intent broadcast
-        mStumblerService.stopForeground(true);
+        ClientStumblerService.stopForegroundScanning(this.getApplicationContext());
 
         if (mMainActivity.get() != null) {
             mMainActivity.get().updateUiOnMainThread(false);
@@ -419,10 +402,6 @@ public class MainApp extends Application
     }
 
     public void updateMotionDetected() {
-        if (mStumblerService == null) {
-            return;
-        }
-
         AppGlobals.guiLogInfo("Is motionless: " + mIsScanningPausedDueToNoMotion);
 
         NotificationUtil util = new NotificationUtil(this.getApplicationContext());

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -162,10 +162,6 @@ public class MainApp extends Application
         return ClientPrefs.getInstance(c);
     }
 
-    public ClientStumblerService getService() {
-        return mStumblerService;
-    }
-
     public void setMainActivity(IMainActivity mainActivity) {
         mMainActivity = new WeakReference<IMainActivity>(mainActivity);
     }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -79,10 +79,6 @@ public class MainApp extends Application
     // These track the state of the currently running service
     private ScanManager.ScannerState scannerState = ScannerState.STOPPED;
 
-    boolean isStumblerStopped() {
-        return scannerState == ScannerState.STOPPED;
-    }
-
     private final BroadcastReceiver scannerStateReceiver = new BroadcastReceiver() {
         // This captures state change from the ScanManager
         @Override

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -42,6 +42,7 @@ import org.mozilla.mozstumbler.service.core.http.IHttpUtil;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 import org.mozilla.osmdroid.ResourceProxy;
 import org.mozilla.osmdroid.api.IGeoPoint;
@@ -67,7 +68,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class MapFragment extends android.support.v4.app.Fragment
         implements MetricsView.IMapLayerToggleListener {
 
+    private static final ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
     private static final String LOG_TAG = LoggerUtil.makeLogTag(MapFragment.class);
+
     private static final String COVERAGE_REDIRECT_URL = "https://location.services.mozilla.com/map.json";
     private static final String ZOOM_KEY = "zoom";
     private static final int LOWEST_UNLIMITED_ZOOM = 6;
@@ -462,9 +465,9 @@ public class MapFragment extends android.support.v4.app.Fragment
         }
         View v = mRootView.findViewById(R.id.status_toolbar_layout);
 
-        final ClientStumblerService service = getApplication().getService();
+        final MainApp app = getApplication();
         float alpha = 0.5f;
-        if (service != null && !service.isStopped()) {
+        if (app != null && !app.isStopped()) {
             alpha = 1.0f;
         }
         v.setAlpha(alpha);
@@ -472,9 +475,6 @@ public class MapFragment extends android.support.v4.app.Fragment
 
     public void toggleScanning(MenuItem menuItem) {
         MainApp app = getApplication();
-        if (app.getService() == null) {
-            return;
-        }
 
         boolean isScanning = app.isScanningOrPaused();
         if (isScanning) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -4,8 +4,6 @@
 
 package org.mozilla.mozstumbler.client.navdrawer;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
@@ -17,14 +15,12 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarActivity;
-import android.text.Html;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.Switch;
-import android.widget.TextView;
 
 import org.mozilla.mozstumbler.BuildConfig;
 import org.mozilla.mozstumbler.R;
@@ -36,13 +32,17 @@ import org.mozilla.mozstumbler.client.Updater;
 import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.mozstumbler.client.subactivities.FirstRunFragment;
 import org.mozilla.mozstumbler.client.subactivities.LeaderboardActivity;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 public class MainDrawerActivity
         extends ActionBarActivity
         implements IMainActivity {
 
+    private ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
     private static final String LOG_TAG = LoggerUtil.makeLogTag(MainDrawerActivity.class);
+
     private static final int MENU_START_STOP = 1;
     private DrawerLayout mDrawerLayout;
     private ActionBarDrawerToggle mDrawerToggle;
@@ -156,11 +156,7 @@ public class MainDrawerActivity
             return;
         }
 
-        ClientStumblerService svc = app.getService();
-        if (svc == null) {
-            return;
-        }
-        if (!svc.isStopped()) {
+        if (!app.isStopped()) {
             keepScreenOn(ClientPrefs.getInstance(this).getKeepScreenOn());
         } else {
             keepScreenOn(false);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -218,7 +218,6 @@ public class MetricsView {
         }
 
         updatePowerSavingsLabels();
-
         updateQueuedStats();
         updateSentStats();
         updateThisSessionStats();
@@ -311,13 +310,17 @@ public class MetricsView {
         }
     };
 
-    public void setObservationCount(int observations, int cells, int wifis, boolean isActive) {
+    public void setObservationCount(int observations, int cells, int wifis) {
         sThisSessionObservationsCount = observations;
         sThisSessionUniqueCellCount = cells;
         sThisSessionUniqueWifiCount = wifis;
 
         NotificationUtil util = new NotificationUtil(mView.getContext().getApplicationContext());
-        util.updateMetrics(observations, cells, wifis, mLastUploadTime, isActive);
+        util.updateMetrics(sThisSessionObservationsCount,
+                sThisSessionUniqueCellCount,
+                sThisSessionUniqueWifiCount,
+                mLastUploadTime,
+                isScanningOrPaused());
     }
 
     public interface IMapLayerToggleListener {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/util/NotificationUtil.java
@@ -14,8 +14,14 @@ import org.mozilla.mozstumbler.client.MainApp;
 import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
+import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 public class NotificationUtil {
+
+    private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
+    private static final String LOG_TAG = LoggerUtil.makeLogTag(NotificationUtil.class);
+
     public static final int NOTIFICATION_ID = 1;
     private static final long UPDATE_FREQUENCY = 60 * 1000;
     private static String sStopTitle;
@@ -23,13 +29,17 @@ public class NotificationUtil {
     private static long sUploadTime, sDisplayTime, sLastUpdateTime;
     private static boolean sIsPaused;
     private final Context mContext;
+    private ISystemClock clock = (ISystemClock) ServiceLocator.getInstance().getService(ISystemClock.class);
 
     public NotificationUtil(Context context) {
         mContext = context;
     }
 
     private Notification build() {
-        PendingIntent turnOffIntent = PendingIntent.getBroadcast(mContext, 0, new Intent(MainApp.INTENT_TURN_OFF), 0);
+        PendingIntent notificationStopIntent = PendingIntent.getBroadcast(mContext,
+                                                        0,
+                                                        new Intent(MainApp.NOTIFICATION_STOP),
+                                                        0);
 
         Intent notificationIntent = new Intent(mContext, MainDrawerActivity.class);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_FROM_BACKGROUND);
@@ -69,7 +79,7 @@ public class NotificationUtil {
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setStyle(new NotificationCompat.BigTextStyle()
                         .bigText(metrics + "\n" + uploadLine))
-                .addAction(R.drawable.ic_action_cancel, sStopTitle, turnOffIntent)
+                .addAction(R.drawable.ic_action_cancel, sStopTitle, notificationStopIntent)
                 .build();
     }
 
@@ -82,7 +92,7 @@ public class NotificationUtil {
     public Notification buildNotification(String stopTitle) {
         sStopTitle = stopTitle;
         sIsPaused = false;
-        sDisplayTime = System.currentTimeMillis();
+        sDisplayTime = clock.currentTimeMillis();
         return build();
     }
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -53,7 +53,7 @@ public class StumblerService extends PersistentIntentService
         super(name);
     }
 
-    public synchronized boolean isStopped() {
+    private synchronized boolean isStopped() {
         return mScanManager.isStopped();
     }
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -41,6 +41,9 @@ public class StumblerService extends PersistentIntentService
     public static final String ACTION_EXTRA_MOZ_API_KEY = ACTION_BASE + ".MOZKEY";
     public static final String ACTION_EXTRA_USER_AGENT = ACTION_BASE + ".USER_AGENT";
     public static final String ACTION_NOT_FROM_HOST_APP = ACTION_BASE + ".NOT_FROM_HOST";
+    public static String HANDLE_LOW_MEMORY = "org.mozilla.mozstumbler.service.stumblerthread.low_mem";
+
+
     public static final AtomicBoolean sFirefoxStumblingEnabled = new AtomicBoolean();
     // This is a delay before the single-shot upload is attempted. The number is arbitrary
     // and used to avoid startup tasks bunching up.
@@ -76,7 +79,6 @@ public class StumblerService extends PersistentIntentService
             } else if (intent.getAction().equals(StumblerServiceIntentActions.SVC_REQ_UNIQUE_WIFI_COUNT)) {
                 broadcastCount(StumblerServiceIntentActions.SVC_RESP_UNIQUE_WIFI_COUNT, getUniqueAPCount());
             }
-
         };
     };
 
@@ -88,7 +90,6 @@ public class StumblerService extends PersistentIntentService
         intent.putExtra("count", visibleAPCount);
         LocalBroadcastManager.getInstance(this.getApplicationContext()).sendBroadcastSync(intent);
     }
-
 
     public StumblerService() {
         this("StumblerService");
@@ -104,10 +105,6 @@ public class StumblerService extends PersistentIntentService
 
     public synchronized void startScanning() {
         mScanManager.startScanning();
-    }
-
-    public synchronized Prefs getPrefs(Context c) {
-        return Prefs.getInstance(c);
     }
 
     public synchronized Location getLocation() {
@@ -293,7 +290,7 @@ public class StumblerService extends PersistentIntentService
         handleLowMemoryNotification();
     }
 
-    public void handleLowMemoryNotification() {
+    private void handleLowMemoryNotification() {
         DataStorageManager manager = DataStorageManager.getInstance();
         if (manager == null) {
             return;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.os.AsyncTask;
-import android.util.Log;
 
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
@@ -18,6 +17,8 @@ import org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager;
 import org.mozilla.mozstumbler.service.uploadthread.UploadAlarmReceiver;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.service.utils.PersistentIntentService;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.IOException;
@@ -28,13 +29,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 //
 public class StumblerService extends PersistentIntentService
         implements DataStorageManager.StorageIsEmptyTracker {
+
+    private static final String LOG_TAG = LoggerUtil.makeLogTag(StumblerService.class);
+    private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
+
     public static final String ACTION_BASE = AppGlobals.ACTION_NAMESPACE;
     public static final String ACTION_START_PASSIVE = ACTION_BASE + ".START_PASSIVE";
     public static final String ACTION_EXTRA_MOZ_API_KEY = ACTION_BASE + ".MOZKEY";
     public static final String ACTION_EXTRA_USER_AGENT = ACTION_BASE + ".USER_AGENT";
     public static final String ACTION_NOT_FROM_HOST_APP = ACTION_BASE + ".NOT_FROM_HOST";
     public static final AtomicBoolean sFirefoxStumblingEnabled = new AtomicBoolean();
-    private static final String LOG_TAG = LoggerUtil.makeLogTag(StumblerService.class);
     // This is a delay before the single-shot upload is attempted. The number is arbitrary
     // and used to avoid startup tasks bunching up.
     private static final int DELAY_IN_SEC_BEFORE_STARTING_UPLOAD_IN_PASSIVE_MODE = 2;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerServiceIntentActions.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerServiceIntentActions.java
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread;
+
+public class StumblerServiceIntentActions {
+    public static final String SVC_RESP_NS = "org.mozilla.mozstumbler.service.intentaction.response";
+    public static final String SVC_RESP_UNIQUE_WIFI_COUNT = SVC_RESP_NS + ".uniq.wifi";
+    public static final String SVC_RESP_UNIQUE_CELL_COUNT = SVC_RESP_NS + ".uniq.cell";
+    public static final String SVC_RESP_OBSERVATION_PT = SVC_RESP_NS + ".obs_pts";
+    public static final String SVC_RESP_VISIBLE_CELL = SVC_RESP_NS + ".cell_towers";
+    public static final String SVC_RESP_VISIBLE_AP = SVC_RESP_NS + ".wifi_access_points";
+
+    public static final String SVC_REQ_NS = "org.mozilla.mozstumbler.service.intentaction.request";
+    public static final String SVC_REQ_UNIQUE_WIFI_COUNT = SVC_REQ_NS + ".uniq.wifi";
+    public static final String SVC_REQ_UNIQUE_CELL_COUNT = SVC_REQ_NS + ".uniq.cell";
+    public static final String SVC_REQ_OBSERVATION_PT = SVC_REQ_NS + ".obs_pts";
+    public static final String SVC_REQ_VISIBLE_CELL = SVC_REQ_NS + ".cell_towers";
+    public static final String SVC_REQ_VISIBLE_AP = SVC_REQ_NS + ".wifi_access_points";
+}

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -32,9 +32,29 @@ public class ScanManager {
     public static final String ACTION_SCAN_PAUSED_USER_MOTIONLESS = AppGlobals.ACTION_NAMESPACE + ".NOTIFY_USER_MOTIONLESS";
     public static final String ACTION_SCAN_UNPAUSED_USER_MOVED = AppGlobals.ACTION_NAMESPACE + ".NOTIFY_USER_MOVED";
 
-    public static final String SCANSTATE_STARTED = AppGlobals.ACTION_NAMESPACE + ".SCANSTATE_STARTED";
-    public static final String SCANSTATE_STOPPED = AppGlobals.ACTION_NAMESPACE + ".SCANSTATE_STOPPED";
-    public static final String SCANSTATE_STARTED_BUT_PAUSED_MOTIONLESS = AppGlobals.ACTION_NAMESPACE + ".SCANSTATE_STARTED_BUT_PAUSED_MOTIONLESS";
+    public static enum ScannerState {
+        STOPPED, STARTED, STARTED_BUT_PAUSED_MOTIONLESS;
+
+        public static final String NAMESPACE = "org.mozilla.mozstumbler.scanner.state";
+
+        @Override
+        public String toString() {
+            return NAMESPACE+ this.name();
+        }
+
+        public static ScannerState fromString(String name)  {
+            try {
+                return ScannerState.valueOf(name.substring(ScannerState.NAMESPACE.length()));
+            } catch (IllegalArgumentException iae) {
+                return null;
+            }
+        }
+    }
+
+    // Convenience strings so that we don't have to keep invoking tostring()
+    private static final String SCANSTATE_STARTED = ScannerState.STARTED.toString();
+    private static final String SCANSTATE_STOPPED = ScannerState.STOPPED.toString();
+    private static final String SCANSTATE_STARTED_BUT_PAUSED_MOTIONLESS = ScannerState.STARTED_BUT_PAUSED_MOTIONLESS.toString();
 
 
     private ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
@@ -72,9 +92,7 @@ public class ScanManager {
     private LocationChangeSensor mLocationChangeSensor;
     private MotionSensor mMotionSensor;
 
-    public static enum ScannerState {
-        STOPPED, STARTED, STARTED_BUT_PAUSED_MOTIONLESS
-    }
+
 
     private ScannerState mScannerState = ScannerState.STOPPED;
 
@@ -118,16 +136,7 @@ public class ScanManager {
     private void broadcastScanState(ScannerState scanState) {
         mScannerState = scanState;
 
-        String action = "";
-        if (scanState == ScannerState.STOPPED) {
-            action = SCANSTATE_STOPPED;
-        } else if (scanState == ScannerState.STARTED_BUT_PAUSED_MOTIONLESS) {
-            action = SCANSTATE_STARTED_BUT_PAUSED_MOTIONLESS;
-        } else if (scanState == ScannerState.STARTED) {
-            action = SCANSTATE_STARTED;
-        } else {
-            throw new RuntimeException("Unrecognized scan state: " + scanState);
-        }
+        String action = scanState.toString();
         Log.i(LOG_TAG, "Broadcasting scan state == " + action);
         LocalBroadcastManager.getInstance(mAppContext).sendBroadcast(new Intent(action));
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/DebugLogger.java
@@ -11,6 +11,11 @@ public class DebugLogger implements ILogger {
         android.util.Log.w(logTag, s);
     }
 
+    @Override
+    public void e(String logTag, String s) {
+        android.util.Log.e(logTag, s);
+    }
+
     public String e(String logTag, String s, Throwable e) {
         if (e instanceof OutOfMemoryError) {
             // These are usually going to be OutOfMemoryErrors

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/ILogger.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/ILogger.java
@@ -7,6 +7,8 @@ package org.mozilla.mozstumbler.svclocator.services.log;
 public interface ILogger {
     public abstract void w(String logTag, String s);
 
+    public abstract void e(String logTag, String s);
+
     public abstract String e(String logTag, String s, Throwable e);
 
     public abstract void i(String logTag, String s);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/ProductionLogger.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/ProductionLogger.java
@@ -4,11 +4,16 @@
 
 package org.mozilla.mozstumbler.svclocator.services.log;
 
+@SuppressWarnings("unused")
 public class ProductionLogger implements ILogger {
 
     public void w(String logTag, String s) {
-
         android.util.Log.w(logTag, s);
+    }
+
+    @Override
+    public void e(String logTag, String s) {
+        android.util.Log.e(logTag, s);
     }
 
     public String e(String logTag, String s, Throwable e) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/UnittestLogger.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/log/UnittestLogger.java
@@ -40,6 +40,13 @@ public class UnittestLogger implements ILogger {
         messageBuffer.addLast(msg);
     }
 
+
+    @Override
+    public void e(String logTag, String s) {
+        String msg = "E: " + logTag + ", " + s;
+        System.out.println(msg);
+    }
+
     public String e(String logTag, String s, Throwable e) {
         if (e instanceof OutOfMemoryError) {
             // These are usually going to be OutOfMemoryErrors


### PR DESCRIPTION
This is a WIP cherry picking from lines and reworking them from : https://github.com/crankycoder/MozStumbler/tree/features/1479-remove-bindservice

This unbinds dependencies to the ClientStumblerService pointer that is exposed with `bindService` from the client and spins the stumbler service off into a completely separate thread.

Please see each commit message for details.
