### PR TITLE
Add developer option to test passive scanning

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -21,6 +21,7 @@ public class ClientPrefs extends Prefs {
     public static final int MIN_BATTERY_DEFAULT = 15;
     public static final String LAST_VERSION = "last_version";
     public static final String IS_MAP_ZOOM_LIMITED = "limited_zoom";
+    public static final String IS_SCANNING_PASSIVE = "passive_scanning";
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ClientPrefs.class);
     private static final String LAT_PREF = "lat";
     private static final String LON_PREF = "lon";
@@ -184,5 +185,13 @@ public class ClientPrefs extends Prefs {
 
     public void setIsMapZoomLimited(boolean isOn) {
         setBoolPref(IS_MAP_ZOOM_LIMITED, isOn);
+    }
+
+    public boolean isScanningPassive() {
+        return getBoolPrefWithDefault(IS_SCANNING_PASSIVE, false);
+    }
+
+    public void setIsScanningPassive(boolean isOn) {
+        setBoolPref(IS_SCANNING_PASSIVE, isOn);
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -150,6 +150,9 @@ public class ClientStumblerService extends StumblerService {
     public synchronized void startScanning() {
         foregroundNotification();
 
+        boolean passiveScanning = ClientPrefs.getInstance(ClientStumblerService.this).isScanningPassive();
+        setPassiveMode(passiveScanning);
+
         super.startScanning();
 
         if (mBatteryChecker == null) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -545,7 +545,11 @@ public class MapFragment extends android.support.v4.app.Fragment
      the class is under test
      */
     void doOnResume() {
-        mMapLocationListener = new UserPositionUpdateManager(this);
+        ClientPrefs prefs = ClientPrefs.getInstance(getActivity().getApplicationContext());
+
+        if (!prefs.isScanningPassive()) {
+            mMapLocationListener = new UserPositionUpdateManager(this);
+        }
 
         ObservedLocationsReceiver observer = ObservedLocationsReceiver.getInstance();
         observer.setMapActivity(this);
@@ -556,7 +560,6 @@ public class MapFragment extends android.support.v4.app.Fragment
 
         mHighLowBandwidthChecker = new HighLowBandwidthReceiver(this);
 
-        ClientPrefs prefs = ClientPrefs.getInstance(getActivity().getApplicationContext());
         setShowMLS(prefs.getOnMapShowMLS());
 
         mObservationPointsOverlay.zoomChanged(mMap);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/DeveloperActivity.java
@@ -111,6 +111,7 @@ public class DeveloperActivity extends ActionBarActivity {
             setupLocationChangeSpinners();
             setupMinPauseTime();
             setupLimitZoom();
+            setupPassiveMode();
             return mRootView;
         }
 
@@ -122,6 +123,23 @@ public class DeveloperActivity extends ActionBarActivity {
                 @Override
                 public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                     ClientPrefs.getInstance(mRootView.getContext()).setIsMapZoomLimited(isChecked);
+                }
+            });
+        }
+
+        private void setupPassiveMode() {
+            boolean isPassive = ClientPrefs.getInstance(mRootView.getContext()).isScanningPassive();
+            CheckBox button = (CheckBox) mRootView.findViewById(R.id.togglePassiveScanning);
+            button.setChecked(isPassive);
+            button.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                    ClientPrefs.getInstance(mRootView.getContext()).setIsScanningPassive(isChecked);
+                    MainApp mainApp = ((MainApp) getActivity().getApplication());
+                    if (mainApp.isScanningOrPaused()) {
+                        mainApp.stopScanning();
+                        mainApp.startScanning();
+                    }
                 }
             });
         }

--- a/android/src/main/res/layout/fragment_developer_options.xml
+++ b/android/src/main/res/layout/fragment_developer_options.xml
@@ -38,10 +38,26 @@
         android:background="#55ffffff" />
 
     <CheckBox
-        android:id="@+id/toggleSimulation"
+        android:id="@+id/togglePassiveScanning"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/line1"
+        android:text="@string/use_passive_scanning" />
+
+    <View
+        android:layout_below="@id/togglePassiveScanning"
+        android:id="@+id/line_passive"
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:layout_marginBottom="10dp"
+        android:layout_marginTop="10dp"
+        android:background="#55ffffff" />
+
+    <CheckBox
+        android:id="@+id/toggleSimulation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/line_passive"
         android:text="@string/enable_simulation" />
 
     <Button

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
 
     <string name="ok">OK</string>
     <string name="limit_map_zoom">Limit zooming out on map</string>
+    <string name="use_passive_scanning">Test Passive Scanning</string>
     <string name="test_significant_sensor_dialog_title">Test Significant Motion Sensor</string>
     <string name="test_significant_sensor_dialog_message">Stand still, then walk for 1 minute.\n\nDetecting movement &#8230;</string>
     <string name="test_significant_sensor_confirmed_working">Motion detected.\nThe sensor is functioning normally.</string>

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -197,7 +197,7 @@ public class StumblerService extends PersistentIntentService
         init();
 
         // Post-init(), set the mode to passive.
-        setPassiveMode();
+        setPassiveMode(true);
 
         if (intent == null) {
             return;
@@ -249,8 +249,8 @@ public class StumblerService extends PersistentIntentService
         startScanning();
     }
 
-    public void setPassiveMode() {
-        mScanManager.setPassiveMode(true);
+    public void setPassiveMode(boolean on) {
+        mScanManager.setPassiveMode(on);
     }
 
     // Note that in passive mode, having data isn't an upload trigger, it is triggered by the start intent

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/GPSScanner.java
@@ -165,7 +165,7 @@ public class GPSScanner implements LocationListener {
         String logMsg = (mIsPassiveMode) ? "[Passive] " : "[Active] ";
 
         String provider = location.getProvider();
-        if (!provider.toLowerCase().contains("gps")) {
+        if (!provider.equals(LocationManager.GPS_PROVIDER)) {
             sendToLogActivity(logMsg + "Discard fused/network location. Provider ["+provider+"]");
             // only interested in GPS locations
             return;

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/mainthread/PassiveServiceReceiverTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/mainthread/PassiveServiceReceiverTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mozilla.mozstumbler.service.AppGlobals;
 import org.mozilla.mozstumbler.service.stumblerthread.StumblerService;
 import org.mozilla.mozstumbler.service.stumblerthread.motiondetection.CustomSensorManager;
@@ -163,7 +164,7 @@ public class PassiveServiceReceiverTest {
 
         // We need to no-op this as the StumblerService won't have an application context yet
         // and binding in the BatteryCheckReceiver is just going to NPE on us.
-        doNothing().when(ss).setPassiveMode();
+        doNothing().when(ss).setPassiveMode(Mockito.anyBoolean());
 
         ss.onHandleIntent(intent);
 


### PR DESCRIPTION
Adds a simple developer option to visually test the passive scanning mode, and fixes #1583.
