### PR TITLE
Simple high-power mode

### DIFF
--- a/android/src/main/res/layout/fragment_developer_options.xml
+++ b/android/src/main/res/layout/fragment_developer_options.xml
@@ -70,10 +70,26 @@
         android:background="#55ffffff" />
 
     <CheckBox
-        android:id="@+id/toggleSimulation"
+        android:id="@+id/toggleHighPowerMode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/line_passive"
+        android:text="@string/use_high_power_mode" />
+
+    <View
+        android:layout_below="@id/toggleHighPowerMode"
+        android:id="@+id/line_high_power"
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:layout_marginBottom="10dp"
+        android:layout_marginTop="10dp"
+        android:background="#55ffffff" />
+
+    <CheckBox
+        android:id="@+id/toggleSimulation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/line_high_power"
         android:text="@string/enable_simulation" />
 
     <Button

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="ok">OK</string>
     <string name="limit_map_zoom">Limit zooming out on map</string>
     <string name="use_passive_scanning">Test Passive Scanning</string>
+    <string name="use_high_power_mode">High Power Mode</string>
     <string name="test_significant_sensor_dialog_title">Test Significant Motion Sensor</string>
     <string name="test_significant_sensor_dialog_message">Stand still, then walk for 1 minute.\n\nDetecting movement &#8230;</string>
     <string name="test_significant_sensor_confirmed_working">Motion detected.\nThe sensor is functioning normally.</string>

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/AppGlobals.java
@@ -25,8 +25,6 @@ public class AppGlobals {
 
     /* Location constructor requires a named origin, these are created in the app. */
     public static final String LOCATION_ORIGIN_INTERNAL = "internal";
-    /* In passive mode, only scan this many times for each gps. */
-    public static final int MAX_SCANS_PER_GPS = 2;
     public static final String NO_TRUNCATE_FLAG = "~";
     public static final String ACTION_TEST_SETTING_ENABLED = "stumbler-test-setting-enabled";
     public static final String ACTION_TEST_SETTING_DISABLED = "stumbler-test-setting-disabled";

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/Prefs.java
@@ -45,6 +45,7 @@ public class Prefs {
     private static final String SAVE_STUMBLE_LOGS = "save_stumble_logs";
 
     private static final String USE_OFFLINE_GEO = "use_offline_geo";
+    private static final String USE_HIGH_POWER = "use_high_power";
     public static final String FXA_LOGIN_PREF = "fxaLogin";
 
     protected static Prefs sInstance;
@@ -318,6 +319,14 @@ public class Prefs {
 
     public void setOfflineGeo(boolean offlineGeo) {
         setBoolPref(USE_OFFLINE_GEO, offlineGeo);
+    }
+
+    public boolean isHighPowerMode() {
+        return getPrefs().getBoolean(USE_HIGH_POWER, false);
+    }
+
+    public void setIsHighPowerMode(boolean highPower) {
+        setBoolPref(USE_HIGH_POWER, highPower);
     }
 
     public void setBearerToken(String bearerToken) {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/CellScanner.java
@@ -30,6 +30,7 @@ public class CellScanner {
     public static final String ACTION_CELLS_SCANNED_ARG_CELLS = "cells";
     public static final String ACTION_CELLS_SCANNED_ARG_TIME = AppGlobals.ACTION_ARG_TIME;
 
+    private static final int MAX_SCANS_PER_GPS = 2;
     private static final long CELL_MIN_UPDATE_TIME = 1000; // milliseconds
 
     private final Context mAppContext;
@@ -89,7 +90,7 @@ public class CellScanner {
                     return;
                 }
 
-                if (mScanCount.incrementAndGet() > AppGlobals.MAX_SCANS_PER_GPS) {
+                if (mScanCount.incrementAndGet() > MAX_SCANS_PER_GPS) {
                     stop();
                     return;
                 }


### PR DESCRIPTION
Basically fixes #1386. It should also increase the accuracy of exported GPS tracks (#490) when enabled.

Effects:
- Allow scans every 15m (instead of 30m), but still only every 2s (~27km/h)
- Scan for WiFi every 2s (instead of 4s)
- Allow max of 3 WiFi scans per GPS position (instead of 2)
