### PR TITLE
Properly configure map location and GPS listeners on start/stop

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/IMainActivity.java
@@ -18,6 +18,9 @@ public interface IMainActivity {
     public void isPausedDueToNoMotion(boolean isPaused);
 
     // Call from main thread only
+    public void start();
+
+    // Call from main thread only
     public void stop();
 }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -307,6 +307,7 @@ public class MainApp extends Application
 
         if (mMainActivity.get() != null) {
             mMainActivity.get().updateUiOnMainThread(false);
+            mMainActivity.get().start();
         }
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -683,11 +683,16 @@ public class MapFragment extends android.support.v4.app.Fragment
         dimToolbar();
     }
 
+    public void start() {
+        if (mMapLocationListener != null) {
+            mMapLocationListener.setActiveLocationUpdatesEnabled(true);
+        }
+    }
+
     public void stop() {
         mRootView.findViewById(R.id.scanning_paused_message).setVisibility(View.INVISIBLE);
         if (mMapLocationListener != null) {
-            mMapLocationListener.removeListener();
-            mMapLocationListener = null;
+            mMapLocationListener.setActiveLocationUpdatesEnabled(false);
         }
         updateGPSInfo(0, 0);
         dimToolbar();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapLocationListener.java
@@ -88,8 +88,7 @@ class MapLocationListener {
         if (app.isIsScanningPausedDueToNoMotion()) {
             pauseGpsUpdates(true);
         } else {
-            enableLocationListener(true, mNetworkLocationListener);
-            enableLocationListener(true, mGpsLocationListener);
+            setActiveLocationUpdatesEnabled(true);
         }
     }
 
@@ -117,8 +116,19 @@ class MapLocationListener {
         }
 
         mLocationManager.removeGpsStatusListener(mSatelliteListener);
-        enableLocationListener(false, mGpsLocationListener);
-        enableLocationListener(false, mNetworkLocationListener);
+        setActiveLocationUpdatesEnabled(false);
+    }
+
+    public void setActiveLocationUpdatesEnabled(boolean enable) {
+        if (enable) {
+            // enable NetworkLocationListener first because GpsLocationListener will disable it
+            enableLocationListener(true, mNetworkLocationListener);
+            enableLocationListener(true, mGpsLocationListener);
+        } else {
+            // disable GpsLocationListener first because it might enable NetworkLocationListener
+            enableLocationListener(false, mGpsLocationListener);
+            enableLocationListener(false, mNetworkLocationListener);
+        }
     }
 
     public void pauseGpsUpdates(boolean isGpsOff) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -373,6 +373,11 @@ public class MainDrawerActivity
     }
 
     @Override
+    public void start() {
+        mMapFragment.start();
+    }
+
+    @Override
     public void stop() {
         mMapFragment.stop();
     }


### PR DESCRIPTION
This fixes the bug that the GPS status listener is removed on stop, and that map location listeners are not re-enabled on start.
