### PR TITLE
Bugzilla 1171213: remove multiprocess flag on prefs

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
@@ -53,7 +53,7 @@ public class Prefs {
     private final boolean mSignificantMotionDefaultValue;
 
     protected Prefs(Context context) {
-        mSharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_MULTI_PROCESS | Context.MODE_PRIVATE);
+        mSharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
         if (getPrefs().getInt(VALUES_VERSION_PREF, -1) != AppGlobals.appVersionCode) {
             Log.i(LOG_TAG, "Version of the application has changed. Updating default values.");
             // Remove old keys


### PR DESCRIPTION
We are no longer using a multi-process model, this flag isn't needed.
