### PR TITLE
Got a non-reproducible NPE in a caller of getTileData(), this guards against it

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTile.java
+++ b/android/src/main/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTile.java
@@ -64,7 +64,7 @@ public class SerializableTile {
     }
 
     public byte[] getTileData() {
-        return tData;
+        return (tData == null)? new byte[0] : tData;
     }
 
     public void setTileData(byte[] tileData) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HTTPResponse.java
@@ -28,11 +28,6 @@ public class HTTPResponse implements IResponse {
         bodyBytes = contentBody;
         bytesSent = txByteLength;
         headers = headerFields;
-        if (AppGlobals.isDebug) {
-            ClientLog.d(LOG_TAG, "HTTP Status: " + Integer.toString(statusCode) +
-                    ", Bytes Sent: " + Integer.toString(bytesSent) +
-                    ", Bytes received: " + Integer.toString(bodyBytes.length));
-        }
     }
 
     public boolean isErrorCode400BadRequest() {


### PR DESCRIPTION
The callers of getTileData() check its length() for validity, so always return a non-null.
