### PR TITLE
Adds millisec timestamp from epoch for GPS and Wifi

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/Reporter.java
@@ -161,9 +161,9 @@ public final class Reporter extends BroadcastReceiver implements IReporter {
         if (mBundle == null) {
             return;
         }
-        for (ScanResult result : results) {
-            String key = result.BSSID;
-            mBundle.addWifiData(key, result);
+        for (ScanResult scanResult: results) {
+            String key = scanResult.BSSID;
+            mBundle.addWifiData(key, scanResult);
         }
     }
 

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/StumblerService.java
@@ -111,10 +111,6 @@ public class StumblerService extends PersistentIntentService
         return Prefs.getInstance(c);
     }
 
-    public synchronized Location getLocation() {
-        return mScanManager.getLocation();
-    }
-
     private synchronized int getVisibleAPCount() {
         return mScanManager.getVisibleAPCount();
     }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -105,7 +105,6 @@ public final class StumblerBundle implements Parcelable {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     public MLSJSONObject toMLSGeosubmit() throws JSONException {
-        ISystemClock clock = (ISystemClock) ServiceLocator.getInstance().getService(ISystemClock.class);
         MLSJSONObject headerFields = new MLSJSONObject();
         headerFields.put(DataStorageConstants.ReportsColumns.LAT, Math.floor(mGpsPosition.getLatitude() * 1.0E6) / 1.0E6);
         headerFields.put(DataStorageConstants.ReportsColumns.LON, Math.floor(mGpsPosition.getLongitude() * 1.0E6) / 1.0E6);
@@ -134,6 +133,8 @@ public final class StumblerBundle implements Parcelable {
 
         if (mWifiData.size() > 0) {
             JSONArray wifis = new JSONArray();
+
+            long gpsTimeSinceBootInMS = (mGpsPosition.getElapsedRealtimeNanos()/1000000);
             for (ScanResult scanResult : mWifiData.values()) {
                 JSONObject wifiEntry = new JSONObject();
                 wifiEntry.put("macAddress", scanResult.BSSID);
@@ -144,7 +145,6 @@ public final class StumblerBundle implements Parcelable {
                     wifiEntry.put("signalStrength", scanResult.level);
                 }
 
-                long gpsTimeSinceBootInMS = (mGpsPosition.getElapsedRealtimeNanos()/1000000);
                 long wifiTimeSinceBootInMS = (scanResult.timestamp / 1000);
                 long ageMS =  wifiTimeSinceBootInMS - gpsTimeSinceBootInMS;
                 wifiEntry.put("age", ageMS);

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/scanners/ScanManager.java
@@ -314,9 +314,5 @@ public class ScanManager {
         return (mGPSScanner == null) ? 0 : mGPSScanner.getLocationCount();
     }
 
-    public Location getLocation() {
-        return (mGPSScanner == null) ? new Location("null") : mGPSScanner.getLocation();
-    }
-
     private enum PassiveModeBatteryState {OK, LOW, IGNORE_BATTERY_STATE}
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/ISystemClock.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/ISystemClock.java
@@ -11,4 +11,7 @@ public interface ISystemClock {
 
     // Implementations should provide an implementation of System.currentTimeMillis
     public long currentTimeMillis();
+
+    // Returns milliseconds since boot for the device, including time spent in sleep.
+    public long elapsedRealtime();
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/MockSystemClock.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/MockSystemClock.java
@@ -6,13 +6,22 @@ package org.mozilla.mozstumbler.svclocator.services;
 public class MockSystemClock implements ISystemClock {
 
     private long currentTime;
+    private long elapsedTime;
 
     public void setCurrentTime(long currentTime) {
         this.currentTime = currentTime;
+    }
+    public void setElapsedRealtime(long elapsedTime) {
+        this.elapsedTime = elapsedTime;
     }
 
     @Override
     public long currentTimeMillis() {
         return currentTime;
+    }
+
+    @Override
+    public long elapsedRealtime() {
+        return elapsedTime;
     }
 }

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/SystemClock.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/svclocator/services/SystemClock.java
@@ -9,4 +9,10 @@ public class SystemClock implements ISystemClock {
     public long currentTimeMillis() {
         return System.currentTimeMillis();
     }
+
+    @Override
+    public long elapsedRealtime() {
+        return android.os.SystemClock.elapsedRealtime();
+    }
+
 }


### PR DESCRIPTION
- add timestamps for wifi on geosubmit
- dropped unused getLocation methods
- added a proper timestamp fixture into the geosubmit test

Both timestamps are millisecond accuracy from the epoch.  The top level timestamp for the geosubmit blob is extracted from the GPS scan.
