### PR TITLE
Improve KML export

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -24,7 +24,6 @@ import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
-import org.mozilla.osmdroid.util.GeoPoint;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -150,7 +149,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
         if (position == null) {
             return;
         }
-        ObservationPoint observation = new ObservationPoint(new GeoPoint(position));
+        ObservationPoint observation = new ObservationPoint(position);
 
         try {
             observation.setCounts(bundle.toMLSGeosubmit());
@@ -172,9 +171,9 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
                 mCollectionPoints.remove(0);
             }
 
-            if (mCollectionPoints.size() > 0) {
-                final GeoPoint previous = mCollectionPoints.get(mCollectionPoints.size() - 1).pointGPS;
-                observation.mHeading = previous.bearingTo(observation.pointGPS);
+            if (mCollectionPoints.size() > 0 && !observation.pointGPS.hasBearing()) {
+                final Location previous = mCollectionPoints.get(mCollectionPoints.size() - 1).pointGPS;
+                observation.pointGPS.setBearing(previous.bearingTo(observation.pointGPS));
             }
             mCollectionPoints.add(observation);
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -173,7 +173,8 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             }
 
             if (mCollectionPoints.size() > 0) {
-                observation.mHeading = observation.pointGPS.bearingTo(mCollectionPoints.get(mCollectionPoints.size() - 1).pointGPS);
+                final GeoPoint previous = mCollectionPoints.get(mCollectionPoints.size() - 1).pointGPS;
+                observation.mHeading = previous.bearingTo(observation.pointGPS);
             }
             mCollectionPoints.add(observation);
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -26,26 +26,23 @@ public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallbac
     private static final ILogger Log = (ILogger) ServiceLocator.getInstance().getService(ILogger.class);
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ObservationPoint.class);
 
-    public final GeoPoint pointGPS;
+    public final Location pointGPS;
     public GeoPoint pointMLS;
-    public long mTimestamp;
     public int mWifiCount;
     public int mCellCount;
-    public boolean mWasReadFromFile;
-    public double mHeading;
     private JSONObject mMLSQuery;
     private boolean mIsMLSLocationQueryRunning;
 
-    public ObservationPoint(GeoPoint pointGPS) {
+    public ObservationPoint(Location pointGPS) {
         this.pointGPS = pointGPS;
-        mTimestamp = System.currentTimeMillis();
     }
 
-    public ObservationPoint(Coordinate pointGPS, int wifis, int cells/*, long timestamp*/) {
-        this.pointGPS = new GeoPoint(pointGPS.getLatitude(), pointGPS.getLongitude());
+    public ObservationPoint(String provider, Coordinate pointGPS, int wifis, int cells/*, long timestamp*/) {
+        this.pointGPS = new Location(provider);
+        this.pointGPS.setLatitude(pointGPS.getLatitude());
+        this.pointGPS.setLongitude(pointGPS.getLongitude());
         mWifiCount = wifis;
         mCellCount = cells;
-        /*mTimestamp = timestamp;*/
     }
 
     public void setMLSQuery(StumblerBundle stumbleBundle) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -15,11 +15,9 @@ import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageConstants;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
-import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
-import org.mozilla.osmdroid.util.GeoPoint;
 
 public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallback {
 
@@ -27,7 +25,7 @@ public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallbac
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ObservationPoint.class);
 
     public final Location pointGPS;
-    public GeoPoint pointMLS;
+    public Coordinate pointMLS;
     public int mWifiCount;
     public int mCellCount;
     private JSONObject mMLSQuery;
@@ -85,7 +83,7 @@ public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallbac
 
         if (location != null) {
             mMLSQuery = null; // todo decide how to persist this to kml
-            pointMLS = new GeoPoint(location);
+            pointMLS = new Coordinate(location.getLongitude(), location.getLatitude(), location.getAltitude());
         }
     }
 
@@ -98,7 +96,7 @@ public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallbac
     }
 
     public void setMLSCoordinate(Coordinate c) {
-        pointMLS = new GeoPoint(c.getLatitude(), c.getLongitude());
+        pointMLS = c;
     }
 
     public void errorMLSResponse(boolean stopRequesting) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -79,15 +79,15 @@ class ObservationPointsOverlay extends Overlay {
     }
 
     void update(ObservationPoint obsPoint, MapView mapView, boolean isMlsPointUpdate) {
-        final Projection pj = mapView.getProjection();
-        GeoPoint geoPoint = (isMlsPointUpdate) ? obsPoint.pointMLS : obsPoint.pointGPS;
-        if (geoPoint == null) {
+        if ((isMlsPointUpdate && obsPoint.pointMLS == null) ||
+                (!isMlsPointUpdate && obsPoint.pointGPS == null)) {
             ClientLog.w(LOG_TAG, "Caller error: geoPoint is null");
             return;
         }
-        final Point point = pj.toPixels(geoPoint, null);
 
         if (!isMlsPointUpdate) {
+            final Projection pj = mapView.getProjection();
+            final Point point = pj.toPixels(obsPoint.pointGPS.getLatitude(), obsPoint.pointGPS.getLongitude(), null);
             // add to hashed grid
             addToGridHash(obsPoint, point, new Point(mapView.getScrollX(), mapView.getScrollY()));
         }
@@ -131,7 +131,7 @@ class ObservationPointsOverlay extends Overlay {
             Point zero = new Point(0, 0);
             while (i.hasNext()) {
                 point = i.next();
-                pj.toPixels(point.pointGPS, gps);
+                pj.toPixels(point.pointGPS.getLatitude(), point.pointGPS.getLongitude(), gps);
                 addToGridHash(point, gps, zero);
             }
         }
@@ -177,7 +177,7 @@ class ObservationPointsOverlay extends Overlay {
             while (revIterator.hasPrevious()) {
                 HashMap.Entry<Integer, ObservationPoint> entry = revIterator.previous();
                 ObservationPoint point = entry.getValue();
-                pj.toPixels(point.pointGPS, gps);
+                pj.toPixels(point.pointGPS.getLatitude(), point.pointGPS.getLongitude(), gps);
 
                 if (!clip.contains(gps.x, gps.y)) {
                     continue;
@@ -210,7 +210,7 @@ class ObservationPointsOverlay extends Overlay {
                 HashMap.Entry<Integer, ObservationPoint> entry = revIterator.previous();
                 ObservationPoint point = entry.getValue();
                 if (point.pointMLS != null) {
-                    pj.toPixels(point.pointGPS, gps);
+                    pj.toPixels(point.pointGPS.getLatitude(), point.pointGPS.getLongitude(), gps);
                     pj.toPixels(point.pointMLS, mls);
                     drawDot(c, mls, radiusInnerRing - 1, mRedPaint, mBlackStrokePaintThin);
                     c.drawLine(gps.x, gps.y, mls.x, mls.y, mBlackMLSLinePaint);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -16,7 +16,6 @@ import android.os.SystemClock;
 import org.mozilla.mozstumbler.client.ObservedLocationsReceiver;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
-import org.mozilla.osmdroid.util.GeoPoint;
 import org.mozilla.osmdroid.views.MapView;
 import org.mozilla.osmdroid.views.Projection;
 import org.mozilla.osmdroid.views.overlay.Overlay;
@@ -25,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -211,7 +209,7 @@ class ObservationPointsOverlay extends Overlay {
                 ObservationPoint point = entry.getValue();
                 if (point.pointMLS != null) {
                     pj.toPixels(point.pointGPS.getLatitude(), point.pointGPS.getLongitude(), gps);
-                    pj.toPixels(point.pointMLS, mls);
+                    pj.toPixels(point.pointMLS.getLatitude(), point.pointMLS.getLongitude(), mls);
                     drawDot(c, mls, radiusInnerRing - 1, mRedPaint, mBlackStrokePaintThin);
                     c.drawLine(gps.x, gps.y, mls.x, mls.y, mBlackMLSLinePaint);
                 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/KMLFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/KMLFragment.java
@@ -160,7 +160,7 @@ public class KMLFragment extends Fragment
         final File dir = getActivity().getExternalFilesDir(null);
         final File file = new File(dir, name);
 
-        showProgress(true, getString(R.string.saving_kml) + " to " + (dir != null ? dir.toString() : "null"));
+        showProgress(true, getString(R.string.saving_kml) + " to " + (file != null ? file.toString() : "null")); // TODO: l10n
         ObservationPointSerializer obs = new ObservationPointSerializer(this,
                 ObservationPointSerializer.Mode.WRITE, file, mPointsToWrite);
         obs.execute();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
@@ -48,7 +48,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
     private static final String MLS_NAME = "MLS";
     private static final String ICON_RED_CIRCLE = "http://maps.google.com/mapfiles/kml/shapes/placemark_circle_highlight.png";
     private static final String STYLE_NAME_RED_CIRCLE = "redcircle";
-    private static final String ICON_ARROW = "http://maps.google.com/mapfiles/kml/shapes/arrow.png";
+    private static final String ICON_ARROW = "http://earth.google.com/images/kml-icons/track-directional/track-0.png";
     private static final String STYLE_NAME_ARROW = "arrow";
     private static final String COLOR_HAS_WIFI = "ffff0000"; //green in AABBGGRR
     private static final String COLOR_HAS_CELLS = "ff00ffff"; // yellow

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
@@ -41,6 +41,7 @@ import java.util.Map;
 // load -> show list to pick from
 
 public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
+    public static final String KML_PROVIDER = "KML_FILE";
     public static final String WIFIS = "Wi-Fis";
     public static final String CELLS = "Cells";
     private static final String LOG_TAG = LoggerUtil.makeLogTag(ObservationPointSerializer.class);
@@ -119,7 +120,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
                 // This point is in-progress in terms of scanning, don't write it out
                 continue;
             }
-            if (observationPoint.mWasReadFromFile) {
+            if (observationPoint.pointGPS.getProvider().equals(KML_PROVIDER)) {
                 // This was previously read in, don't write out again
                 continue;
             }
@@ -130,7 +131,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
             point.setCoordinates(observationPoint.getGPSCoordinate());
             Placemark placemark = new Placemark();
             placemark.setName(GPS_NAME);
-            DateTime dateTime = new DateTime(observationPoint.mTimestamp);
+            DateTime dateTime = new DateTime(observationPoint.pointGPS.getTime());
             TimeStamp time = new TimeStamp();
             time.setWhen(dateTime.toString() /* Date auto formats to RFC 3339 */);
             placemark.setTimePrimitive(time);
@@ -140,7 +141,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
                 color = COLOR_HAS_BOTH;
             }
 
-            setHeadingAndColor(placemark, observationPoint.mHeading, color);
+            setHeadingAndColor(placemark, observationPoint.pointGPS.getBearing(), color);
 
             List<Data> dataList = new LinkedList<Data>();
             Data data = new Data();
@@ -268,8 +269,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
                     }
                 }
 
-                ObservationPoint observationPoint = new ObservationPoint(coordinate, wifis, cells);
-                observationPoint.mWasReadFromFile = true;
+                ObservationPoint observationPoint = new ObservationPoint(KML_PROVIDER, coordinate, wifis, cells);
 
                 if (isGps) {
                     mPointList.add(observationPoint);
@@ -321,10 +321,10 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
     public enum Mode {READ, WRITE}
 
     public interface IListener {
-        public void onWriteComplete(File file);
+        void onWriteComplete(File file);
 
-        public void onReadComplete(File file);
+        void onReadComplete(File file);
 
-        public void onError();
+        void onError();
     }
 }

--- a/android/src/main/java/org/mozilla/osmdroid/views/Projection.java
+++ b/android/src/main/java/org/mozilla/osmdroid/views/Projection.java
@@ -98,7 +98,11 @@ public class Projection implements IProjection, MapViewConstants {
 
     @Override
     public Point toPixels(final IGeoPoint in, final Point reuse) {
-        Point out = TileSystem.LatLongToPixelXY(in.getLatitude(), in.getLongitude(),
+        return toPixels(in.getLatitude(), in.getLongitude(), reuse);
+    }
+
+    public Point toPixels(double latitude, double longitude, final Point reuse) {
+        Point out = TileSystem.LatLongToPixelXY(latitude, longitude,
                 getZoomLevel(), reuse);
 
         out = toPixelsFromMercator(out.x, out.y, out);

--- a/android/src/test/java/org/mozilla/mozstumbler/client/mapview/ObservationPointTest.java
+++ b/android/src/test/java/org/mozilla/mozstumbler/client/mapview/ObservationPointTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
 import org.mozilla.mozstumbler.service.stumblerthread.scanners.cellscanner.CellInfo;
-import org.mozilla.osmdroid.util.GeoPoint;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -50,7 +49,7 @@ public class ObservationPointTest {
     }
 
     private void testObservationCounts(StumblerBundle bundle, int cells, int wifis) {
-        ObservationPoint observation = new ObservationPoint(new GeoPoint(bundle.getGpsPosition()));
+        ObservationPoint observation = new ObservationPoint(bundle.getGpsPosition());
         try {
             observation.setCounts(bundle.toMLSGeosubmit());
         } catch (JSONException e) {


### PR DESCRIPTION
This fixes a bug in the KML export and hopefully cleans up some code.
1. The heading for an observation was computed from the current position to the previous one, which is in the wrong direction. The heading icon specified in the KML file was showing downwards at 0 heading, which visually compensated this bug.
2. I switched to use the `Location` class instead of `GeoPoint` in the `ObservationPoint` to store more of the original information (i.e. accuracy, speed, `hasAltitude`). This can later be used for GPX export (#490).
