### PR TITLE
Fix power settings button alignment

### DIFF
--- a/android/src/main/res/layout/button_bg.xml
+++ b/android/src/main/res/layout/button_bg.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" android:layout_height="match_parent" android:layout_width="match_parent">
 </shape>

--- a/android/src/main/res/layout/button_bg_pressed.xml
+++ b/android/src/main/res/layout/button_bg_pressed.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" android:layout_height="match_parent" android:layout_width="match_parent">
 </shape>

--- a/android/src/main/res/layout/button_selector.xml
+++ b/android/src/main/res/layout/button_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+<selector xmlns:android="http://schemas.android.com/apk/res/android" android:layout_height="match_parent" android:layout_width="match_parent" >
 <item android:state_focused="true" android:state_pressed="true" 
         android:drawable="@layout/button_bg_pressed" /> 
 <item android:state_focused="false" android:state_pressed="true" 

--- a/android/src/main/res/layout/fragment_metrics_drawer.xml
+++ b/android/src/main/res/layout/fragment_metrics_drawer.xml
@@ -296,6 +296,7 @@
 
             <Button
                 android:id="@+id/button_change_power_setting"
+                style="?android:attr/buttonStyleSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@layout/button_selector"
@@ -304,6 +305,8 @@
                 android:layout_alignRight="@+id/cell_plus_wifi_layout"
                 android:minHeight="0dp"
                 android:text="@string/change_power_saving"
+                android:textAllCaps="false"
+                android:padding="5dp"
                 android:layout_marginBottom="10dp" />
 
             <TextView


### PR DESCRIPTION
@crankycoder The alignment of the power settings button is not as nice as it was before (#1779).
This PR fixes it for me, see screenshots.

**Old:**
![stumbler_1](https://cloud.githubusercontent.com/assets/3845150/14876870/ae0be3d2-0d18-11e6-8dad-03c426d06d12.png)

**Current:**
![stumbler_2](https://cloud.githubusercontent.com/assets/3845150/14876957/4fcfce4a-0d19-11e6-922d-d6a9e43ea915.png)

**Fixed:**
![stumbler_3](https://cloud.githubusercontent.com/assets/3845150/14876880/bdf302bc-0d18-11e6-95fd-eb6a98c92073.png)
