### PR TITLE
dropped javadoc requirements when building libstumbler

### DIFF
--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -159,18 +159,7 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
 artifacts {
-    archives javadocJar
     archives sourcesJar
 }
 


### PR DESCRIPTION
I have no idea why, but Javadoc compiles have broken.
