### PR TITLE
Fix: Android 10 upload exception.

### DIFF
--- a/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/GlobalConstants.java
+++ b/libraries/stumbler/src/main/java/org/mozilla/mozstumbler/service/core/http/GlobalConstants.java
@@ -32,7 +32,15 @@ public class GlobalConstants {
     public static final String[] DEFAULT_PROTOCOLS;
 
     static {
-        if (Build.VERSION.SDK_INT >= 20) {
+        if (Build.VERSION.SDK_INT >= 29) {
+            DEFAULT_CIPHER_SUITES = new String[]
+                    {
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",     // 20+
+                            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",        // 11+
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",     // 20+
+                            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",        // 11+
+                    };
+        } else if (Build.VERSION.SDK_INT >= 20) {
             DEFAULT_CIPHER_SUITES = new String[]
                     {
                             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",     // 20+


### PR DESCRIPTION
(see issue #1863)
Some cipher are no longer supported and must be removed from the list.
https://developer.android.com/about/versions/10/behavior-changes-all#sha2-cbc-cipher-suites

Full cipher list:
https://developer.android.com/reference/javax/net/ssl/SSLEngine#cipher-suites

Tested on Nokia 7.1 (Android 10)
Without this fix, the uploading process always crash/shutdown the program on my phone.
After the fix the program is able to upload the data files.

To verify that the data is actually process by the server. I have download the differential Cell exports data. My cell data are present in the diff file. (https://location.services.mozilla.com/downloads)

**Download my own APK build:**
https://github.com/GerryFerdinandus/MozStumbler/releases/tag/V1.8.8_android_10
