### PR TITLE
Add support for notification channels for Android Oreo and higher

### DIFF
--- a/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
+++ b/android/src/main/java/org/mozilla/mozstumbler/client/ClientStumblerService.java
@@ -164,6 +164,7 @@ public class ClientStumblerService extends StumblerService {
 
     private void foregroundNotification() {
         NotificationUtil nm = new NotificationUtil(this.getApplicationContext());
+        nm.createAndRegisterNotificationChannels();
         Notification notification = nm.buildNotification(getString(R.string.stop_scanning));
         startForeground(NotificationUtil.NOTIFICATION_ID, notification);
     }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -217,5 +217,8 @@
     <string name="fxa_no_config">Firefox Accounts configuration could not be loaded</string>
     <string name="fxa_loading_config">Trying to load Firefox Accounts configuration</string>
     <string name="fxa_config_loaded">Firefox Accounts configuration is loaded</string>
+    <string name="notification_channel_name">mozstumbler-notifications-foreground</string>
+    <string name="notification_channel_foreground_description">Shows the persistent notification while stumbling.</string>
+    <string name="notification_channel_foreground_name">Foreground service</string>
 
 </resources>


### PR DESCRIPTION
Added basic support for notification channels, so the notification for the foreground service actually shows up on devices running Oreo or newer. Channels are only utilized on those devices using runtime version code checks.

The string resources still need translations and probably better wording. I'm not good at that.

+ Added method for registering notification channels to NotificationUtil
+ Registering channels in ClientStumblerService