### PR TITLE
Features/bug 1764

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // each of the version numbers must be 0-99
 def versionMajor = 1
 def versionMinor = 8 // minor feature releases
-def versionPatch = 1 // This should be bumped for hot fixes
+def versionPatch = 3 // This should be bumped for hot fixes
 
 // Double check the versioning
 for (versionPart in [versionPatch, versionMinor, versionMajor]) {

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -411,6 +411,7 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
 
     private void setNicknamePreferenceTitle(String displayName) {
         if (!TextUtils.isEmpty(displayName)) {
+            mNicknamePreference.setEnabled(true);
             String title = String.format(getString(R.string.enter_nickname_title), displayName);
             mNicknamePreference.setTitle(title);
         } else {


### PR DESCRIPTION
Fix for #1764 - force the nickname field to be enabled if we write a non-empty value to it.
