### PR TITLE
Update Travis CI build status image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Please refer to the [wiki](https://github.com/mozilla/MozStumbler/wiki) for detailed documentation.
 
 MozStumbler
-[![Build Status](https://travis-ci.org/mozilla/MozStumbler.png)](https://travis-ci.org/mozilla/MozStumbler.png)
+[![Build Status](https://travis-ci.org/mozilla/MozStumbler.png)](https://travis-ci.org/mozilla/MozStumbler)
 
 # Building a debug version from command line #
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Please refer to the [wiki](https://github.com/mozilla/MozStumbler/wiki) for detailed documentation.
 
 MozStumbler
-[![Build Status](https://travis-ci.org/mozilla/MozStumbler.png)](https://travis-ci.org/mozilla/MozStumbler)
+[![Build Status](https://travis-ci.org/mozilla/MozStumbler.png?branch=dev)](https://travis-ci.org/mozilla/MozStumbler)
 
 # Building a debug version from command line #
 


### PR DESCRIPTION
This pull request contains two changes for the Travis CI build status image:
- Change it to link to the build status instead for the logo image.
- Show the build status of the dev branch, instead of whatever branch was built last.
