### PR TITLE
More cleanups of DatabaseManager

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/QueuedCountsTracker.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/QueuedCountsTracker.java
@@ -49,7 +49,7 @@ public class QueuedCountsTracker {
         }
 
         byte[] bytes = dsm.getCurrentReportsRawBytes();
-        if (bytes == null) {
+        if (bytes == null || bytes.length == 0) {
             mCachedByteCount = 0;
             return 0;
         }

--- a/android/src/test/java/org/mozilla/mozstumbler/client/QueuedCountsTrackerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/QueuedCountsTrackerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.ClientDataStorageManager;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StorageIsEmptyTracker;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.ISystemClock;
 import org.mozilla.mozstumbler.svclocator.services.MockSystemClock;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.spy;
 @RunWith(RobolectricTestRunner.class)
 public class QueuedCountsTrackerTest {
 
-    public class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+    public class StorageTracker implements StorageIsEmptyTracker {
         public void notifyStorageStateEmpty(boolean isEmpty) {
         }
     }

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/ReporterTest.java
@@ -5,12 +5,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.net.wifi.ScanResult;
-import android.telephony.TelephonyManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StorageIsEmptyTracker;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
@@ -189,7 +189,7 @@ public class ReporterTest {
         return Robolectric.application;
     }
 
-    public class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+    public class StorageTracker implements StorageIsEmptyTracker {
         public void notifyStorageStateEmpty(boolean isEmpty) {
         }
     }

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -83,11 +83,9 @@ public class DataStorageManagerTest {
                 bundle.addCellData(key, cell);
             }
 
-            JSONObject mlsObj = bundle.toMLSGeosubmit();
+            MLSJSONObject mlsObj = bundle.toMLSGeosubmit();
 
-            int wifiCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
-            int cellCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
-            dm.insert(mlsObj, wifiCount, cellCount);
+            dm.insert(mlsObj);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY,
                     dm.mCachedReportBatches.reportsCount());
@@ -114,11 +112,9 @@ public class DataStorageManagerTest {
                 bundle.addCellData(key, cell);
             }
 
-            JSONObject mlsObj = bundle.toMLSGeosubmit();
+            MLSJSONObject mlsObj = bundle.toMLSGeosubmit();
 
-            int wifiCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
-            int cellCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
-            dm.insert(mlsObj, wifiCount, cellCount);
+            dm.insert(mlsObj);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY  ,
                     dm.mCachedReportBatches.reportsCount());

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -87,7 +87,7 @@ public class DataStorageManagerTest {
 
             int wifiCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
             int cellCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
-            dm.insert(mlsObj.toString(), wifiCount, cellCount);
+            dm.insert(mlsObj, wifiCount, cellCount);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY,
                     dm.mCurrentReports.reportsCount());
@@ -118,7 +118,7 @@ public class DataStorageManagerTest {
 
             int wifiCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
             int cellCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
-            dm.insert(mlsObj.toString(), wifiCount, cellCount);
+            dm.insert(mlsObj, wifiCount, cellCount);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY  ,
                     dm.mCurrentReports.reportsCount());

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -49,20 +49,20 @@ public class DataStorageManagerTest {
         ClientDataStorageManager.sInstance = null;
         dm = ClientDataStorageManager.createGlobalInstance(ctx, tracker, maxBytes, maxWeeks);
         // Force the current reports to clear out between test runs.
-        dm.mCurrentReports.clearReports();
+        dm.mCachedReportBatches.clear();
 
         rp = new Reporter();
 
         // The Reporter class needs a reference to a context
         rp.startup(ctx);
-        assertEquals(0, dm.mCurrentReports.reportsCount());
+        assertEquals(0, dm.mCachedReportBatches.reportsCount());
     }
 
     @Test
     public void testMaxReportsLength() throws JSONException {
         StumblerBundle bundle;
 
-        assertEquals(0, dm.mCurrentReports.reportsCount());
+        assertEquals(0, dm.mCachedReportBatches.reportsCount());
 
         for (int locCount = 0; locCount < ReportBatchBuilder.MAX_REPORTS_IN_MEMORY - 1; locCount++) {
             Location loc = new Location("mock");
@@ -90,7 +90,7 @@ public class DataStorageManagerTest {
             dm.insert(mlsObj, wifiCount, cellCount);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY,
-                    dm.mCurrentReports.reportsCount());
+                    dm.mCachedReportBatches.reportsCount());
         }
 
         for (int locCount = ReportBatchBuilder.MAX_REPORTS_IN_MEMORY -1;
@@ -121,7 +121,7 @@ public class DataStorageManagerTest {
             dm.insert(mlsObj, wifiCount, cellCount);
 
             assertEquals((locCount+1) % ReportBatchBuilder.MAX_REPORTS_IN_MEMORY  ,
-                    dm.mCurrentReports.reportsCount());
+                    dm.mCachedReportBatches.reportsCount());
 
         }
 

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -48,8 +48,6 @@ public class DataStorageManagerTest {
         // directory will be properly created
         ClientDataStorageManager.sInstance = null;
         dm = ClientDataStorageManager.createGlobalInstance(ctx, tracker, maxBytes, maxWeeks);
-        // Force the current reports to clear out between test runs.
-        dm.mCachedReportBatches.clear();
 
         rp = new Reporter();
 

--- a/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManagerTest.java
@@ -127,7 +127,7 @@ public class DataStorageManagerTest {
 
     }
 
-    public class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+    public class StorageTracker implements StorageIsEmptyTracker {
         public void notifyStorageStateEmpty(boolean isEmpty) {
         }
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -173,7 +173,7 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     }
 
     private synchronized void flush() {
-        JSONObject mlsObj;
+        JSONObject geoSubmitJSON;
         int wifiCount = 0;
         int cellCount = 0;
 
@@ -182,12 +182,12 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         }
 
         try {
-            mlsObj = mBundle.toMLSGeosubmit();
-            if (mlsObj.has(DataStorageConstants.ReportsColumns.WIFI)) {
-                wifiCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
+            geoSubmitJSON = mBundle.toMLSGeosubmit();
+            if (geoSubmitJSON.has(DataStorageConstants.ReportsColumns.WIFI)) {
+                wifiCount = geoSubmitJSON.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
             }
-            if (mlsObj.has(DataStorageConstants.ReportsColumns.CELL)) {
-                cellCount = mlsObj.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
+            if (geoSubmitJSON.has(DataStorageConstants.ReportsColumns.CELL)) {
+                cellCount = geoSubmitJSON.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
             }
         } catch (JSONException e) {
             ClientLog.w(LOG_TAG, "Failed to convert bundle to JSON: " + e);
@@ -200,9 +200,7 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             return;
         }
 
-        AppGlobals.guiLogInfo("MLS record: " + mlsObj.toString());
-
-        DataStorageManager.getInstance().insert(mlsObj.toString(), wifiCount, cellCount);
+        DataStorageManager.getInstance().insert(geoSubmitJSON, wifiCount, cellCount);
 
         mObservationCount++;
         mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -12,12 +12,14 @@ import android.location.Location;
 import android.net.wifi.ScanResult;
 import android.support.v4.content.LocalBroadcastManager;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageConstants;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.MLSJSONObject;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.GPSScanner;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.WifiScanner;
@@ -173,7 +175,7 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
     }
 
     private synchronized void flush() {
-        JSONObject geoSubmitJSON;
+        MLSJSONObject geoSubmitJSON = null;
         int wifiCount = 0;
         int cellCount = 0;
 
@@ -183,24 +185,18 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
 
         try {
             geoSubmitJSON = mBundle.toMLSGeosubmit();
-            if (geoSubmitJSON.has(DataStorageConstants.ReportsColumns.WIFI)) {
-                wifiCount = geoSubmitJSON.getJSONArray(DataStorageConstants.ReportsColumns.WIFI).length();
-            }
-            if (geoSubmitJSON.has(DataStorageConstants.ReportsColumns.CELL)) {
-                cellCount = geoSubmitJSON.getJSONArray(DataStorageConstants.ReportsColumns.CELL).length();
-            }
         } catch (JSONException e) {
             ClientLog.w(LOG_TAG, "Failed to convert bundle to JSON: " + e);
             mBundle = null;
             return;
         }
 
-        if (wifiCount + cellCount < 1) {
+        if (geoSubmitJSON.radioCount() < 1) {
             mBundle = null;
             return;
         }
 
-        DataStorageManager.getInstance().insert(geoSubmitJSON, wifiCount, cellCount);
+        DataStorageManager.getInstance().insert(geoSubmitJSON);
 
         mObservationCount++;
         mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -181,7 +181,7 @@ public class StumblerService extends PersistentIntentService
                 }
 
                 if (DataStorageManager.getInstance() != null) {
-                    DataStorageManager.getInstance().saveCurrentReportsToDisk();
+                    DataStorageManager.getInstance().saveCachedReportsToDisk();
                 }
                 return null;
             }
@@ -281,6 +281,6 @@ public class StumblerService extends PersistentIntentService
         if (manager == null) {
             return;
         }
-        manager.saveCurrentReportsToDisk();
+        manager.saveCachedReportsToDisk();
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -17,6 +17,7 @@ import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageManager;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.IDataStorageManager;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StorageIsEmptyTracker;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager;
 import org.mozilla.mozstumbler.service.uploadthread.UploadAlarmReceiver;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
@@ -25,14 +26,13 @@ import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 // In stand-alone service mode (a.k.a passive scanning mode), this is created from PassiveServiceReceiver (by calling startService).
 // The StumblerService is a sticky unbound service in this usage.
 //
 public class StumblerService extends PersistentIntentService
-        implements DataStorageManager.StorageIsEmptyTracker {
+        implements StorageIsEmptyTracker {
 
     private static final String LOG_TAG = LoggerUtil.makeLogTag(StumblerService.class);
     private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -240,9 +240,8 @@ public class DataStorageManager implements IDataStorageManager {
             final int cellCount = mCachedReportBatches.getCellCount();
 
             mCachedReportBatches.clear();
-            final ReportBatch result = new ReportBatch(filename, data, currentReportsCount, wifiCount, cellCount);
-            mCurrentReportsSendBuffer = result;
-            return result;
+            mCurrentReportsSendBuffer = new ReportBatch(filename, data, currentReportsCount, wifiCount, cellCount);
+            return mCurrentReportsSendBuffer;
         } else {
             return getNextBatch();
         }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -375,10 +375,7 @@ public class DataStorageManager implements IDataStorageManager {
             mFlushMemoryBuffersToDiskTimer = null;
         }
 
-        mCachedReportBatches.addReport(geoSubmitObj.toString());
-
-        mCachedReportBatches.incWifiCount(geoSubmitObj.getWifiCount());
-        mCachedReportBatches.incCellCount(geoSubmitObj.getCellCount());
+        mCachedReportBatches.addReport(geoSubmitObj);
 
         if (mCachedReportBatches.maxReportsReached()) {
             // save to disk

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -7,6 +7,7 @@ package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 import android.content.Context;
 
 import org.acra.ACRA;
+import org.json.JSONObject;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.utils.Zipper;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
@@ -80,7 +81,7 @@ public class DataStorageManager implements IDataStorageManager {
             mReportsDir.mkdirs();
         }
 
-        mFileList = new ReportFileList();
+        mFileList = new ReportFileList(null);
         mFileList.update(mReportsDir);
 
         mPersistedOnDiskUploadStats = new PersistedStats(baseDir, c);
@@ -375,7 +376,7 @@ public class DataStorageManager implements IDataStorageManager {
         clearCurrentReports();
     }
 
-    public synchronized void insert(String report, int wifiCount, int cellCount) {
+    public synchronized void insert(JSONObject geoSubmitObj, int wifiCount, int cellCount) {
         notifyStorageIsEmpty(false);
 
         if (mFlushMemoryBuffersToDiskTimer != null) {
@@ -383,7 +384,7 @@ public class DataStorageManager implements IDataStorageManager {
             mFlushMemoryBuffersToDiskTimer = null;
         }
 
-        mCurrentReports.addReport(report);
+        mCurrentReports.addReport(geoSubmitObj.toString());
 
         mCurrentReports.wifiCount += wifiCount;
         mCurrentReports.cellCount += cellCount;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -367,7 +367,7 @@ public class DataStorageManager implements IDataStorageManager {
         mCachedReportBatches.clear();
     }
 
-    public synchronized void insert(JSONObject geoSubmitObj, int wifiCount, int cellCount) {
+    public synchronized void insert(MLSJSONObject geoSubmitObj) {
         notifyStorageIsEmpty(false);
 
         if (mFlushMemoryBuffersToDiskTimer != null) {
@@ -377,8 +377,8 @@ public class DataStorageManager implements IDataStorageManager {
 
         mCachedReportBatches.addReport(geoSubmitObj.toString());
 
-        mCachedReportBatches.incWifiCount(wifiCount);
-        mCachedReportBatches.incCellCount(cellCount);
+        mCachedReportBatches.incWifiCount(geoSubmitObj.getWifiCount());
+        mCachedReportBatches.incCellCount(geoSubmitObj.getCellCount());
 
         if (mCachedReportBatches.maxReportsReached()) {
             // save to disk

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/DataStorageManager.java
@@ -55,16 +55,19 @@ public class DataStorageManager implements IDataStorageManager {
     static final String SEP_CELL_COUNT = "-c";
     static final String SEP_TIME_MS = "-t";
     static final String FILENAME_PREFIX = "reports";
-    static final String MEMORY_BUFFER_NAME = "in memory send buffer";
     public static DataStorageManager sInstance;
-    final File mReportsDir;
-    final ReportBatchBuilder mCurrentReports = new ReportBatchBuilder();
     // Set to the default value specified above.
     private final long mMaxBytesDiskStorage;
     // Set to the default value specified above.
     private final int mMaxWeeksStored;
     private final StorageIsEmptyTracker mTracker;
     protected final PersistedStats mPersistedOnDiskUploadStats;
+
+    // This set of members are used to keep track of ReportBatch instances in memory
+    // and on disk.  The Timer is used to periodically flush the in-memory buffer to disk.
+    static final String MEMORY_BUFFER_NAME = "in memory send buffer";
+    final File mReportsDir;
+    final ReportBatchBuilder mCurrentReports = new ReportBatchBuilder();
     protected ReportBatch mCurrentReportsSendBuffer;
     protected ReportFileList mFileList;
     private ReportBatchIterator mReportBatchIterator;
@@ -89,18 +92,6 @@ public class DataStorageManager implements IDataStorageManager {
 
     public static String getStorageDir(Context c) {
         File dir = null;
-
-        // Uncomment the following block if you're debugging
-        // persistent log storage on a non-rooted device
-        /*
-        if (AppGlobals.isDebug) {
-            // in debug, put files in public location
-            dir = c.getExternalFilesDir(null);
-            if (dir != null) {
-                dir = new File(dir.getAbsolutePath() + File.separator + MOZ_STUMBLER_RELPATH);
-            }
-        }
-        */
 
         if (dir == null) {
             dir = c.getFilesDir();
@@ -446,9 +437,5 @@ public class DataStorageManager implements IDataStorageManager {
     @Override
     public synchronized void incrementSyncStats(long bytesSent, long reports, long cells, long wifis) {
         mPersistedOnDiskUploadStats.incrementSyncStats(bytesSent, reports, cells, wifis);
-    }
-
-    public interface StorageIsEmptyTracker {
-        public void notifyStorageStateEmpty(boolean isEmpty);
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
@@ -25,7 +25,7 @@ public interface IDataStorageManager {
     public byte[] getCurrentReportsRawBytes();
 
     // Insert a report into storage
-    public void insert(JSONObject geoSubmitObj, int wifiCount, int cellCount);
+    public void insert(MLSJSONObject geoSubmitObj);
 
     // It feels like this method should be pushed behind the DataStorageManager implementation
     public void incrementSyncStats(long bytesSent, long reports, long cells, long wifis);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
@@ -4,10 +4,6 @@
 
 package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
-import org.json.JSONObject;
-
-import java.io.IOException;
-
 /*
  This interface just exists to firm up the public interface of the DataStorageManager
  */

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 
 /*
@@ -23,7 +25,7 @@ public interface IDataStorageManager {
     public byte[] getCurrentReportsRawBytes();
 
     // Insert a report into storage
-    public void insert(String report, int wifiCount, int cellCount);
+    public void insert(JSONObject geoSubmitObj, int wifiCount, int cellCount);
 
     // It feels like this method should be pushed behind the DataStorageManager implementation
     public void incrementSyncStats(long bytesSent, long reports, long cells, long wifis);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/IDataStorageManager.java
@@ -35,13 +35,7 @@ public interface IDataStorageManager {
     // DataStorageManager.
     public boolean isDirEmpty();
 
-
-    // It seems like we should be able to get rid of the sendBuffer which is just a ReportBatch
-    // record. This would get rid of having to maintain the state of `mCurrentReportsSendBuffer`
-    // and get rid of the saveCurrentReportsSendBufferToDisk method.
-    public boolean saveCurrentReportsSendBufferToDisk();
-    public void saveCurrentReportsToDisk();
-
+    public void saveCachedReportsToDisk();
 
     // Getting an instance of ReportBatch should really hang off of an iterator.
     // We have two methods because we have a special case where the first batch is
@@ -49,7 +43,6 @@ public interface IDataStorageManager {
     // We should extend the ReportBatchIterator to have knowledge of the in-memory reports
     // and implement java.util.Iterator to return the ReportBatch instances.
     public ReportBatch getFirstBatch();
-
     public ReportBatch getNextBatch();
 
     // These 3 methods are *only* used to determine if we have stale data and if we should be

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/MLSJSONObject.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/MLSJSONObject.java
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/*
+ This subclass of JSONObject provides additional getters - and only getters for convenient access
+ to bits of data that are relevant to the Ichnaea JSON specification.
+ */
+public class MLSJSONObject extends JSONObject {
+
+    public int radioCount() {
+        int result = 0;
+        result += getWifiCount();
+        result += getCellCount();
+        return result;
+    }
+
+    public int getWifiCount() {
+        JSONArray wifiRecords = this.optJSONArray(DataStorageConstants.ReportsColumns.WIFI);
+        return (wifiRecords == null ? 0 : wifiRecords.length());
+    }
+
+    public int getCellCount() {
+        JSONArray cellRecords = this.optJSONArray(DataStorageConstants.ReportsColumns.CELL);
+        return (cellRecords == null ? 0 : cellRecords.length());
+    }
+
+}

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -5,6 +5,7 @@
 package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 
 import org.mozilla.mozstumbler.service.Prefs;
+import org.mozilla.mozstumbler.service.utils.Zipper;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -31,8 +32,8 @@ public class ReportBatchBuilder {
      converted to a string.  You almost certainly want to set that flag to false though as you'll
      eat memory.
      */
-    String finalizeAndClearReports() {
-        return generateJSON(false);
+    byte[] finalizeAndClearReports() {
+        return Zipper.zipData(generateJSON(false).getBytes());
     }
 
     private String generateJSON(boolean preserveReports) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -41,21 +41,18 @@ public class ReportBatchBuilder {
         MLSJSONObject report = null;
         final String kPrefix = "{\"items\":[";
         StringBuilder reportString = new StringBuilder(kPrefix);
-        report = mReportList.poll();
-        if (report != null) {
-            if (preserveReports) {
-                jsonCollector.add(report);
-            }
-            reportString.append(report.toString());
-        }
+
+        // Note that this is a blank separator for first iteration
+        String jsonSep = "";
 
         report = mReportList.poll();
         while (report != null) {
             if (preserveReports) {
                 jsonCollector.add(report);
             }
-            reportString.append("," + report.toString());
+            reportString.append(jsonSep + report.toString());
             report = mReportList.poll();
+            jsonSep = ",";
         }
 
         // Restore the ejected reports if necessary

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -40,7 +40,11 @@ public class ReportBatchBuilder {
         wifiCount = cellCount = 0;
     }
 
-    public void addReport(String report) {
+    public void addReport(MLSJSONObject geoSubmitObj) {
+        String report = geoSubmitObj.toString();
+        wifiCount += geoSubmitObj.getWifiCount();
+        cellCount += geoSubmitObj.getCellCount();
+
         if (reportCount == MAX_REPORTS_IN_MEMORY) {
             // This can happen in the event that serializing reports to disk fails
             // and the reports list is never cleared.
@@ -63,14 +67,6 @@ public class ReportBatchBuilder {
             return true;
         }
         return reportsCount() == MAX_REPORTS_IN_MEMORY;
-    }
-
-    public void incWifiCount(int v) {
-        wifiCount += v;
-    }
-
-    public void incCellCount(int v) {
-        cellCount += v;
     }
 
     public int getCellCount() {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -7,7 +7,6 @@ package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.utils.Zipper;
 
-import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /*
@@ -19,10 +18,10 @@ public class ReportBatchBuilder {
     // Once this size is reached, data is persisted to disk, mCachedReportBatches is cleared.
     public static final int MAX_REPORTS_IN_MEMORY = 50;
 
-    private ConcurrentLinkedQueue<MLSJSONObject> reportList = new ConcurrentLinkedQueue<MLSJSONObject>();
+    private ConcurrentLinkedQueue<MLSJSONObject> mReportList = new ConcurrentLinkedQueue<MLSJSONObject>();
 
     public int reportsCount() {
-        return reportList.size();
+        return mReportList.size();
     }
 
     /*
@@ -42,7 +41,7 @@ public class ReportBatchBuilder {
         MLSJSONObject report = null;
         final String kPrefix = "{\"items\":[";
         StringBuilder reportString = new StringBuilder(kPrefix);
-        report = reportList.poll();
+        report = mReportList.poll();
         if (report != null) {
             if (preserveReports) {
                 jsonCollector.add(report);
@@ -50,20 +49,20 @@ public class ReportBatchBuilder {
             reportString.append(report.toString());
         }
 
-        report = reportList.poll();
+        report = mReportList.poll();
         while (report != null) {
             if (preserveReports) {
                 jsonCollector.add(report);
             }
             reportString.append("," + report.toString());
-            report = reportList.poll();
+            report = mReportList.poll();
         }
 
         // Restore the ejected reports if necessary
         if (preserveReports) {
             report = jsonCollector.poll();
             while (report != null) {
-                reportList.add(report);
+                mReportList.add(report);
                 report = jsonCollector.poll();
             }
         }
@@ -79,7 +78,7 @@ public class ReportBatchBuilder {
             // and the reports list is never cleared.
             return;
         }
-        reportList.add(geoSubmitObj);
+        mReportList.add(geoSubmitObj);
     }
 
     public boolean maxReportsReached() {
@@ -92,7 +91,7 @@ public class ReportBatchBuilder {
 
     public int getCellCount() {
         int result = 0;
-        for (MLSJSONObject obj: reportList) {
+        for (MLSJSONObject obj: mReportList) {
             result += obj.getCellCount();
         }
         return result;
@@ -100,7 +99,7 @@ public class ReportBatchBuilder {
 
     public int getWifiCount() {
         int result = 0;
-        for (MLSJSONObject obj : reportList) {
+        for (MLSJSONObject obj : mReportList) {
             result += obj.getWifiCount();
         }
         return result;

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportBatchBuilder.java
@@ -15,11 +15,13 @@ public class ReportBatchBuilder {
     private static ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
     private static String LOG_TAG = LoggerUtil.makeLogTag(ReportBatchBuilder.class);
 
-    // The max number of reports stored in the mCurrentReports. Each report is a GPS location plus wifi and cell scan.
-    // Once this size is reached, data is persisted to disk, mCurrentReports is cleared.
+    // The max number of reports stored in the mCachedReportBatches. Each report is a GPS location plus wifi and cell scan.
+    // Once this size is reached, data is persisted to disk, mCachedReportBatches is cleared.
     public static final int MAX_REPORTS_IN_MEMORY = 50;
-    public int wifiCount;
-    public int cellCount;
+
+    private int wifiCount;
+    private int cellCount;
+
     StringBuilder reportString;
     int reportCount;
 
@@ -32,9 +34,10 @@ public class ReportBatchBuilder {
         return reportString.toString() + kSuffix;
     }
 
-    public void clearReports() {
+    public void clear() {
         reportCount = 0;
         reportString = null;
+        wifiCount = cellCount = 0;
     }
 
     public void addReport(String report) {
@@ -60,5 +63,21 @@ public class ReportBatchBuilder {
             return true;
         }
         return reportsCount() == MAX_REPORTS_IN_MEMORY;
+    }
+
+    public void incWifiCount(int v) {
+        wifiCount += v;
+    }
+
+    public void incCellCount(int v) {
+        cellCount += v;
+    }
+
+    public int getCellCount() {
+        return cellCount;
+    }
+
+    public int getWifiCount() {
+        return wifiCount;
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportFileList.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ReportFileList.java
@@ -16,9 +16,6 @@ class ReportFileList {
     int mCellCount;
     long mFilesOnDiskBytes;
 
-    public ReportFileList() {
-    }
-
     public ReportFileList(ReportFileList other) {
         if (other == null) {
             return;
@@ -53,5 +50,9 @@ class ReportFileList {
             mCellCount += (int) DataStorageManager.getLongFromFilename(f.getName(), DataStorageManager.SEP_CELL_COUNT);
             mFilesOnDiskBytes += f.length();
         }
+    }
+
+    public synchronized boolean isDirEmpty() {
+        return (mFiles == null || mFiles.length < 1);
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StorageIsEmptyTracker.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StorageIsEmptyTracker.java
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.mozstumbler.service.stumblerthread.datahandling;
+
+public interface StorageIsEmptyTracker {
+    public void notifyStorageStateEmpty(boolean isEmpty);
+}

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -82,12 +82,11 @@ public final class StumblerBundle implements Parcelable {
         return Collections.unmodifiableMap(mCellData);
     }
 
-    public JSONObject toMLSGeosubmit() throws JSONException {
-        JSONObject headerFields = new JSONObject();
+    public MLSJSONObject toMLSGeosubmit() throws JSONException {
+        MLSJSONObject headerFields = new MLSJSONObject();
         headerFields.put(DataStorageConstants.ReportsColumns.LAT, Math.floor(mGpsPosition.getLatitude() * 1.0E6) / 1.0E6);
         headerFields.put(DataStorageConstants.ReportsColumns.LON, Math.floor(mGpsPosition.getLongitude() * 1.0E6) / 1.0E6);
         headerFields.put(DataStorageConstants.ReportsColumns.TIME, mGpsPosition.getTime());
-
 
         /* Skip adding 'heading'
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploader.java
@@ -77,9 +77,7 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
         }
 
 
-        if (Prefs.getInstanceWithoutContext().isSaveStumbleLogs()) {
-            DataStorageManager.getInstance().saveCurrentReportsSendBufferToDisk();
-        }
+
         uploadReports(param);
 
         isUploading.set(false);
@@ -121,7 +119,6 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
         }
 
         IDataStorageManager dm = DataStorageManager.getInstance();
-
         ReportBatch batch = dm.getFirstBatch();
         HashMap<String, String> headers = new HashMap<String, String>();
         headers.put(MLS.EMAIL_HEADER, param.emailAddress);
@@ -171,7 +168,7 @@ public class AsyncUploader extends AsyncTask<AsyncUploadParam, AsyncProgressList
                     }
                     dm.delete(batch.filename);
                 } else {
-                    dm.saveCurrentReportsToDisk();
+                    dm.saveCachedReportsToDisk();
                 }
                 AppGlobals.guiLogError(logMsg);
             }

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManagerTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/ClientDataStorageManagerTest.java
@@ -30,7 +30,7 @@ import static junit.framework.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class ClientDataStorageManagerTest {
 
-    private class StorageTracker implements DataStorageManager.StorageIsEmptyTracker {
+    private class StorageTracker implements StorageIsEmptyTracker {
         public void notifyStorageStateEmpty(boolean isEmpty) {
         }
     }

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
+import org.mozilla.mozstumbler.service.utils.Zipper;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -158,7 +159,7 @@ public class StumblerBundleTest {
             rbb.addReport(b.toMLSGeosubmit());
         }
 
-        String finalReport = rbb.finalizeAndClearReports();
+        String finalReport = Zipper.unzipData(rbb.finalizeAndClearReports());
         JSONObject actualJson = new JSONObject(finalReport);
 
         System.out.println("Actual JSON with accuracy and location: " + actualJson.toString(2));

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
@@ -155,7 +155,7 @@ public class StumblerBundleTest {
 
         ReportBatchBuilder rbb = new ReportBatchBuilder();
         for (StumblerBundle b: bundleList) {
-            rbb.addReport(b.toMLSGeosubmit().toString(4));
+            rbb.addReport(b.toMLSGeosubmit());
         }
 
         String finalReport = rbb.finalizeReports();

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundleTest.java
@@ -158,12 +158,11 @@ public class StumblerBundleTest {
             rbb.addReport(b.toMLSGeosubmit());
         }
 
-        String finalReport = rbb.finalizeReports();
+        String finalReport = rbb.finalizeAndClearReports();
         JSONObject actualJson = new JSONObject(finalReport);
 
         System.out.println("Actual JSON with accuracy and location: " + actualJson.toString(2));
         System.out.println("Expected JSON with accuracy and location: " + expectedJson.toString(2));
-
 
         JSONAssert.assertEquals(expectedJson, actualJson, true);
     }


### PR DESCRIPTION
This is yet another patch to cleanup the interface in IDataStorageManager.

This gets rid of `saveCurrentReportsSendBufferToDisk()` and simplifies the interface to `insert()`.

MLSJSONObject is introduced as a subclass of JSONObject.  This reduces the clutter of getting wifi and cell counts and maintaining that state all over the place.
