### PR TITLE
Features/fdroid 1.8x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ jdk: oraclejdk7
 
 android:
     components:
+        - platform-tools
+        - tools
         - android-23
         - build-tools-23.0.0
         - extra-android-support
+        - extra-android-m2repository
     licenses:
         - android-sdk-license-5be876d5
+        - android-sdk-license-c81a61d9
 script:
     - make test

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // each of the version numbers must be 0-99
 def versionMajor = 1
 def versionMinor = 8 // minor feature releases
-def versionPatch = 3 // This should be bumped for hot fixes
+def versionPatch = 5 // This should be bumped for hot fixes
 
 // Double check the versioning
 for (versionPart in [versionPatch, versionMinor, versionMajor]) {

--- a/android/src/main/res/values-cs/strings.xml
+++ b/android/src/main/res/values-cs/strings.xml
@@ -112,9 +112,9 @@
     <string name="delete_file">Smazat soubor</string>
     <string name="kml_file_saved">KML uloženo</string>
     <string name="share_after_kml_saved">Soubor byl uložen ve vašem zařízení, chcete jej sdílet?</string>
-    <string name="enter_email">Vložte e-mailovou adresu (nepovinné)</string>
-    <string name="enter_email_title">E-mail: %1$s</string>
-    <string name="enter_email_longtext">Vaše e-mailová adresa nebude nikde zobrazována a je použita pouze pro vaše vlastní reporty.</string>
+
+
+
     <!--<string name="drawer_open">Show drawer</string>
     <string name="drawer_close">Close drawer</string>-->
     <string name="title_activity_leaderboard">Žebříček</string>

--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -122,9 +122,9 @@
     <string name="load_file">Datei laden</string>
     <string name="delete_file">Datei löschen</string>
 
-    <string name="enter_email">E-Mail-Adresse eingeben (optional)</string>
-    <string name="enter_email_title">E-Mail: %1$s</string>
-    <string name="enter_email_longtext">Ihre E-Mail-Adresse wird niemals anderen Leuten angezeigt und wird nur für Ihre eigenen Berichte verwendet.</string>
+
+
+
     <string name="drawer_open">Leiste einblenden</string>
     <string name="drawer_close">Leiste ausblenden</string>
     <string name="title_activity_leaderboard">Bestenliste</string>

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -108,9 +108,9 @@
     <string name="delete_file">Borrar archivo</string>
     <string name="kml_file_saved">KML guardado</string>
     <string name="share_after_kml_saved">El archivo fue guardado en el dispositivo, ¿Te gustaría compartir el archivo?</string>
-    <string name="enter_email">Ingresa tu dirección de correo (opcional)</string>
-    <string name="enter_email_title">Correo: %1$s</string>
-    <string name="enter_email_longtext">Tu dirección de correo jamás es mostrada a las personas y sólo es usada para tus reportes</string>
+
+
+
     <string name="drawer_open">Mostrar barra lateral</string>
     <string name="drawer_close">Cerrar barra lateral</string>
     <string name="title_activity_leaderboard">Tabla de posiciones</string>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -80,9 +80,9 @@
     <string name="delete_file">Poista tiedosto</string>
     <string name="kml_file_saved">KML tallennettu</string>
     <string name="share_after_kml_saved">Tiedosto on tallennettu laitteelle, haluatko jakaa sen?</string>
-    <string name="enter_email">Anna sähköpostiosoite (vapaaehtoinen)</string>
-    <string name="enter_email_title">Sähköposti: %1$s</string>
-    <string name="enter_email_longtext">Sähköpostiosoitetta ei näytetä muille ja sitä käytetään vain sinun omille raporteillesi.</string>
+
+
+
     <string name="drawer_open">Näytä laatikko</string>
     <string name="drawer_close">Sulje laatikko</string>
     <string name="title_activity_leaderboard">Tilastot</string>

--- a/android/src/main/res/values-hi/strings.xml
+++ b/android/src/main/res/values-hi/strings.xml
@@ -73,9 +73,9 @@
     <string name="delete_file">फ़ाइल नष्ट करे</string>
     <string name="kml_file_saved">KML सुरक्षित</string>
     <string name="share_after_kml_saved">यह फ़ाइल आपके डिवाइस पर सुरक्षित है, आप इसे भेजना पसंद करेंगे?</string>
-    <string name="enter_email">इमेल पता डाले (वैकल्पिक)</string>
-    <string name="enter_email_title">इमेल: %1$s</string>
-    <string name="enter_email_longtext">आपका इमेल पता लोगोंको कभी नहीं दिखाया जायेगा और यह सिर्फ आपके विवरणोंके लिए इस्तेमाल किया जाएगा.</string>
+
+
+
     <string name="drawer_open">दराज दिखाए</string>
     <string name="drawer_close">दराज बंद करे</string>
     <string name="title_activity_leaderboard">अग्रणी उपयोगकर्ता फलक</string>

--- a/android/src/main/res/values-mr/strings.xml
+++ b/android/src/main/res/values-mr/strings.xml
@@ -73,9 +73,9 @@
     <string name="delete_file">फाईल नष्ट करा</string>
     <string name="kml_file_saved">KML  सुरक्षित करण्यात आली आहे</string>
     <string name="share_after_kml_saved">हि फाईल यंत्रावर सुरक्षित आहे, तुम्हाला ती वाटायला आवडेल का?</string>
-    <string name="enter_email">इमेल पत्ता टाका (ऐच्छिक)</string>
-    <string name="enter_email_title">इमेल: %1$s</string>
-    <string name="enter_email_longtext">तुमचा इमेल पत्ता कधीच लोकांना दाखवला जात नाही आणि फक्त तुमच्या अहवालाकरिता वापरला जातो.</string>
+
+
+
     <string name="drawer_open">कप्पा दाखवा</string>
     <string name="drawer_close">कप्पा बंद करा</string>
     <string name="title_activity_leaderboard">अग्रेसर वापरकर्ता फलक</string>

--- a/android/src/main/res/values-ne/strings.xml
+++ b/android/src/main/res/values-ne/strings.xml
@@ -15,9 +15,9 @@
     <string name="developer_title">निर्माता</string>
     <string name="drawer_close">दराज बन्द</string>
     <string name="drawer_map_layers_title">नक्शा कथा</string>
-    <string name="enter_email">ई-मेल ठेगाना (वैकल्पिक)</string>
-    <string name="enter_email_longtext">तपाईंको इमेल ठेगाना मान्छे को लागि प्रदर्शित कहिल्यै हुदैन र केवल आफ्नो रिपोर्ट को लागि प्रयोग गरिन्छ।</string>
-    <string name="enter_email_title">इमेल: %1$s</string>
+
+
+
     <string name="enter_nickname">उपनाम हल्नुहोस (वैकल्पिक)</string>
     <string name="enter_nickname_longtext">तपाईंको उपनाम लिडरबोर्डको देखा पर्नेछ।</string>
     <string name="enter_nickname_title">उपनाम: %1$s</string>

--- a/android/src/main/res/values-pl/strings.xml
+++ b/android/src/main/res/values-pl/strings.xml
@@ -126,9 +126,9 @@
     <string name="load_file">Wczytaj plik</string>
     <string name="delete_file">Usuń plik</string>
 
-    <string name="enter_email">Wpisz adres e-mail (opcjonalnie)</string>
-    <string name="enter_email_title">E-mail: %1$s</string>
-    <string name="enter_email_longtext">Adres e-mail nie jest nikomu pokazywany i jest używany tylko do obserwacji użytkownika.</string>
+
+
+
     <string name="drawer_open">Wysuń szufladę</string>
     <string name="drawer_close">Zamknij szufladę</string>
     <string name="title_activity_leaderboard">Ranking</string>

--- a/android/src/main/res/values-tr/strings.xml
+++ b/android/src/main/res/values-tr/strings.xml
@@ -108,9 +108,9 @@
     <string name="delete_file">Dosyayı sil</string>
     <string name="kml_file_saved">KML Kaydedildi</string>
     <string name="share_after_kml_saved">Dosya cihaza kaydedildi. Dosyayı paylaşmak ister misiniz?</string>
-    <string name="enter_email">E-posta adresiniz (isteğe bağlı)</string>
-    <string name="enter_email_title">E-posta: %1$s</string>
-    <string name="enter_email_longtext">E-posta adresiniz asla başkalarına gösterilmez ve sadece raporlarınız için kullanılır.</string>
+
+
+
     <string name="drawer_open">Sürgüyü göster</string>
     <string name="drawer_close">Sürgüyü kapat</string>
     <string name="title_activity_leaderboard">Puan Durumu</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -69,9 +69,9 @@
     <string name="delete_file">删除文件</string>
     <string name="kml_file_saved">KML 已保存</string>
     <string name="share_after_kml_saved">文件已保存到设备，是否分享文件？</string>
-    <string name="enter_email">输入 e-mail 地址 </string>
-    <string name="enter_email_title">Email：</string>
-    <string name="enter_email_longtext">你的 email 地址不会被展示给其他人，只会用于你自己的报告</string>
+
+
+
     <string name="drawer_open">显示抽屉</string>
     <string name="drawer_close">关闭抽屉</string>
     <string name="title_activity_leaderboard">积分榜</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -122,10 +122,10 @@
     <string name="share_file">分享檔案</string>
     <string name="load_file">載入檔案</string>
     <string name="delete_file">刪除檔案</string>
-    <string name="enter_email">輸入電子郵件地址（非必填）</string>
 
-    <string name="enter_email_title">電子郵件地址: %1$s</string>
-    <string name="enter_email_longtext">您的電子郵件地址不會顯示給其他人知道，而只會用於您自己上傳的報告當中</string>
+
+
+
     <string name="drawer_open">顯示抽屜</string>
     <string name="drawer_close">關閉抽屜</string>
     <string name="title_activity_leaderboard">排行榜</string>

--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     }
 }
 
-version = "1.7.10"
+version = "1.8.5"
 group = 'org.mozilla.mozstumbler'
 
 // The groupname will be changed into a path for the final library
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 18
+        targetSdkVersion 23
     }
 
     lintOptions {
@@ -137,8 +137,8 @@ dependencies {
     // libraries, because they support a wide range of Android versions and
     // provide APIs for recommended user interface patterns.
 
-    compile "com.android.support:support-v4:21.0.+"
-    compile 'com.android.support:appcompat-v7:19.1.0'
+    compile "com.android.support:support-v4:23.0.0"
+    compile 'com.android.support:appcompat-v7:23.0.0'
 
     // Acralyzer crash reports
     compile('ch.acra:acra:4.5.0') {

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/GlobalConstants.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/GlobalConstants.java
@@ -6,8 +6,6 @@ package org.mozilla.mozstumbler.service.core.http;
 
 import android.os.Build;
 
-import org.mozilla.mozstumbler.svclocator.BuildConfig;
-
 public class GlobalConstants {
     /*
      * The DEFALUT_CIPHER_SUITES and DEFAULT_PROTOCOLS is copied from

--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/HttpUtil.java
@@ -9,7 +9,6 @@ import android.os.Build;
 import org.mozilla.mozstumbler.service.Prefs;
 import org.mozilla.mozstumbler.service.core.logging.ClientLog;
 import org.mozilla.mozstumbler.service.utils.Zipper;
-import org.mozilla.mozstumbler.svclocator.BuildConfig;
 import org.mozilla.mozstumbler.svclocator.ServiceLocator;
 import org.mozilla.mozstumbler.svclocator.services.log.ILogger;
 import org.mozilla.mozstumbler.svclocator.services.log.LoggerUtil;
@@ -270,10 +269,6 @@ public class HttpUtil implements IHttpUtil {
         } catch (IOException e) {
             ClientLog.e(LOG_TAG, "post error", e);
         } finally {
-            if (BuildConfig.DEBUG) {
-                String cipherSuite = ((HttpsURLConnection) httpURLConnection).getCipherSuite();
-                Log.i(LOG_TAG, "Negotiated HTTPS ciphers: " + cipherSuite);
-            }
             httpURLConnection.disconnect();
         }
         return null;


### PR DESCRIPTION
F-Droid is much more picky than the Google Play store.  strings.xml cleaned up.  

Version numbers aligned in libstumbler and the primary application project.

targetSdkVersion bumped to version 23 from 18 for the build.

appcompat library versions are dependant on SDK versions, these weren't aligned with SDK 23 before.

appcompat versions are now pinned to v23.0.0 for both v4 and v7 libraries to provide stability.

``` bash
$ fdroid build org.mozilla.mozstumbler -l
INFO: Building version 1.8.5 (1080500) of org.mozilla.mozstumbler
INFO: Getting source for revision 9a99675
INFO: Creating local.properties file at build/org.mozilla.mozstumbler/local.properties
INFO: Creating local.properties file at build/org.mozilla.mozstumbler/android/local.properties
INFO: Cleaned build.gradle of keysigning configs at build/org.mozilla.mozstumbler/android/build.gradle
INFO: Running 'prebuild' commands in build/org.mozilla.mozstumbler/android
INFO: Cleaning Gradle project...
INFO: Scanning source for common problems...
WARNING: Found JAR file at android_studio/stumbler_codestyle.jar
WARNING: Found JAR file at gradle/wrapper/gradle-wrapper.jar
WARNING: Found JAR file at libraries/stumbler/gradle/wrapper/gradle-wrapper.jar
INFO: Creating source tarball...
INFO: Building Gradle project...
INFO: Successfully built version 1.8.5 of org.mozilla.mozstumbler
INFO: success: org.mozilla.mozstumbler
INFO: Finished.
INFO: 1 builds succeeded
```
