### PR TITLE
put an API 17 guard around grabbing the age for wifi signals

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/stumblerthread/datahandling/StumblerBundle.java
@@ -125,8 +125,12 @@ public final class StumblerBundle implements Parcelable {
 
         if (mWifiData.size() > 0) {
             JSONArray wifis = new JSONArray();
+            long gpsTimeSinceBootInMS = 0;
 
-            long gpsTimeSinceBootInMS = (mGpsPosition.getElapsedRealtimeNanos()/1000000);
+            if (Build.VERSION.SDK_INT >= 17) {
+                gpsTimeSinceBootInMS = (mGpsPosition.getElapsedRealtimeNanos() / 1000000);
+            }
+
             for (ScanResult scanResult : mWifiData.values()) {
                 JSONObject wifiEntry = new JSONObject();
                 wifiEntry.put("macAddress", scanResult.BSSID);
@@ -137,9 +141,12 @@ public final class StumblerBundle implements Parcelable {
                     wifiEntry.put("signalStrength", scanResult.level);
                 }
 
-                long wifiTimeSinceBootInMS = (scanResult.timestamp / 1000);
-                long ageMS =  wifiTimeSinceBootInMS - gpsTimeSinceBootInMS;
-                wifiEntry.put("age", ageMS);
+                if (Build.VERSION.SDK_INT >= 17) {
+                    long wifiTimeSinceBootInMS = (scanResult.timestamp / 1000);
+                    long ageMS =  wifiTimeSinceBootInMS - gpsTimeSinceBootInMS;
+                    wifiEntry.put("age", ageMS);
+                }
+
                 wifis.put(wifiEntry);
             }
             headerFields.put(DataStorageConstants.ReportsColumns.WIFI, wifis);


### PR DESCRIPTION
This fixes #1792 

@hannosch r?

The relevant documentation is here:

http://developer.android.com/reference/android/location/Location.html#getElapsedRealtimeNanos()

And a sample crash on Android 4.1.2:

```
java.lang.NoSuchMethodError: android.location.Location.getElapsedRealtimeNanos
at org.mozilla.mozstumbler.service.stumblerthread.datahandling.StumblerBundle.toMLSGeosubmit(StumblerBundle.java:129)
at org.mozilla.mozstumbler.service.stumblerthread.Reporter.flush(Reporter.java:201)
at org.mozilla.mozstumbler.service.stumblerthread.Reporter.onReceive(Reporter.java:135)
at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
at android.support.v4.content.LocalBroadcastManager.sendBroadcastSync(LocalBroadcastManager.java:278)
at org.mozilla.mozstumbler.service.stumblerthread.scanners.ScanManager$4.run(ScanManager.java:176)
at java.util.Timer$TimerImpl.run(Timer.java:284)
```

We'll need to patch Fennec as well.
