### PR TITLE
Bugfix for #1760

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 test: libtest unittest
 	./gradlew copyTestResources
-	./gradlew testGithubLbDevUnittest --info
+	./gradlew testGithubLbprodUnittest --info
 
 libtest:
 	cd libraries/stumbler; ./gradlew test
 
 unittest:
-	./gradlew assembleGithubLbdevUnittest
+	./gradlew assembleGithubLbprodUnittest
 
 debug:
-	./gradlew assembleGithubLbdevDebug
+	./gradlew assembleGithubLbprodDebug
 
 github:
 	./release_check.py github
@@ -31,4 +31,4 @@ clean:
 	./gradlew clean
 
 install_debug:
-	./gradlew installGithubLbdevDebug
+	./gradlew installGithubLbprodDebug

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // each of the version numbers must be 0-99
 def versionMajor = 1
 def versionMinor = 8 // minor feature releases
-def versionPatch = 1 // This should be bumped for hot fixes
+def versionPatch = 3 // This should be bumped for hot fixes
 
 // Double check the versioning
 for (versionPart in [versionPatch, versionMinor, versionMajor]) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -343,6 +343,6 @@ project.archivesBaseName = "MozStumbler";
 
 task copyTestResources(type: Copy) {
     from "${projectDir}/src/test/res"
-    into "${buildDir}/test-classes/githublbdev/unittest"
+    into "${buildDir}/test-classes/githublbprod/unittest"
 }
 check.dependsOn copyTestResources

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -40,6 +40,8 @@ public class ClientPrefs extends Prefs {
     private static final String FXA_OAUTH2_SERVER = "org.mozilla.mozstumbler.fxa_oauth2_server";
     private static final String FXA_SCOPES = "org.mozilla.mozstumbler.client.fxa_scopes";
 
+    private static final String FXA_ENABLED = "org.mozilla.mozstumbler.client.fxa_enabled";
+
     protected ClientPrefs(Context context) {
         super(context);
     }
@@ -61,6 +63,10 @@ public class ClientPrefs extends Prefs {
     // For Mozilla Stumbler to use for manual upgrade of old prefs.
     static String getPrefsFileNameForUpgrade() {
         return PREFS_FILE;
+    }
+
+    public synchronized void setFxaEnabled(boolean on) {
+        setBoolPref(FXA_ENABLED, on);
     }
 
     public String getFxaOauth2Server() {
@@ -240,6 +246,10 @@ public class ClientPrefs extends Prefs {
 
     public void setFxaProfileServer(String fxaProfileServer) {
         setStringPref(FXA_PROFILE_SERVER, fxaProfileServer);
+    }
+
+    public synchronized boolean isFxaEnabled() {
+        return getBoolPrefWithDefault(FXA_ENABLED, false);
     }
 
     public enum MapTileResolutionOptions {Default, HighRes, LowRes, NoMap}

--- a/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/MainApp.java
@@ -180,6 +180,11 @@ public class MainApp extends Application
         mMainActivity = new WeakReference<IMainActivity>(mainActivity);
     }
 
+
+    public IMainActivity getMainActivity() {
+        return mMainActivity.get();
+    }
+
     private File getCacheDir(Context c) {
         File dir = c.getExternalCacheDir();
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MainDrawerActivity.java
@@ -82,21 +82,27 @@ public class MainDrawerActivity
             }
 
             int count = intent.getIntExtra("count", 0);
-            if (intent.getAction().equals(StumblerServiceIntentActions.SVC_RESP_VISIBLE_AP)) {
-                mSvcVisibleAP = count;
-            } else if (intent.getAction().equals(StumblerServiceIntentActions.SVC_RESP_VISIBLE_CELL)) {
-                mSvcVisibleCell = count;
-            } else if (intent.getAction().equals(StumblerServiceIntentActions.SVC_RESP_OBSERVATION_PT)) {
-                mSvcObservationPoints = count;
-            } else if (intent.getAction().equals(StumblerServiceIntentActions.SVC_RESP_UNIQUE_CELL_COUNT)) {
-                mSvcUniqueCell = count;
-            } else if (intent.getAction().equals(StumblerServiceIntentActions.SVC_RESP_UNIQUE_WIFI_COUNT)) {
-                mSvcUniqueAP = count;
+            switch (intent.getAction()) {
+                case StumblerServiceIntentActions.SVC_RESP_VISIBLE_AP:
+                    mSvcVisibleAP = count;
+                    break;
+                case StumblerServiceIntentActions.SVC_RESP_VISIBLE_CELL:
+                    mSvcVisibleCell = count;
+                    break;
+                case StumblerServiceIntentActions.SVC_RESP_OBSERVATION_PT:
+                    mSvcObservationPoints = count;
+                    break;
+                case StumblerServiceIntentActions.SVC_RESP_UNIQUE_CELL_COUNT:
+                    mSvcUniqueCell = count;
+                    break;
+                case StumblerServiceIntentActions.SVC_RESP_UNIQUE_WIFI_COUNT:
+                    mSvcUniqueAP = count;
+                    break;
             }
         };
     };
-    private AtomicBoolean initializeIntentFilters = new AtomicBoolean(false);
 
+    private AtomicBoolean initializeIntentFilters = new AtomicBoolean(false);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -240,6 +246,20 @@ public class MainDrawerActivity
     }
 
     @Override
+    public synchronized boolean onPrepareOptionsMenu (Menu menu) {
+        if (menu == null) { return true; }
+
+        ClientPrefs prefs = ClientPrefs.getInstance(this);
+        for (int i = 0; i < menu.size(); i++ ) {
+            MenuItem item = menu.getItem(i);
+            if (item.getItemId() == R.id.action_view_leaderboard) {
+                item.setEnabled(prefs.isFxaEnabled());
+            }
+        }
+        return true;
+    }
+
+    @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         // Sync the toggle state after onRestoreInstanceState has occurred.
@@ -311,6 +331,10 @@ public class MainDrawerActivity
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
+
+                // Force the leaderboard menu item to update it's enabled status
+                invalidateOptionsMenu();
+
                 if (mMapFragment == null || mMapFragment.getActivity() == null) {
                     return;
                 }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -436,7 +436,6 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
             mFxaLoginPreference.setTitle(getString(R.string.fxa_settings_title));
             mFxaLoginPreference.setSummary(getString(R.string.fxaDescription));
             mNicknamePreference.setEnabled(false);
-            enableLeaderboardMenuItem(false);
         }
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -120,6 +120,15 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
 
     }
 
+    /*
+     We enable the leaderboard button in either of two scenarios:
+      a) the leaderboard FxA configuration was valid
+      b) the user is signed into FxA
+
+      Both of these state transitions indicate that FxA is 'mostly' live
+      with respect to the leaderboard, so it should be ok to either start the signon
+      process to FxA via leaderboard, or display the user's leaderboard page.
+     */
     private void enableLeaderboardMenuItem(boolean b) {
         ClientPrefs clientPrefs = ClientPrefs.getInstance(this);
         clientPrefs.setFxaEnabled(b);


### PR DESCRIPTION
This should fix #1760 by testing if FxA config was loaded and forcing the leaderboard menu item to be enabled/disabled based on logins and fxa config loading.
