### PR TITLE
Fix significant motion sensor initial state

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/SignificantMotionSensor.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/SignificantMotionSensor.java
@@ -27,7 +27,7 @@ public class SignificantMotionSensor implements IMotionSensor {
 
     private final Context mAppContext;
     private Sensor mSignificantMotionSensor;
-    private boolean mStopSignificantMotionSensor;
+    private boolean mIsActive;
     static SensorManager mSensorManager;
 
     public static SignificantMotionSensor getSensor(Context appCtx) {
@@ -50,21 +50,21 @@ public class SignificantMotionSensor implements IMotionSensor {
     }
 
     private SignificantMotionSensor(Context appCtx, Sensor significantSensor) {
-        mStopSignificantMotionSensor = false;
+        mIsActive = false;
         mSignificantMotionSensor = significantSensor;
         mAppContext = appCtx;
     }
 
     @Override
     public void start() {
-        mStopSignificantMotionSensor = false;
+        mIsActive = true;
 
         if (Build.VERSION.SDK_INT >= 18) {
             final TriggerEventListener tr = new TriggerEventListener() {
                 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
                 @Override
                 public void onTrigger(TriggerEvent event) {
-                    if (mStopSignificantMotionSensor) {
+                    if (!mIsActive) {
                         return;
                     }
                     AppGlobals.guiLogInfo("Major motion detected.");
@@ -111,11 +111,11 @@ public class SignificantMotionSensor implements IMotionSensor {
 
     @Override
     public void stop() {
-        mStopSignificantMotionSensor = true;
+        mIsActive = false;
     }
 
     @Override
     public boolean isActive() {
-        return !mStopSignificantMotionSensor;
+        return mIsActive;
     }
 }

--- a/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/SignificantMotionSensorTest.java
+++ b/libraries/stumbler/src/test/java/org/mozilla/mozstumbler/service/stumblerthread/motiondetection/SignificantMotionSensorTest.java
@@ -24,8 +24,10 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 import static org.robolectric.Robolectric.shadowOf;
 
 
@@ -75,8 +77,10 @@ public class SignificantMotionSensorTest {
         Context ctx = Robolectric.application;
         SignificantMotionSensor sensor = SignificantMotionSensor.getSensor(ctx);
 
+        assertFalse(sensor.isActive());
         sensor.start();
         Log.d(LOG_TAG, "Started significant sensor");
+        assertTrue(sensor.isActive());
 
         assertNull(captured);
         shadow.triggerEvent();
@@ -84,6 +88,9 @@ public class SignificantMotionSensorTest {
         // Verify that the significant motion event has triggered the intent to be broadcast
         assertNotNull(captured);
         assertEquals(captured.getAction(), MotionSensor.ACTION_USER_MOTION_DETECTED);
+
+        sensor.stop();
+        assertFalse(sensor.isActive());
     }
 
 


### PR DESCRIPTION
The initial state of the significant motion sensor is active. I fixed that and inverted the semantic of the variable to hopefully make it more comprehensible.
This is really a small bug, I only noticed it because the false positive motion filter was triggered although I had motion sensors disabled.
