### PR TITLE
bug 1650, tally object may not be populated if no upload occured.

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploaderMLS.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/uploadthread/AsyncUploaderMLS.java
@@ -55,6 +55,11 @@ public class AsyncUploaderMLS extends AsyncUploader {
 
     protected void tallyCompleted(HashMap<String, Integer> tally, long totalBytesSent) {
         assert(storageManager instanceof DataStorageManager);
+        if (!tally.containsKey(OBSERVATIONS_TALLY)) {
+            // Just check one key, as obs, wifi, and cell keys are added at the same time
+            return;
+        }
+
         ((DataStorageManager) storageManager).incrementSyncStats(totalBytesSent,
                 tally.get(OBSERVATIONS_TALLY),
                 tally.get(CELLS_TALLY),


### PR DESCRIPTION
Fix for issue #1650
