### PR TITLE
Allow exporting points that have no radio data

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -155,7 +155,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
         try {
             observation.setCounts(bundle.toMLSGeosubmit());
 
-            boolean getInfoForMLS = prefs.isOptionEnabledToShowMLSOnMap();
+            boolean getInfoForMLS = prefs.isOptionEnabledToShowMLSOnMap() && bundle.hasRadioData();
             if (getInfoForMLS) {
                 observation.setMLSQuery(bundle);
 
@@ -183,12 +183,14 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
             return;
         }
 
-        getMapActivity().getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                addObservationPointToMap();
-            }
-        });
+        if (bundle.hasRadioData()) {
+            getMapActivity().getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    addObservationPointToMap();
+                }
+            });
+        }
     }
 
     private void addObservationPointToMap() {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/leaderboard/LBStumblerBundleReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/leaderboard/LBStumblerBundleReceiver.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.support.v4.content.LocalBroadcastManager;
 
-import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.stumblerthread.Reporter;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
@@ -59,7 +58,9 @@ public class LBStumblerBundleReceiver extends BroadcastReceiver {
         // Guard against LeaderBoard intents when we're not logged into FxA
         if (Prefs.getInstance(context).getBearerToken() != null) {
             final StumblerBundle bundle = intent.getParcelableExtra(Reporter.NEW_BUNDLE_ARG_BUNDLE);
-            mStorage.insert(bundle.getGpsPosition());
+            if (bundle.hasRadioData()) {
+                mStorage.insert(bundle.getGpsPosition());
+            }
         }
     }
 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPoint.java
@@ -8,12 +8,11 @@ import android.location.Location;
 
 import com.ekito.simpleKML.model.Coordinate;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
-import org.mozilla.mozstumbler.service.stumblerthread.datahandling.DataStorageConstants;
+import org.mozilla.mozstumbler.service.stumblerthread.datahandling.MLSJSONObject;
 import org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
@@ -54,12 +53,9 @@ public class ObservationPoint implements AsyncGeolocate.MLSLocationGetterCallbac
         }
     }
 
-    public void setCounts(JSONObject ichnaeaQueryObj) {
-        JSONArray cells = ichnaeaQueryObj.optJSONArray(DataStorageConstants.ReportsColumns.CELL);
-        mCellCount = (cells != null) ? cells.length() : 0;
-
-        JSONArray wifis = ichnaeaQueryObj.optJSONArray(DataStorageConstants.ReportsColumns.WIFI);
-        mWifiCount = (wifis != null) ? wifis.length() : 0;
+    public void setCounts(MLSJSONObject ichnaeaQueryObj) {
+        mCellCount = ichnaeaQueryObj.getCellCount();
+        mWifiCount = ichnaeaQueryObj.getWifiCount();
     }
 
     public void fetchMLS(boolean isWifiConnected, boolean isWifiAvailable) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/ObservationPointsOverlay.java
@@ -110,6 +110,9 @@ class ObservationPointsOverlay extends Overlay {
     }
 
     private void addToGridHash(ObservationPoint obsPoint, Point screenPoint, Point currentScroll) {
+        if (obsPoint.mCellCount == 0 && obsPoint.mWifiCount == 0) {
+            return;
+        }
         int hash = hashedGridPoint(screenPoint.x, screenPoint.y, currentScroll.x, currentScroll.y);
         ObservationPoint gp = mHashedGrid.get(hash);
         if (gp == null || toTypeBitField(obsPoint) > toTypeBitField(gp)) {
@@ -184,12 +187,12 @@ class ObservationPointsOverlay extends Overlay {
                 boolean hasWifiScan = point.mWifiCount > 0;
                 boolean hasCellScan = point.mCellCount > 0;
 
-                if (hasWifiScan && !hasCellScan) {
-                    drawWifiScan(c, gps);
-                } else if (hasCellScan && !hasWifiScan) {
-                    drawCellScan(c, gps);
-                } else {
+                if (hasCellScan && hasWifiScan) {
                     drawDot(c, gps, radiusInnerRing, mGreenPaint, mBlackStrokePaint);
+                } else if (hasWifiScan) {
+                    drawWifiScan(c, gps);
+                } else if (hasCellScan) {
+                    drawCellScan(c, gps);
                 }
 
                 if ((++count % TIME_CHECK_MULTIPLE == 0) && (SystemClock.uptimeMillis() > endTime)) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/GpxObservationPointSerializer.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/GpxObservationPointSerializer.java
@@ -6,8 +6,11 @@ package org.mozilla.mozstumbler.client.serialize;
 
 import android.location.Location;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.util.Log;
 
+import org.mozilla.mozstumbler.BuildConfig;
+import org.mozilla.mozstumbler.service.AppGlobals;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
@@ -47,15 +50,17 @@ public class GpxObservationPointSerializer extends AsyncTask<Void, Void, Boolean
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         Gpx gpx = new Gpx();
+        gpx.creator = "Mozilla Stumbler " + BuildConfig.VERSION_NAME;
+        if (AppGlobals.isDebug) {
+            gpx.creator += " (" + BuildConfig.GIT_DESCRIPTION + ")";
+        }
 
         Trk trk = new Trk();
         gpx.trk.add(trk);
 
         Trkseg seg;
         for (ObservationPoint observationPoint : mPointList) {
-            if ((observationPoint.mWifiCount < 1 && observationPoint.mCellCount < 1)
-                    || observationPoint.mTrackSegment < 0) {
-                // This point is in-progress in terms of scanning, don't write it out
+            if (observationPoint.mTrackSegment < 0) {
                 continue;
             }
 
@@ -121,12 +126,13 @@ public class GpxObservationPointSerializer extends AsyncTask<Void, Void, Boolean
             @Namespace(reference="http://www.w3.org/2001/XMLSchema-instance", prefix="xsi")
     })
     static class Gpx {
+        // TODO optional: time, bounds, author
         @Attribute
         static final String version = "1.1";
         @Attribute
-        static final String creator = "Mozilla Stumbler";
-        @Attribute
         static final String schemaLocation = "http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd";
+        @Attribute
+        String creator;
 
         @ElementList(inline=true)
         List<Trk> trk;
@@ -138,6 +144,8 @@ public class GpxObservationPointSerializer extends AsyncTask<Void, Void, Boolean
 
     @Root
     static class Trk {
+        @Element
+        static final String src = Build.MANUFACTURER + " " + Build.MODEL + " (" + Build.HARDWARE + ")";
         @ElementList(inline=true)
         List<Trkseg> trkseg;
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/serialize/ObservationPointSerializer.java
@@ -52,9 +52,10 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
     private static final String STYLE_NAME_RED_CIRCLE = "redcircle";
     private static final String ICON_ARROW = "http://earth.google.com/images/kml-icons/track-directional/track-0.png";
     private static final String STYLE_NAME_ARROW = "arrow";
-    private static final String COLOR_HAS_WIFI = "ffff0000"; //green in AABBGGRR
-    private static final String COLOR_HAS_CELLS = "ff00ffff"; // yellow
-    private static final String COLOR_HAS_BOTH = "ff00ff00"; // blue
+    private static final String COLOR_HAS_WIFI = "ff0000ff"; // red in AABBGGRR
+    private static final String COLOR_HAS_CELLS = "ffff0000"; // blue
+    private static final String COLOR_HAS_BOTH = "ff00ff00"; // green
+    private static final String COLOR_HAS_NONE = "aa000000"; // transparent black
     final WeakReference<IListener> mObservationPointSerializerListener;
     private final LinkedList<ObservationPoint> mPointList;
     private File mFile;
@@ -117,10 +118,6 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
         List<Feature> mlsFeatures = new LinkedList<Feature>();
         int idCounter = 0;
         for (ObservationPoint observationPoint : mPointList) {
-            if (observationPoint.mWifiCount < 1 && observationPoint.mCellCount < 1) {
-                // This point is in-progress in terms of scanning, don't write it out
-                continue;
-            }
             if (observationPoint.pointGPS.getProvider().equals(KML_PROVIDER)) {
                 // This was previously read in, don't write out again
                 continue;
@@ -137,9 +134,13 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
             time.setWhen(dateTime.toString() /* Date auto formats to RFC 3339 */);
             placemark.setTimePrimitive(time);
 
-            String color = (observationPoint.mWifiCount > 0) ? COLOR_HAS_WIFI : COLOR_HAS_CELLS;
+            String color = COLOR_HAS_NONE;
             if (observationPoint.mWifiCount > 0 && observationPoint.mCellCount > 0) {
                 color = COLOR_HAS_BOTH;
+            } else if (observationPoint.mWifiCount > 0) {
+                color = COLOR_HAS_WIFI;
+            } else if (observationPoint.mCellCount > 0) {
+                color = COLOR_HAS_CELLS;
             }
 
             setHeadingAndColor(placemark, observationPoint.pointGPS.getBearing(), color);
@@ -183,7 +184,7 @@ public class ObservationPointSerializer extends AsyncTask<Void, Void, Boolean> {
 
         Document doc = new Document();
         addStyle(doc, ICON_RED_CIRCLE, STYLE_NAME_RED_CIRCLE, null);
-        addStyle(doc, ICON_ARROW, STYLE_NAME_ARROW, 0.7f);
+        addStyle(doc, ICON_ARROW, STYLE_NAME_ARROW, 1.2f);
 
         List<Feature> docFeatures = new LinkedList<Feature>();
         docFeatures.add(createFolder(GPS_NAME, gpsFeatures));

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -191,16 +191,12 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
             return;
         }
 
-        if (geoSubmitJSON.radioCount() < 1) {
-            mBundle = null;
-            return;
+        if (geoSubmitJSON.radioCount() > 0) {
+            DataStorageManager.getInstance().insert(geoSubmitJSON);
+            mObservationCount++;
+            mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());
+            mUniqueCells.addAll(mBundle.getUnmodifiableCellData().keySet());
         }
-
-        DataStorageManager.getInstance().insert(geoSubmitJSON);
-
-        mObservationCount++;
-        mUniqueAPs.addAll(mBundle.getUnmodifiableWifiData().keySet());
-        mUniqueCells.addAll(mBundle.getUnmodifiableCellData().keySet());
 
         Intent i = new Intent(ACTION_NEW_BUNDLE);
         i.putExtra(NEW_BUNDLE_ARG_BUNDLE, mBundle);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -78,6 +78,12 @@ public final class StumblerBundle implements Parcelable {
         return mTrackSegment;
     }
 
+    public boolean hasRadioData() {
+        boolean hasCellData = mCellData != null && !mCellData.isEmpty();
+        boolean hasWifiData = mWifiData != null && !mWifiData.isEmpty();
+        return hasCellData || hasWifiData;
+    }
+
     public Map<String, ScanResult> getUnmodifiableWifiData() {
         if (mWifiData == null) {
             return null;


### PR DESCRIPTION
GPX tracks (#490) are incomplete when the path contains observations without radio data.
The second commit modifies the `Reporter` to also send intents for observations without radio data, but without counting or adding them to the `DataStorageManager`. They are also filtered in the client so that they are not displayed on the map.
