### PR TITLE
Fix unlimited zoom

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -32,7 +32,7 @@ public abstract class AbstractMapOverlay extends TilesOverlay {
     // TODO make this a single value configurable in developer settings
     private static final int SMALL_SCREEN_MIN_ZOOM = 11;
     private static final int MEDIUM_SCREEN_MIN_ZOOM = 12;
-    private static final int LARGE_SCREEN_MIN_ZOOM = 13;
+    protected static final int LARGE_SCREEN_MIN_ZOOM = 13;
     // Use png32 which is a 32-color indexed image, the tiles are ~30% smaller
     public static String FILE_TYPE_SUFFIX_PNG = ".png32";
     private static int sMinZoomLevelOfMapDisplaySizeBased;

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/AbstractMapOverlay.java
@@ -141,7 +141,7 @@ public abstract class AbstractMapOverlay extends TilesOverlay {
         currentMapTile.draw(c);
     }
 
-    public enum LowResType {
-        HIGHER_ZOOM, LOWER_ZOOM
+    public enum TileResType {
+        HIGHER_ZOOM, LOWER_ZOOM, ORIGINAL_ZOOM
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -16,18 +16,27 @@ import org.mozilla.osmdroid.views.MapView;
  * This class provides the Mozilla Coverage overlay
  */
 public class CoverageOverlay extends AbstractMapOverlay {
+    public static final String MLS_MAP_TILE_COVERAGE_NAME = "Mozilla Location Service Coverage Map";
     // Use a lower zoom than the LowResMapOverlay, the coverage can be very low detail and still look ok
-    private static final int LOW_ZOOM_LEVEL = 10;
+    public static final int LOW_ZOOM_LEVEL = 10;
+
+    public CoverageOverlay(final Context aContext, final String coverageUrl, MapView mapView) {
+        super(aContext);
+        setup(1, AbstractMapOverlay.LARGE_SCREEN_MIN_ZOOM, coverageUrl, mapView);
+    }
 
     public CoverageOverlay(LowResType type, final Context aContext, final String coverageUrl, MapView mapView) {
         super(aContext);
 
         final int zoomLevel = (type == LowResType.HIGHER_ZOOM) ?
                 AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
+        setup(zoomLevel, zoomLevel, coverageUrl, mapView);
+    }
 
-        final ITileSource coverageTileSource = new XYTileSource("Mozilla Location Service Coverage Map",
+    private void setup(int aZoomMinLevel, int aZoomMaxLevel, final String coverageUrl, MapView mapView) {
+        final ITileSource coverageTileSource = new XYTileSource(MLS_MAP_TILE_COVERAGE_NAME,
                 null,
-                zoomLevel, zoomLevel,
+                aZoomMinLevel, aZoomMaxLevel,
                 AbstractMapOverlay.TILE_PIXEL_SIZE,
                 ".png",
                 new String[]{coverageUrl});

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/CoverageOverlay.java
@@ -7,6 +7,7 @@ package org.mozilla.mozstumbler.client.mapview.tiles;
 import android.content.Context;
 import android.graphics.Color;
 
+import org.mozilla.mozstumbler.client.mapview.MapFragment;
 import org.mozilla.osmdroid.tileprovider.tilesource.ITileSource;
 import org.mozilla.osmdroid.tileprovider.tilesource.XYTileSource;
 import org.mozilla.osmdroid.tileprovider.util.SimpleInvalidationHandler;
@@ -20,23 +21,23 @@ public class CoverageOverlay extends AbstractMapOverlay {
     // Use a lower zoom than the LowResMapOverlay, the coverage can be very low detail and still look ok
     public static final int LOW_ZOOM_LEVEL = 10;
 
-    public CoverageOverlay(final Context aContext, final String coverageUrl, MapView mapView) {
-        super(aContext);
-        setup(1, AbstractMapOverlay.LARGE_SCREEN_MIN_ZOOM, coverageUrl, mapView);
-    }
-
-    public CoverageOverlay(LowResType type, final Context aContext, final String coverageUrl, MapView mapView) {
+    public CoverageOverlay(TileResType type, final Context aContext, final String coverageUrl, MapView mapView) {
         super(aContext);
 
-        final int zoomLevel = (type == LowResType.HIGHER_ZOOM) ?
+        if (type == TileResType.ORIGINAL_ZOOM) {
+            setup(MapFragment.LOWEST_UNLIMITED_ZOOM, LOW_ZOOM_LEVEL - 1, coverageUrl, mapView);
+            return;
+        }
+
+        final int zoomLevel = (type == TileResType.HIGHER_ZOOM) ?
                 AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
         setup(zoomLevel, zoomLevel, coverageUrl, mapView);
     }
 
-    private void setup(int aZoomMinLevel, int aZoomMaxLevel, final String coverageUrl, MapView mapView) {
+    private void setup(int zoomMinLevel, int zoomMaxLevel, final String coverageUrl, MapView mapView) {
         final ITileSource coverageTileSource = new XYTileSource(MLS_MAP_TILE_COVERAGE_NAME,
                 null,
-                aZoomMinLevel, aZoomMaxLevel,
+                zoomMinLevel, zoomMaxLevel,
                 AbstractMapOverlay.TILE_PIXEL_SIZE,
                 ".png",
                 new String[]{coverageUrl});

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -15,7 +15,7 @@ import org.mozilla.osmdroid.tileprovider.util.SimpleInvalidationHandler;
 import org.mozilla.osmdroid.views.MapView;
 
 public class LowResMapOverlay extends AbstractMapOverlay {
-    private static final int LOW_ZOOM_LEVEL = 11;
+    public static final int LOW_ZOOM_LEVEL = 11;
 
     public LowResMapOverlay(LowResType type, final Context aContext, boolean isMLSTileStore, MapView mapView) {
         super(aContext);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/tiles/LowResMapOverlay.java
@@ -17,10 +17,10 @@ import org.mozilla.osmdroid.views.MapView;
 public class LowResMapOverlay extends AbstractMapOverlay {
     public static final int LOW_ZOOM_LEVEL = 11;
 
-    public LowResMapOverlay(LowResType type, final Context aContext, boolean isMLSTileStore, MapView mapView) {
+    public LowResMapOverlay(TileResType type, final Context aContext, boolean isMLSTileStore, MapView mapView) {
         super(aContext);
 
-        final int zoomLevel = (type == LowResType.HIGHER_ZOOM) ?
+        final int zoomLevel = (type == TileResType.HIGHER_ZOOM) ?
                 AbstractMapOverlay.getDisplaySizeBasedMinZoomLevel() : LOW_ZOOM_LEVEL;
 
         ITileSource mapTileSource;


### PR DESCRIPTION
First commit:
- cleanup some code
- make the full unlimited zoom mode apply only in high res mode

Second commit:
- add an additional coverage overlay that is used if zoom is lower than the current minimum coverage zoom level

Fixes #1506, fixes #1481
