### PR TITLE
Fix NPE

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/offline/OrderedCityTiles.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/offline/OrderedCityTiles.java
@@ -34,6 +34,7 @@ public class OrderedCityTiles {
             fileReader = new BufferedReader(new FileReader(LocationService.sdcardArchivePath()+ "/" + ORDERED_CITY_CSV));
         } catch (FileNotFoundException e) {
             Log.e(LOG_TAG, "Can't open file", e);
+            return;
         }
 
         //Read the file line by line


### PR DESCRIPTION
Fix NPE

```
9126-9126/org.mozilla.mozstumbler.debug E/Stumbler_ocationService﹕ Error loading trie data.
    java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.io.BufferedReader.readLine()' on a null object reference
            at org.mozilla.mozstumbler.service.core.offline.OrderedCityTiles.parse_csv(OrderedCityTiles.java:44)
            at org.mozilla.mozstumbler.service.core.offline.OrderedCityTiles.<init>(OrderedCityTiles.java:27)
            at org.mozilla.mozstumbler.service.core.offline.LocationService.<init>(LocationService.java:53)
            at java.lang.reflect.Constructor.newInstance(Native Method)
            at java.lang.reflect.Constructor.newInstance(Constructor.java:288)
            at org.mozilla.mozstumbler.svclocator.ServiceConfig.load(ServiceConfig.java:36)
            at org.mozilla.mozstumbler.client.MainApp.defaultServiceConfig(MainApp.java:156)
            at org.mozilla.mozstumbler.client.MainApp.onCreate(MainApp.java:202)
            at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1012)
            at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4553)
            at android.app.ActivityThread.access$1500(ActivityThread.java:151)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1364)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5254)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)

```
