### PR TITLE
Better invalid tile handling

### DIFF
--- a/android/src/test/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTileTest.java
+++ b/android/src/test/java/org/mozilla/osmdroid/tileprovider/modules/SerializableTileTest.java
@@ -6,11 +6,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
@@ -53,4 +55,67 @@ public class SerializableTileTest {
 
         assertTrue(Arrays.equals(tileData, newTile.getTileData()));
     }
+
+    @Test
+    public void testLoadTileMissingFile() throws IOException {
+        File temp = File.createTempFile("temp", ".txt");
+        String path = temp.getAbsolutePath();
+        temp.delete();
+
+        SerializableTile newTile = new SerializableTile(new File(path));
+
+        // Invalid tile paths should return 0 bytes
+        assertEquals(0, newTile.getTileData().length);
+    }
+
+    @Test
+    public void testLoadTileValidHeaderNoData() throws IOException {
+        // This is a file with a valid header, but no actual data
+        File temp = File.createTempFile("temp", ".txt");
+        FileOutputStream fos = new FileOutputStream(temp);
+
+        byte[] tileData = {(byte) 0xde, (byte) 0xca, (byte) 0xfb, (byte) 0xad};
+
+        fos.write(tileData);
+        fos.flush();
+        fos.close();
+
+        assertTrue(temp.exists());
+        SerializableTile newTile = new SerializableTile(temp);
+
+        // Invalid tiles should return 0 bytes
+        assertEquals(0, newTile.getTileData().length);
+
+        // Corrupt tiles should also be automatically wiped off the disk
+        assertFalse(temp.exists());
+    }
+
+
+    @Test
+    public void testLoadTileInvalidPayload() throws IOException {
+        // This is a file with a valid header, and invalid payload
+        File temp = File.createTempFile("temp", ".txt");
+        FileOutputStream fos = new FileOutputStream(temp);
+
+        byte[] tileData = {(byte) 0xde, (byte) 0xca, (byte) 0xfb, (byte) 0xad,
+                // These bytes are garbage
+               (byte) 0xaf, (byte) 0xad, (byte) 0xaf, (byte) 0xad,
+               (byte) 0xaf, (byte) 0xad, (byte) 0xaf, (byte) 0xad,
+               (byte) 0xaf, (byte) 0xad
+        };
+
+        fos.write(tileData);
+        fos.flush();
+        fos.close();
+
+        assertTrue(temp.exists());
+        SerializableTile newTile = new SerializableTile(temp);
+
+        // Invalid tiles should return 0 bytes
+        assertEquals(0, newTile.getTileData().length);
+
+        // Corrupt tiles should also be automatically wiped off the disk
+        assertFalse(temp.exists());
+    }
+
 }


### PR DESCRIPTION
This adds onto #1616 to handle corrupt tiles and missing files.

Any exception from java.nio gets propogated up as a RuntimeException, so those are all captured now and partial files are removed from storage.
