### PR TITLE
bumped to 1.8.8 and applied runtime permissions checking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // each of the version numbers must be 0-99
 def versionMajor = 1
 def versionMinor = 8 // minor feature releases
-def versionPatch = 6 // This should be bumped for hot fixes
+def versionPatch = 8 // This should be bumped for hot fixes
 
 // Double check the versioning
 for (versionPart in [versionPatch, versionMinor, versionMajor]) {
@@ -32,6 +32,8 @@ repositories {
 android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"
+    useLibrary 'org.apache.http.legacy'
+
 
     def gitHash = "git rev-parse --short HEAD".execute().text.trim()
     def hasModifiedDeletedOrOtherFiles = !"git ls-files -mdo --exclude-standard".execute().text.trim().isEmpty()
@@ -49,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 26
 
         applicationId "org.mozilla.mozstumbler"
 

--- a/libraries/stumbler/build.gradle
+++ b/libraries/stumbler/build.gradle
@@ -32,7 +32,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 28
     }
 


### PR DESCRIPTION
This bumps the android API level to 26 and adds basic runtime permissions checking.  The playstore requires API 26 or higher for new releases.

This version bump for the API level is required to properly disable the leaderboard from the stumbler.