### PR TITLE
Clear FxA loginstate when PrefScreen is first created

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -158,6 +158,7 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
 
         mFxaLoginPreference = getPreferenceManager().findPreference(Prefs.FXA_LOGIN_PREF);
         setFxALoginTitle(getPrefs().getBearerToken(), getPrefs().getEmail());
+
         setNicknamePreferenceTitle(getPrefs().getNickname());
 
         mWifiPreference = (CheckBoxPreference) getPreferenceManager().findPreference(Prefs.WIFI_ONLY);
@@ -174,7 +175,6 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
         setPreferenceListener();
         setButtonListeners();
 
-
         String app_name = getResources().getString(R.string.app_name);
 
         FxAGlobals fxa = new FxAGlobals();
@@ -187,6 +187,12 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
                 BuildConfig.LB_CONFIG_URL);
         fxaConfigTask.execute();
 
+        // Kludge for 1.8.4 to clear out FxA logins if a token is detected, but no email.
+        String bearerToken = getPrefs().getBearerToken();
+        String fxaEmail = getPrefs().getEmail();
+        if ((!TextUtils.isEmpty(bearerToken)) && (TextUtils.isEmpty(fxaEmail))) {
+            clearFxaLoginState();
+        }
     }
 
     private void verifyBearerToken() {


### PR DESCRIPTION
If the preference screen is loaded and the FxA login is inconsistent - that is the email address is not available but a bearer token is available, clear the FxA login state.

This is a fix for #1772 in v1.8.3
