### PR TITLE
tagging the library with the same version as the containing client

### DIFF
--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -24,8 +24,8 @@ allprojects {
     }
 }
 
-version = "0.9.0"
-group = 'com.crankycoder'
+version = "1.7.10"
+group = 'org.mozilla.mozstumbler'
 
 // The groupname will be changed into a path for the final library
 // http://dl.bintray.com/crankycoder/libMozStumbler/com/crankycoder/stumbler/0.9.0/


### PR DESCRIPTION
also renamed from com.crankycoder to org.mozilla.mozstumbler for the maven group
