### PR TITLE
Features/1609 eofexception

### DIFF
--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import android.location.Location;
 import android.net.wifi.ScanResult;
+import android.provider.ContactsContract;
 import android.telephony.TelephonyManager;
 
 import org.json.JSONException;
@@ -11,6 +12,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
 import org.robolectric.Robolectric;
@@ -41,11 +43,16 @@ public class DataStorageManagerTest {
     public void setUp() {
         ctx = getApplicationContext();
 
+        // Disable stumble logs
+        Prefs.getInstance(ctx).setSaveStumbleLogs(false);
         StorageTracker tracker = new StorageTracker();
 
         long maxBytes = 20000;
         int maxWeeks = 10;
 
+        // We need to explicitly clear the global instance or else we can't guarantee that the
+        // directory will be properly created
+        ClientDataStorageManager.sInstance = null;
         dm = ClientDataStorageManager.createGlobalInstance(ctx, tracker, maxBytes, maxWeeks);
         // Force the current reports to clear out between test runs.
         dm.mCurrentReports.clearReports();
@@ -62,6 +69,7 @@ public class DataStorageManagerTest {
         StumblerBundle bundle;
 
         assertEquals(0, dm.mCurrentReports.reportsCount());
+
         for (int locCount = 0; locCount < ReportBatchBuilder.MAX_REPORTS_IN_MEMORY - 1; locCount++) {
             Location loc = new Location("mock");
             loc.setLatitude(42 + (locCount * 0.1));
@@ -84,18 +92,14 @@ public class DataStorageManagerTest {
             JSONObject mlsObj = bundle.toMLSGeosubmit();
             int wifiCount = mlsObj.getJSONArray(DataStorageContract.ReportsColumns.WIFI).length();
             int cellCount = mlsObj.getJSONArray(DataStorageContract.ReportsColumns.CELL).length();
-            try {
-                dm.insert(mlsObj.toString(), wifiCount, cellCount);
-            } catch (IOException ioEx) {
-            }
+            dm.insert(mlsObj.toString(), wifiCount, cellCount);
+
+            assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY,
+                    dm.mCurrentReports.reportsCount());
         }
 
-        assertEquals(ReportBatchBuilder.MAX_REPORTS_IN_MEMORY - 1,
-                dm.mCurrentReports.reportsCount());
-
-
-        for (int locCount = ReportBatchBuilder.MAX_REPORTS_IN_MEMORY;
-             locCount < ReportBatchBuilder.MAX_REPORTS_IN_MEMORY + 100;
+        for (int locCount = ReportBatchBuilder.MAX_REPORTS_IN_MEMORY -1;
+             locCount < (ReportBatchBuilder.MAX_REPORTS_IN_MEMORY*2-1);
              locCount++) {
             Location loc = new Location("mock");
             loc.setLatitude(42 + (locCount * 0.1));
@@ -118,15 +122,14 @@ public class DataStorageManagerTest {
             JSONObject mlsObj = bundle.toMLSGeosubmit();
             int wifiCount = mlsObj.getJSONArray(DataStorageContract.ReportsColumns.WIFI).length();
             int cellCount = mlsObj.getJSONArray(DataStorageContract.ReportsColumns.CELL).length();
-            try {
-                dm.insert(mlsObj.toString(), wifiCount, cellCount);
-            } catch (FileNotFoundException fex) {
-                // This is ok
-            } catch (IOException ioEx) {
-            }
 
-            assertTrue(dm.mCurrentReports.reportsCount() == ReportBatchBuilder.MAX_REPORTS_IN_MEMORY);
+            dm.insert(mlsObj.toString(), wifiCount, cellCount);
+
+            assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY  ,
+                    dm.mCurrentReports.reportsCount());
+
         }
+
     }
 
     public class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -185,20 +185,16 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
         AppGlobals.guiLogInfo("MLS record: " + mlsObj.toString());
 
-        try {
-            DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);
+        DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);
 
-            mObservationCount++;
-            mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());
-            mUniqueCells.addAll(mBundle.getUnmodifiableCellData().keySet());
+        mObservationCount++;
+        mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());
+        mUniqueCells.addAll(mBundle.getUnmodifiableCellData().keySet());
 
-            Intent i = new Intent(ACTION_NEW_BUNDLE);
-            i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
-            i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
-            LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
-        } catch (IOException e) {
-            ClientLog.w(LOG_TAG, e.toString());
-        }
+        Intent i = new Intent(ACTION_NEW_BUNDLE);
+        i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);
+        i.putExtra(AppGlobals.ACTION_ARG_TIME, System.currentTimeMillis());
+        LocalBroadcastManager.getInstance(mContext).sendBroadcastSync(i);
 
         mBundle = null;
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -197,12 +197,7 @@ public class StumblerService extends PersistentIntentService
                 }
 
                 if (DataStorageManager.getInstance() != null) {
-                    try {
-                        DataStorageManager.getInstance().saveCurrentReportsToDisk();
-                    } catch (IOException ex) {
-                        AppGlobals.guiLogInfo(ex.toString());
-                        Log.e(LOG_TAG, "Exception in onDestroy saving reports" + ex.toString());
-                    }
+                    DataStorageManager.getInstance().saveCurrentReportsToDisk();
                 }
                 return null;
             }
@@ -302,10 +297,6 @@ public class StumblerService extends PersistentIntentService
         if (manager == null) {
             return;
         }
-        try {
-            manager.saveCurrentReportsToDisk();
-        } catch (IOException ioException) {
-            Log.e(LOG_TAG, ioException.toString());
-        }
+        manager.saveCurrentReportsToDisk();
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -10,10 +10,12 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.utils.Zipper;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -41,8 +43,12 @@ import java.util.TimerTask;
  * when the service is destroyed.
  */
 public class DataStorageManager {
-    ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
+    private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
     private static final String LOG_TAG = LoggerUtil.makeLogTag(DataStorageManager.class);
+
+    private static final ISystemClock clock = (ISystemClock) ServiceLocator
+                                                                .getInstance()
+                                                                .getService(ISystemClock.class);
 
     public static final String MOZ_STUMBLER_RELPATH = "mozstumbler";
     static final String SEP_REPORT_COUNT = "-r";
@@ -81,6 +87,7 @@ public class DataStorageManager {
         if (!mReportsDir.exists()) {
             mReportsDir.mkdirs();
         }
+
         mFileList = new ReportFileList();
         mFileList.update(mReportsDir);
 
@@ -109,7 +116,8 @@ public class DataStorageManager {
         if (!dir.exists()) {
             boolean ok = dir.mkdirs();
             if (!ok) {
-                ClientLog.d(LOG_TAG, "getStorageDir: error in mkdirs()");
+                ClientLog.w(LOG_TAG, "getStorageDir: error in mkdirs()");
+                Log.e(LOG_TAG, "Error creating storage directory: ["+dir.getAbsolutePath()+"]");
             }
         }
 
@@ -139,14 +147,24 @@ public class DataStorageManager {
         return sInstance;
     }
 
-    private static byte[] readFile(File file) throws IOException {
-        final RandomAccessFile f = new RandomAccessFile(file, "r");
+    private static byte[] readFile(File file) {
+        RandomAccessFile f = null;
         try {
+            f = new RandomAccessFile(file, "r");
             final byte[] data = new byte[(int) f.length()];
             f.readFully(data);
             return data;
+        } catch (IOException e) {
+            Log.e(LOG_TAG, "Error reading reports file: " + e.toString());
+            return new byte[]{};
         } finally {
-            f.close();
+            if (f != null) {
+                try {
+                    f.close();
+                } catch (IOException e) {
+                    // eat it
+                }
+            }
         }
     }
 
@@ -206,7 +224,7 @@ public class DataStorageManager {
 
     /* return name of file used, or memory buffer sentinel value.
      * The return value is used to delete the file/buffer later. */
-    public synchronized ReportBatch getFirstBatch() throws IOException {
+    public synchronized ReportBatch getFirstBatch() {
         final boolean dirEmpty = isDirEmpty();
         final int currentReportsCount = mCurrentReports.reportsCount();
 
@@ -242,7 +260,7 @@ public class DataStorageManager {
         mCurrentReports.wifiCount = mCurrentReports.cellCount = 0;
     }
 
-    public synchronized ReportBatch getNextBatch() throws IOException {
+    public synchronized ReportBatch getNextBatch() {
         if (mReportBatchIterator == null) {
             return null;
         }
@@ -263,7 +281,7 @@ public class DataStorageManager {
     }
 
     private File createFile(int reportCount, int wifiCount, int cellCount) {
-        final long time = System.currentTimeMillis();
+        final long time = clock.currentTimeMillis();
         final String name = FILENAME_PREFIX +
                 SEP_TIME_MS + time +
                 SEP_REPORT_COUNT + reportCount +
@@ -287,34 +305,63 @@ public class DataStorageManager {
         return oldest;
     }
 
-    public synchronized void saveCurrentReportsSendBufferToDisk() throws IOException {
+    /*
+     Return true if the current reports (if any exist) are properly saved.
+     Return false only on a failed write to storage.
+     */
+    private synchronized boolean saveCurrentReportsSendBufferToDisk() {
         if (mCurrentReportsSendBuffer == null || mCurrentReportsSendBuffer.reportCount < 1) {
-            return;
+            return true;
         }
 
-        saveToDisk(mCurrentReportsSendBuffer.data,
+        boolean result = saveToDisk(mCurrentReportsSendBuffer.data,
                 mCurrentReportsSendBuffer.reportCount,
                 mCurrentReportsSendBuffer.wifiCount,
                 mCurrentReportsSendBuffer.cellCount);
         mCurrentReportsSendBuffer = null;
+        return result;
     }
 
-    private void saveToDisk(byte[] bytes, int reportCount, int wifiCount, int cellCount)
-            throws IOException {
+    /*
+     Return true if reports are saved.
+     Return false only on a failed write to storage.
+     */
+    private boolean saveToDisk(byte[] bytes, int reportCount, int wifiCount, int cellCount) {
         if (mFileList.mFilesOnDiskBytes > mMaxBytesDiskStorage) {
-            return;
+            return false;
         }
 
-        final FileOutputStream fos = new FileOutputStream(createFile(reportCount, wifiCount, cellCount));
+        FileOutputStream fos = null;
+        File f = createFile(reportCount, wifiCount, cellCount);
         try {
+            Log.i(LOG_TAG, "Preparing to write to : ["+f.getAbsolutePath()+"]");
+            if (!f.exists()) {
+                f.createNewFile();
+            }
+            fos = new FileOutputStream(f);
             fos.write(bytes);
+        } catch (IOException e) {
+           Log.e(LOG_TAG, "Error writing reports to disk: " + e.toString());
+
+           // Try to remove the file safely if we can't save it.
+           if (f.exists()) {
+               f.delete();
+           }
+           return false;
         } finally {
-            fos.close();
+            if (fos != null) {
+                try {
+                    fos.close();
+                } catch (IOException e) {
+                    // eat it - nothing we can do here
+                }
+            }
         }
         mFileList.update(mReportsDir);
+        return true;
     }
 
-    public synchronized void saveCurrentReportsToDisk() throws IOException {
+    public synchronized void saveCurrentReportsToDisk() {
         saveCurrentReportsSendBufferToDisk();
         if (mCurrentReports.reportsCount() < 1) {
             return;
@@ -330,7 +377,7 @@ public class DataStorageManager {
         clearCurrentReports();
     }
 
-    public synchronized void insert(String report, int wifiCount, int cellCount) throws IOException {
+    public synchronized void insert(String report, int wifiCount, int cellCount) {
         notifyStorageIsEmpty(false);
 
         if (mFlushMemoryBuffersToDiskTimer != null) {
@@ -339,6 +386,7 @@ public class DataStorageManager {
         }
 
         mCurrentReports.addReport(report);
+
         mCurrentReports.wifiCount += wifiCount;
         mCurrentReports.cellCount += cellCount;
 
@@ -353,11 +401,7 @@ public class DataStorageManager {
             mFlushMemoryBuffersToDiskTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    try {
-                        saveCurrentReportsToDisk();
-                    } catch (IOException ex) {
-                        ClientLog.e(LOG_TAG, "mFlushMemoryBuffersToDiskTimer exception", ex);
-                    }
+                    saveCurrentReportsSendBufferToDisk();
                 }
             }, kMillis);
         }
@@ -400,7 +444,7 @@ public class DataStorageManager {
         }
     }
 
-    public synchronized void incrementSyncStats(long bytesSent, long reports, long cells, long wifis) throws IOException {
+    public synchronized void incrementSyncStats(long bytesSent, long reports, long cells, long wifis) {
         mPersistedOnDiskUploadStats.incrementSyncStats(bytesSent, reports, cells, wifis);
 
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -6,6 +6,7 @@ package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
 import android.content.Context;
 
+import org.acra.ACRA;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.utils.Zipper;
@@ -15,7 +16,6 @@ import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -50,7 +50,6 @@ public class DataStorageManager {
                                                                 .getInstance()
                                                                 .getService(ISystemClock.class);
 
-    public static final String MOZ_STUMBLER_RELPATH = "mozstumbler";
     static final String SEP_REPORT_COUNT = "-r";
     static final String SEP_WIFI_COUNT = "-w";
     static final String SEP_CELL_COUNT = "-c";
@@ -156,6 +155,7 @@ public class DataStorageManager {
             return data;
         } catch (IOException e) {
             Log.e(LOG_TAG, "Error reading reports file: " + e.toString());
+            ACRA.getErrorReporter().handleSilentException(e);
             return new byte[]{};
         } finally {
             if (f != null) {
@@ -342,7 +342,7 @@ public class DataStorageManager {
             fos.write(bytes);
         } catch (IOException e) {
            Log.e(LOG_TAG, "Error writing reports to disk: " + e.toString());
-
+           ACRA.getErrorReporter().handleSilentException(e);
            // Try to remove the file safely if we can't save it.
            if (f.exists()) {
                f.delete();

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
@@ -12,17 +12,24 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.utils.TelemetryWrapper;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
+import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 public class PersistedStats {
+
     private final File mStatsFile;
     private final Context mContext;
+
+    private static final ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
+    private static final String LOG_TAG = LoggerUtil.makeLogTag(PersistedStats.class);
 
     public static final String ACTION_PERSISTENT_SYNC_STATUS_UPDATED = AppGlobals.ACTION_NAMESPACE + ".PERSISTENT_SYNC_STATUS_UPDATED";
     public static final String EXTRAS_PERSISTENT_SYNC_STATUS_UPDATED = ACTION_PERSISTENT_SYNC_STATUS_UPDATED + ".EXTRA";
@@ -35,27 +42,39 @@ public class PersistedStats {
     }
 
     void forceBroadcastOfSyncStats() {
-        try {
-            sendToListeners(readSyncStats());
-        } catch (IOException ex) {}
+        sendToListeners(readSyncStats());
     }
 
-    public synchronized Properties readSyncStats() throws IOException {
+    public synchronized Properties readSyncStats() {
+        Properties props = new Properties();
+
         if (!mStatsFile.exists()) {
             return createStatsProp(0, 0, 0, 0, 0, 0);
         }
 
-        final FileInputStream input = new FileInputStream(mStatsFile);
+        FileInputStream input = null;
         try {
-            final Properties props = new Properties();
+            input = new FileInputStream(mStatsFile);
             props.load(input);
-            return props;
+        } catch (IOException e) {
+            Log.e(LOG_TAG, "Error reading sync stats: " + e.toString());
         } finally {
-            input.close();
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    // eat it - nothing we can do anyway.
+                }
+            }
         }
+        return props;
+
     }
 
-    public synchronized void incrementSyncStats(long bytesSent, long reports, long cells, long wifis) throws IOException {
+    public synchronized void incrementSyncStats(long bytesSent,
+                                                long reports,
+                                                long cells,
+                                                long wifis) {
         if (reports + cells + wifis < 1) {
             return;
         }
@@ -111,14 +130,31 @@ public class PersistedStats {
     }
 
     private synchronized Properties writeSyncStats(long time, long bytesSent, long totalObs,
-                                            long totalCells, long totalWifis, long obsPerDay) throws IOException {
-        final FileOutputStream out = new FileOutputStream(mStatsFile);
+                                            long totalCells, long totalWifis, long obsPerDay) {
+        final FileOutputStream out;
         final Properties props = createStatsProp(time, bytesSent, totalObs, totalCells, totalWifis, obsPerDay);
+
+
+        try {
+            out = new FileOutputStream(mStatsFile);
+        } catch (FileNotFoundException e) {
+            Log.w(LOG_TAG, "Error opening sync stats for write: " + e.toString());
+            return props;
+        }
 
         try {
             props.store(out, null);
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "Error writing sync stats: " + e.toString());
+            return props;
         } finally {
-            out.close();
+            try {
+                if (out != null) {
+                    out.close();
+                }
+            } catch (IOException e) {
+                // eat it - nothing we can do
+            }
         }
         return props;
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/PersistedStats.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
 
+import org.acra.ACRA;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.utils.TelemetryWrapper;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
@@ -146,6 +147,7 @@ public class PersistedStats {
             props.store(out, null);
         } catch (IOException e) {
             Log.w(LOG_TAG, "Error writing sync stats: " + e.toString());
+            ACRA.getErrorReporter().handleSilentException(e);
             return props;
         } finally {
             try {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -5,18 +5,24 @@
  package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
 import org.mozilla.mozstumbler.service.Prefs;
+import org.mozilla.mozstumbler.svclocator.ServiceLocator;
+import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 
 public class ReportBatchBuilder {
+
+    private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
+    private static String LOG_TAG = LoggerUtil.makeLogTag(ReportBatchBuilder.class);
+
     // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
     // Once this size is reached, data is persisted to disk, mCurrentReports is cleared.
     public static final int MAX_REPORTS_IN_MEMORY = 50;
-    private static final String LOG_TAG = LoggerUtil.makeLogTag(ReportBatchBuilder.class);
     public int wifiCount;
     public int cellCount;
     StringBuilder reportString;
     int reportCount;
+
     public int reportsCount() {
         return reportCount;
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -19,7 +19,6 @@ import org.mozilla.mozstumbler.service.utils.Zipper;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,18 +69,14 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
         }
 
         if (sAsyncListener != null) {
-             wrapper = new AsyncProgressListenerStatusWrapper(sAsyncListener, true);
+            wrapper = new AsyncProgressListenerStatusWrapper(sAsyncListener, true);
             sAsyncListener.onUploadProgress(true);
             publishProgress(wrapper);
         }
 
 
         if (Prefs.getInstanceWithoutContext().isSaveStumbleLogs()) {
-            try {
-                DataStorageManager.getInstance().saveCurrentReportsSendBufferToDisk();
-            } catch (IOException e) {
-                AppGlobals.guiLogError("Error flushing in-memory reports to sdcard");
-            }
+            DataStorageManager.getInstance().saveCurrentReportsToDisk();
         }
         uploadReports(param);
 
@@ -124,78 +119,65 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
         }
 
         DataStorageManager dm = DataStorageManager.getInstance();
+        DataStorageManager.ReportBatch batch = dm.getFirstBatch();
+        HashMap<String, String> headers = new HashMap<String, String>();
+        headers.put(MLS.EMAIL_HEADER, param.emailAddress);
+        headers.put(MLS.NICKNAME_HEADER, param.nickname);
 
-        String error = null;
+        Prefs prefs = Prefs.getInstanceWithoutContext();
+        while (batch != null) {
+            IResponse result;
+            if (prefs != null && prefs.isSimulateStumble()) {
 
-        try {
-            DataStorageManager.ReportBatch batch = dm.getFirstBatch();
-            HashMap<String, String> headers = new HashMap<String, String>();
-            headers.put(MLS.EMAIL_HEADER, param.emailAddress);
-            headers.put(MLS.NICKNAME_HEADER, param.nickname);
-
-            Prefs prefs = Prefs.getInstanceWithoutContext();
-            while (batch != null) {
-                IResponse result;
-                if (prefs != null && prefs.isSimulateStumble()) {
-
-                    result = new HTTPResponse(200,
-                            new HashMap<String, List<String>>(),
-                            new byte[]{},
-                            batch.data.length);
-                    Log.i(LOG_TAG, "Simulation skipped upload.");
-                } else {
-                    result = mls.submit(batch.data, headers, true);
-                }
-
-                if (result != null && result.isSuccessCode2XX()) {
-                    totalBytesSent += result.bytesSent();
-
-                    String logMsg = "MLS geosubmit: [HTTP Status:" + result.httpStatusCode() + "], [Bytes Sent:" + result.bytesSent() + "]";
-                    AppGlobals.guiLogInfo(logMsg, "#FFFFCC", true, false);
-                    Log.d(LOG_TAG, logMsg);
-
-                    dm.delete(batch.filename);
-
-                    uploadedObservations += batch.reportCount;
-                    uploadedWifis += batch.wifiCount;
-                    uploadedCells += batch.cellCount;
-                } else {
-                    String logMsg = "HTTP error unknown";
-                    if (result != null) {
-                        logMsg = "HTTP non-success code: " + result.httpStatusCode();
-                    }
-
-                    if (result != null && result.isErrorCode400BadRequest()) {
-                        logMsg += ", 400 Error, deleting bad report";
-                        if (AppGlobals.guiLogMessageBuffer != null) { // if true, this is a GUI app
-                            String unzipped = Zipper.unzipData(batch.data);
-                            AppGlobals.guiLogInfo(unzipped, "red", false, true);
-                        }
-                        dm.delete(batch.filename);
-                    } else {
-                        dm.saveCurrentReportsSendBufferToDisk();
-                    }
-                    AppGlobals.guiLogError(logMsg);
-                }
-
-                batch = dm.getNextBatch();
+                result = new HTTPResponse(200,
+                        new HashMap<String, List<String>>(),
+                        new byte[]{},
+                        batch.data.length);
+                Log.i(LOG_TAG, "Simulation skipped upload.");
+            } else {
+                result = mls.submit(batch.data, headers, true);
             }
-        } catch (IOException ex) {
-            error = ex.toString();
+
+            if (result != null && result.isSuccessCode2XX()) {
+                totalBytesSent += result.bytesSent();
+
+                String logMsg = "MLS geosubmit: [HTTP Status:" + result.httpStatusCode() + "], [Bytes Sent:" + result.bytesSent() + "]";
+                AppGlobals.guiLogInfo(logMsg, "#FFFFCC", true, false);
+                Log.d(LOG_TAG, logMsg);
+
+                dm.delete(batch.filename);
+
+                uploadedObservations += batch.reportCount;
+                uploadedWifis += batch.wifiCount;
+                uploadedCells += batch.cellCount;
+            } else {
+                String logMsg = "HTTP error unknown";
+                if (result != null) {
+                    logMsg = "HTTP non-success code: " + result.httpStatusCode();
+                }
+
+                if (result != null && result.isErrorCode400BadRequest()) {
+                    logMsg += ", 400 Error, deleting bad report";
+                    if (AppGlobals.guiLogMessageBuffer != null) { // if true, this is a GUI app
+                        String unzipped = Zipper.unzipData(batch.data);
+                        if (unzipped == null) {
+                            unzipped = "Corrupt gzip data found.";
+                        }
+                        AppGlobals.guiLogInfo(unzipped, "red", false, true);
+                    }
+                    dm.delete(batch.filename);
+                } else {
+                    dm.saveCurrentReportsToDisk();
+                }
+                AppGlobals.guiLogError(logMsg);
+            }
+
+            batch = dm.getNextBatch();
         }
 
         sTotalBytesUploadedThisSession.addAndGet(totalBytesSent);
 
-        try {
-            dm.incrementSyncStats(totalBytesSent, uploadedObservations, uploadedCells, uploadedWifis);
-        } catch (IOException ex) {
-            error = ex.toString();
-        } finally {
-            if (error != null) {
-                Log.d(LOG_TAG, error);
-                AppGlobals.guiLogError(error + " (uploadReports)");
-            }
-        }
+        dm.incrementSyncStats(totalBytesSent, uploadedObservations, uploadedCells, uploadedWifis);
     }
 
     public interface AsyncUploaderListener {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/Zipper.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/utils/Zipper.java
@@ -56,26 +56,45 @@ public class Zipper {
         return output;
     }
 
-    public static String unzipData(byte[] data) throws IOException {
+
+    /*
+     Decompress gzip data or return NULL if the stream cannot be decompressed properly.
+     */
+    public static String unzipData(byte[] data) {
         StringBuilder result = new StringBuilder();
-        final ByteArrayInputStream bs = new ByteArrayInputStream(data);
-        GZIPInputStream gstream = new GZIPInputStream(bs);
+
+        ByteArrayInputStream bs = null;
+        GZIPInputStream gzipInputStream = null;
         try {
-            InputStreamReader reader = new InputStreamReader(gstream);
+            bs = new ByteArrayInputStream(data);
+            gzipInputStream = new GZIPInputStream(bs);
+            InputStreamReader reader = new InputStreamReader(gzipInputStream);
             BufferedReader in = new BufferedReader(reader);
             String read;
             while ((read = in.readLine()) != null) {
                 result.append(read);
             }
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "Can't decompress report data: " + e.toString());
+            return null;
         } finally {
-            gstream.close();
-            bs.close();
+            if (gzipInputStream != null) {
+                try {
+                    gzipInputStream.close();
+                } catch (IOException e) {
+                    // eat it - nothing we can do
+                }
+            }
+
+            if (bs!= null) {
+                try {
+                    bs.close();
+                } catch (IOException e) {
+                    // eat it - nothing we can do.
+                }
+            }
         }
         return result.toString();
     }
 
-    public enum ZippedState {
-        eNotZipped,
-        eAlreadyZipped
-    }
 }


### PR DESCRIPTION
This removes most of the `throws IOException` declarations from DataStorageManager and the Reporter class and make debugging issues like #1609 easier.

Exception handling for bad I/O is now handled as close to the I/O call as possible.  Failure to write to disk will try to remove the partially written file from disk.  

ACRA hooks have been added for IOExceptions when writing sync stats as well as reading reports or writing reports from disk.  This should give us better visibility into where and why crashes are happening.
