### PR TITLE
dropped the clickbox from the metrics view to enable MLS queries

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientPrefs.java
@@ -16,7 +16,8 @@ import org.mozilla.osmdroid.util.GeoPoint;
 public class ClientPrefs extends Prefs {
     public static final String MAP_TILE_RESOLUTION_TYPE = "map_tile_res_options";
     public static final String KEEP_SCREEN_ON_PREF = "keep_screen_on";
-    public static final String ENABLE_OPTION_TO_SHOW_MLS_ON_MAP = "enable_the_option_to_show_mls_on_map";
+
+
     public static final String CRASH_REPORTING = "crash_reporting";
     public static final int MIN_BATTERY_DEFAULT = 15;
     public static final String LAST_VERSION = "last_version";
@@ -26,7 +27,9 @@ public class ClientPrefs extends Prefs {
     private static final String LAT_PREF = "lat";
     private static final String LON_PREF = "lon";
     private static final String IS_FIRST_RUN = "is_first_run";
-    private static final String ON_MAP_MLS_DRAW_IS_ON = "actually_draw_mls_dots_on_map";
+
+    public static final String ENABLE_OPTION_TO_SHOW_MLS_ON_MAP = "enable_the_option_to_show_mls_on_map";
+
     private static final String DEFAULT_SIMULATION_LAT_LONG = "default_simulation_lat_lon";
     private static final String MIN_BATTERY_PCT = "min_battery_pct";
 
@@ -150,13 +153,16 @@ public class ClientPrefs extends Prefs {
         setBoolPref(KEEP_SCREEN_ON_PREF, on);
     }
 
-    public boolean getOnMapShowMLS() {
-        return getBoolPrefWithDefault(ON_MAP_MLS_DRAW_IS_ON, false);
+    /****************/
+    public boolean showMLSQueryResults() {
+        return getBoolPrefWithDefault(ENABLE_OPTION_TO_SHOW_MLS_ON_MAP, false);
     }
 
-    public void setOnMapShowMLS(boolean on) {
-        setBoolPref(ON_MAP_MLS_DRAW_IS_ON, on);
+    public void enableMLSQueryResults(boolean isEnabled) {
+        setBoolPref(ENABLE_OPTION_TO_SHOW_MLS_ON_MAP, isEnabled);
     }
+    /****************/
+
 
     public boolean isFirstRun() {
         return getBoolPrefWithDefault(IS_FIRST_RUN, true);
@@ -166,16 +172,6 @@ public class ClientPrefs extends Prefs {
         setBoolPref(IS_FIRST_RUN, b);
     }
 
-    public boolean isOptionEnabledToShowMLSOnMap() {
-        return getBoolPrefWithDefault(ENABLE_OPTION_TO_SHOW_MLS_ON_MAP, false);
-    }
-
-    public void setOptionEnabledToShowMLSOnMap(boolean isEnabled) {
-        setBoolPref(ENABLE_OPTION_TO_SHOW_MLS_ON_MAP, isEnabled);
-        // have this pref follow the parent pref, so when the parent is turned on
-        // this starts in the on state, and when parent is off, this pref is off
-        setOnMapShowMLS(isEnabled);
-    }
 
     public boolean isCrashReportingEnabled() {
         // default to true for GITHUB build

--- a/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ObservedLocationsReceiver.java
@@ -90,7 +90,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
                 NetworkInfo networkInfo = new NetworkInfo(mContext);
 
                 mHandler.postDelayed(mFetchMLSRunnable, FREQ_FETCH_MLS_MS);
-                if (mQueuedForMLS.size() < 1 || !prefs.getOnMapShowMLS()) {
+                if (mQueuedForMLS.size() < 1 || !prefs.showMLSQueryResults()) {
                     return;
                 }
                 int count = 0;
@@ -155,7 +155,7 @@ public class ObservedLocationsReceiver extends BroadcastReceiver {
         try {
             observation.setCounts(bundle.toMLSGeosubmit());
 
-            boolean getInfoForMLS = prefs.isOptionEnabledToShowMLSOnMap() && bundle.hasRadioData();
+            boolean getInfoForMLS = prefs.showMLSQueryResults() && bundle.hasRadioData();
             if (getInfoForMLS) {
                 observation.setMLSQuery(bundle);
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/mapview/MapFragment.java
@@ -574,7 +574,7 @@ public class MapFragment extends android.support.v4.app.Fragment
 
         mHighLowBandwidthChecker = new HighLowBandwidthReceiver(this);
 
-        setShowMLS(prefs.getOnMapShowMLS());
+        setShowMLS(prefs.showMLSQueryResults());
 
         mObservationPointsOverlay.zoomChanged(mMap);
         mMap.postInvalidate();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/navdrawer/MetricsView.java
@@ -58,7 +58,6 @@ public class MetricsView {
             mThisSessionObservationsView,
             mThisSessionUniqueCellsView,
             mThisSessionUniqueAPsView;
-    private final CheckBox mOnMapShowMLS;
     private final Handler mHandler = new Handler(Looper.getMainLooper());
     private final long FREQ_UPDATE_UPLOADTIME = 10 * 1000;
     private final ImageButton mUploadButton;
@@ -85,18 +84,6 @@ public class MetricsView {
                     }
                 },
                 new IntentFilter(PersistedStats.ACTION_PERSISTENT_SYNC_STATUS_UPDATED));
-
-        mOnMapShowMLS = (CheckBox) mView.findViewById(R.id.checkBox_show_mls);
-        mOnMapShowMLS.setVisibility(View.GONE);
-        mOnMapShowMLS.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ClientPrefs.getInstance(mView.getContext()).setOnMapShowMLS(mOnMapShowMLS.isChecked());
-                if (mMapLayerToggleListener.get() != null) {
-                    mMapLayerToggleListener.get().setShowMLS(mOnMapShowMLS.isChecked());
-                }
-            }
-        });
 
         mLastUpdateTimeView = (TextView) mView.findViewById(R.id.last_upload_time_value);
         mAllTimeObservationsSentView = (TextView) mView.findViewById(R.id.observations_sent_value);
@@ -179,7 +166,6 @@ public class MetricsView {
 
     public void setMapLayerToggleListener(IMapLayerToggleListener listener) {
         mMapLayerToggleListener = new WeakReference<IMapLayerToggleListener>(listener);
-        mOnMapShowMLS.setChecked(ClientPrefs.getInstance(mView.getContext()).getOnMapShowMLS());
     }
 
     private void updateUploadButtonEnabled() {
@@ -215,12 +201,6 @@ public class MetricsView {
     }
 
     public void update() {
-        if (ClientPrefs.getInstance(mView.getContext()).isOptionEnabledToShowMLSOnMap()) {
-            mOnMapShowMLS.setVisibility(View.VISIBLE);
-        } else {
-            mOnMapShowMLS.setVisibility(View.GONE);
-        }
-
         updatePowerSavingsLabels();
         updateQueuedStats();
         updateSentStats();

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -18,7 +18,6 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
-import android.support.v4.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
@@ -40,17 +39,13 @@ import org.mozilla.mozstumbler.R;
 import org.mozilla.mozstumbler.client.ClientPrefs;
 import org.mozilla.mozstumbler.client.IMainActivity;
 import org.mozilla.mozstumbler.client.MainApp;
-import org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity;
 import org.mozilla.mozstumbler.service.Prefs;
-import org.mozilla.mozstumbler.service.stumblerthread.StumblerService;
-import org.mozilla.mozstumbler.service.stumblerthread.StumblerServiceIntentActions;
 import org.mozilla.mozstumbler.service.utils.NetworkInfo;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
 
 import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class PreferencesScreen extends PreferenceActivity implements IFxACallbacks{
 
@@ -362,7 +357,7 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
         mEnableShowMLSLocations.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-                getPrefs().setOptionEnabledToShowMLSOnMap(newValue.equals(true));
+                getPrefs().enableMLSQueryResults(newValue.equals(true));
                 if (newValue.equals(true)) {
                     Context c = PreferencesScreen.this;
                     String message = String.format(getString(R.string.enable_option_show_mls_on_map_detailed_info),

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -434,19 +434,6 @@
                     android:textSize="@dimen/font_size_for_metrics" />
 
             </LinearLayout>
-
-            <CheckBox
-                android:id="@+id/checkBox_show_mls"
-                android:layout_width="wrap_content"
-                android:layout_height="20dp"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
-                android:layout_below="@id/mls_location_layout"
-                android:layout_marginLeft="-8dp"
-                android:layout_marginStart="-8dp"
-                android:checked="false"
-                android:text="@string/drawer_map_option_show_mls_locations"
-                android:textSize="14sp" />
         </RelativeLayout>
 
     </ScrollView>


### PR DESCRIPTION
This fixes a long standing UI nit that's been bothering me.  

When you enable MLS queries in the settings screen, you also have to find the little checkbox at the bottom of the MetricsView; the pop out drawer; and turn that on as well.

I think we had this split initially when we were just testing the MLS query ability before we had a way to render the locations.

This no longer makes any sense - if users turn on the MLS query setting in the preferences - we should just render the layer.
