### PR TITLE
getNeighboringCellInfo() is deprecated on Android M.

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/SimpleCellScannerImplementation.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/cellscanner/SimpleCellScannerImplementation.java
@@ -168,6 +168,11 @@ public class SimpleCellScannerImplementation implements ISimpleCellScanner {
     }
 
     private List<CellInfo> getNeighboringCells() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("deprecation")
         Collection<NeighboringCellInfo> cells = mTelephonyManager.getNeighboringCellInfo();
         if (cells == null || cells.isEmpty()) {
             return Collections.emptyList();


### PR DESCRIPTION
On Android M, don't call this function, and on older OS's keep using it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1195854
