### PR TITLE
Fix zoom

### DIFF
--- a/android/src/main/java/org/mozilla/osmdroid/events/DelayedMapListener.java
+++ b/android/src/main/java/org/mozilla/osmdroid/events/DelayedMapListener.java
@@ -25,7 +25,8 @@ public class DelayedMapListener implements MapListener {
      */
     protected long delay;
     protected Handler handler;
-    protected CallbackTask callback;
+    protected CallbackTask callbackScroll;
+    protected CallbackTask callbackZoom;
     /**
      * The wrapped MapListener
      */
@@ -40,7 +41,8 @@ public class DelayedMapListener implements MapListener {
         this.wrappedListener = wrappedListener;
         this.delay = delay;
         this.handler = new Handler();
-        this.callback = null;
+        this.callbackScroll = null;
+        this.callbackZoom = null;
     }
 
     /*
@@ -54,20 +56,20 @@ public class DelayedMapListener implements MapListener {
 
     @Override
     public boolean onScroll(final ScrollEvent event) {
-        dispatch(event);
+        callbackScroll = dispatch(event, callbackScroll);
         return true;
     }
 
     @Override
     public boolean onZoom(final ZoomEvent event) {
-        dispatch(event);
+        callbackZoom = dispatch(event, callbackZoom);
         return true;
     }
 
     /*
      * Process an incoming MapEvent.
      */
-    protected void dispatch(final MapEvent event) {
+    protected CallbackTask dispatch(final MapEvent event, CallbackTask callback) {
         // cancel any pending callback
         if (callback != null) {
             handler.removeCallbacks(callback);
@@ -76,6 +78,7 @@ public class DelayedMapListener implements MapListener {
 
         // set timer
         handler.postDelayed(callback, delay);
+        return callback;
     }
 
     // Callback tasks


### PR DESCRIPTION
In some cases, especially when using pinch to zoom, the coverage overlay mode is not updated.

There is a `MapListener` in [MapFragment.java#L171](https://github.com/mozilla/MozStumbler/blob/dev/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java#L171) to trigger `updateOverlayCoverageLayer`. 
But the `DelayedMapListener` will sometimes cancel a zoom event when dispatching a scroll event. So as a result the zoom listener will not run.

Using separate `Runnables` in `DelayedMapListener` fixes the problem.

Not using `DelayedMapListener` also fixes the problem, but I do not know if that is somehow otherwise problematic. The code was introduced in d8e1faae9f88c269d41fd759d561b42789fa192f. 
