### PR TITLE
Features/1776 fxa no config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ unittest:
 	./gradlew assembleGithubLbprodUnittest
 
 debug:
-	./gradlew assembleGithubLbprodDebug
+	./gradlew assembleGithubLbstageDebug
 
 github:
 	./release_check.py github
@@ -31,4 +31,4 @@ clean:
 	./gradlew clean
 
 install_debug:
-	./gradlew installGithubLbprodDebug
+	./gradlew installGithubLbstageDebug

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FetchFxaConfiguration.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FetchFxaConfiguration.java
@@ -7,6 +7,7 @@ import android.content.IntentFilter;
 import android.os.AsyncTask;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
+import android.widget.Toast;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,6 +15,7 @@ import org.mozilla.accounts.fxa.FxAGlobals;
 import org.mozilla.accounts.fxa.LoggerUtil;
 import org.mozilla.accounts.fxa.net.HTTPResponse;
 import org.mozilla.accounts.fxa.net.HttpUtil;
+import org.mozilla.mozstumbler.R;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -62,6 +64,10 @@ public class FetchFxaConfiguration extends AsyncTask<Void, Void, JSONObject> {
             Log.i(LOG_TAG, "Invalid number of arguments.");
             return null;
         }
+        Toast.makeText(PreferencesScreen.this,
+                mContext.getString(R.string.fxa_loading_config),
+                Toast.LENGTH_SHORT).show();
+
 
         HttpUtil httpUtil = new HttpUtil(System.getProperty("http.agent") + " " +
                 FxAGlobals.appName + "/" + FxAGlobals.appVersionName);

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FetchFxaConfiguration.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/FetchFxaConfiguration.java
@@ -64,10 +64,6 @@ public class FetchFxaConfiguration extends AsyncTask<Void, Void, JSONObject> {
             Log.i(LOG_TAG, "Invalid number of arguments.");
             return null;
         }
-        Toast.makeText(PreferencesScreen.this,
-                mContext.getString(R.string.fxa_loading_config),
-                Toast.LENGTH_SHORT).show();
-
 
         HttpUtil httpUtil = new HttpUtil(System.getProperty("http.agent") + " " +
                 FxAGlobals.appName + "/" + FxAGlobals.appVersionName);
@@ -101,6 +97,9 @@ public class FetchFxaConfiguration extends AsyncTask<Void, Void, JSONObject> {
             Intent intent = new Intent(FXA_CONFIG_LOAD);
             intent.putExtra("json", result.toString());
             LocalBroadcastManager.getInstance(mContext).sendBroadcast(intent);
+            Toast.makeText(mContext,
+                    mContext.getString(R.string.fxa_loading_config),
+                    Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -79,6 +79,9 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
 
     private void processFxaConfigLoad(Intent intent, boolean success) {
         if (!success) {
+            Toast.makeText(PreferencesScreen.this,
+                    getApplicationContext().getString(R.string.fxa_no_config),
+                    Toast.LENGTH_SHORT).show();
             Log.e(LOG_TAG, "No fxa configuration is available");
             return;
         }
@@ -103,6 +106,10 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
 
             getPrefs().setLbBaseURI(configJSON.getString("leaderboard_base_uri"));
             getPrefs().setLbSubmitURL(configJSON.getString("leaderboard_base_uri") + "/api/v1/contributions/");
+
+            Toast.makeText(PreferencesScreen.this,
+                    mContext.getString(R.string.fxa_config_loaded),
+                    Toast.LENGTH_SHORT).show();
 
             enableLeaderboardMenuItem(true);
             // Only after all the FXA crap is setup can we initiate bearer token verification
@@ -338,6 +345,11 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
                             getFxaAppCallback(),
                             getFxaScopes(),
                             getFxaClientId()).show();
+                } else {
+                    // Try to get the FxA configuration again
+                    FetchFxaConfiguration fxaConfigTask = new FetchFxaConfiguration(PreferencesScreen.this,
+                            BuildConfig.LB_CONFIG_URL);
+                    fxaConfigTask.execute();
                 }
                 return true;
             }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -190,13 +190,19 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
         // Register callbacks so that we can load the FxA configuration JSON blob
         FetchFxaConfiguration.registerFxaIntents(this.getApplicationContext(), callbackReceiver);
 
-        FetchFxaConfiguration fxaConfigTask = new FetchFxaConfiguration(this.getApplicationContext(),
-                BuildConfig.LB_CONFIG_URL);
-        fxaConfigTask.execute();
+
 
         // Kludge for 1.8.4 to clear out FxA logins if a token is detected, but no email.
         String bearerToken = getPrefs().getBearerToken();
         String fxaEmail = getPrefs().getEmail();
+
+        if (TextUtils.isEmpty(getPrefs().getLbSubmitUrl())) {
+            // Only update the FxA configuration if we have to.
+            FetchFxaConfiguration fxaConfigTask = new FetchFxaConfiguration(this.getApplicationContext(),
+                    BuildConfig.LB_CONFIG_URL);
+            fxaConfigTask.execute();
+        }
+
         if ((!TextUtils.isEmpty(bearerToken)) && (TextUtils.isEmpty(fxaEmail))) {
             clearFxaLoginState();
         }

--- a/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/subactivities/PreferencesScreen.java
@@ -108,7 +108,7 @@ public class PreferencesScreen extends PreferenceActivity implements IFxACallbac
             getPrefs().setLbSubmitURL(configJSON.getString("leaderboard_base_uri") + "/api/v1/contributions/");
 
             Toast.makeText(PreferencesScreen.this,
-                    mContext.getString(R.string.fxa_config_loaded),
+                    this.getString(R.string.fxa_config_loaded),
                     Toast.LENGTH_SHORT).show();
 
             enableLeaderboardMenuItem(true);

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -215,5 +215,8 @@
     <string name="fxa_logged_in">Firefox Accounts is logged in</string>
     <string name="fxa_settings_title">Firefox Accounts</string>
     <string name="fxa_needs_network">A data network connection is required.</string>
+    <string name="fxa_no_config">Firefox Accounts configuration could not be loaded</string>
+    <string name="fxa_loading_config">Trying to load Firefox Accounts Configuration</string>
+    <string name="fxa_config_loaded">Firefox Accounts configuration is loaded</string>
 
 </resources>


### PR DESCRIPTION
I've added 3 toasts:

"Trying to load Firefox Accounts Configuration" when the FetchFxaConfiguration task is run
"Firefox Accounts configuration could not be loaded" on failure to load the configuration JSON correctly
"Firefox Accounts configuration is loaded" all expected fields in the FxA config JSON were parsed correctly.
