### PR TITLE
Remove conditional location of stumbler files

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -89,6 +89,10 @@ public class DataStorageManager {
 
     public static String getStorageDir(Context c) {
         File dir = null;
+
+        // Uncomment the following block if you're debugging
+        // persistent log storage on a non-rooted device
+        /*
         if (AppGlobals.isDebug) {
             // in debug, put files in public location
             dir = c.getExternalFilesDir(null);
@@ -96,6 +100,7 @@ public class DataStorageManager {
                 dir = new File(dir.getAbsolutePath() + File.separator + MOZ_STUMBLER_RELPATH);
             }
         }
+        */
 
         if (dir == null) {
             dir = c.getFilesDir();


### PR DESCRIPTION
I've removed a block of code which put the stumbler reports into a special directory for debug builds.

This was just confusing when diagnosing a problem with the DemoStumbler.  In a nutshell - AppGlobals.isDebug is not final and it had a value which I wasn't expecting, so files were not being written or read from an expected directory.

I don't think there's really any benefit to multiple directories anyway. If we really want to have an alternate directory, I would opt for an explicit path that is set into the DataStorageManager.
