### PR TITLE
1428 - push library to BinTray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gen
 build
 local.properties
 gradle.properties
+bintray.properties
 
 # ignore vim swap files
 *.sw?

--- a/libraries/stumbler/Makefile
+++ b/libraries/stumbler/Makefile
@@ -3,3 +3,6 @@ all:
 
 test:
 	./gradlew test
+
+upload:
+	./gradlew bintrayUpload

--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -25,7 +25,11 @@ allprojects {
 }
 
 version = "0.9.0"
-group = "Mozilla"
+group = 'com.crankycoder'
+
+// The groupname will be changed into a path for the final library
+// http://dl.bintray.com/crankycoder/libMozStumbler/com/crankycoder/stumbler/0.9.0/
+
 def siteUrl = 'https://github.com/mozilla/MozStumbler'
 def gitUrl = 'https://github.com/mozilla/MozStumbler.git'
 

--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -1,17 +1,33 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
         classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
+
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }
 
 apply plugin: 'android-sdk-manager'
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+version = "0.9.0"
+group = "Mozilla"
+def siteUrl = 'https://github.com/mozilla/MozStumbler'
+def gitUrl = 'https://github.com/mozilla/MozStumbler.git'
 
 android {
     compileSdkVersion 19
@@ -32,11 +48,63 @@ android {
     }
 }
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('bintray.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+    configurations = ['archives']
+    pkg {
+        repo = "libMozStumbler"
+        name = "libMozStumbler"
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = ["MPL-2.0"]
+        publish = true
+    }
+}
+
+
 apply plugin: 'android-unit-test'
 
 androidUnitTest {
 }
 
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging 'aar'
+                name 'A simple library to embed Mozilla Stumbler.'
+                url siteUrl
+                licenses {
+                    license {
+                        name 'Mozilla Public License, Version 2.0'
+                        url 'https://www.mozilla.org/MPL/2.0/'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'garvankeeley'
+                        name 'Garvan Keeley'
+                        email 'garvank@victor@crankycoder.com'
+                    }
+                    developer {
+                        id 'crankycoder'
+                        name 'Victor Ng'
+                        email 'victor@crankycoder.com'
+                    }
+                }
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+                }
+            }
+        }
+    }
+}
 
 dependencies {
     androidTestCompile 'junit:junit:4.10'
@@ -66,4 +134,28 @@ dependencies {
         exclude group: 'org.json'
     }
 
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+task findConventions << {
+    println project.getConvention()
 }

--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -53,11 +53,18 @@ android {
 }
 
 Properties properties = new Properties()
-properties.load(project.rootProject.file('bintray.properties').newDataInputStream())
+File bintrayFile = project.rootProject.file('bintray.properties')
+if (bintrayFile.exists()) {
+    properties.load(bintrayFile.newDataInputStream())
+} else {
+    properties = null
+}
 
 bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
+    if (properties != null) {
+        user = properties.getProperty("bintray.user")
+        key = properties.getProperty("bintray.apikey")
+    }
     configurations = ['archives']
     pkg {
         repo = "libMozStumbler"
@@ -92,7 +99,7 @@ install {
                     developer {
                         id 'garvankeeley'
                         name 'Garvan Keeley'
-                        email 'garvank@victor@crankycoder.com'
+                        email 'garvankeeley@gmail.com'
                     }
                     developer {
                         id 'crankycoder'


### PR DESCRIPTION
This patch adds some directives so that we can upload into BinTray/JCenter - an alternate Maven repository.

Some notes:
- Upgrade from the old "android-library" gradle plugin to the more modern "com.android.library" gradle plugin
- The group namespace is using "com.crankycoder" as our library has not been formally accepted into JCenter yet.  As such, users of the library need to provide a explicit Maven repo link in their build.  

The groupname will be switched to 'Mozilla' once our package is properly accepted into JCenter's main repository.
